### PR TITLE
Add FastAPI property management service

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+__pycache__/
+*.pyc
+

--- a/README.md
+++ b/README.md
@@ -1,2 +1,23 @@
 # Stands
-Property Sales Manager
+
+Simple FastAPI service that allows a Property Sales Manager to manage real estate projects and stands.
+
+## Setup
+
+```
+pip install -r requirements.txt
+```
+
+## Running
+
+```
+uvicorn app.main:app --reload
+```
+
+Interactive docs will be available at `http://127.0.0.1:8000/docs`.
+
+## Tests
+
+```
+pytest
+```

--- a/app/main.py
+++ b/app/main.py
@@ -1,0 +1,62 @@
+from fastapi import FastAPI, HTTPException
+from typing import Dict, List
+from .models import Project, Stand, PropertyStatus, Mandate
+
+app = FastAPI(title="Property Management API")
+
+# In-memory stores
+projects: Dict[int, Project] = {}
+stands: Dict[int, Stand] = {}
+
+
+@app.post("/projects", response_model=Project)
+def create_project(project: Project):
+    if project.id in projects:
+        raise HTTPException(status_code=400, detail="Project ID exists")
+    projects[project.id] = project
+    return project
+
+
+@app.get("/projects", response_model=List[Project])
+def list_projects():
+    return list(projects.values())
+
+
+@app.post("/stands", response_model=Stand)
+def create_stand(stand: Stand):
+    if stand.id in stands:
+        raise HTTPException(status_code=400, detail="Stand ID exists")
+    if stand.project_id not in projects:
+        raise HTTPException(status_code=404, detail="Project not found")
+    stands[stand.id] = stand
+    return stand
+
+
+@app.put("/stands/{stand_id}", response_model=Stand)
+def update_stand(stand_id: int, stand: Stand):
+    if stand_id not in stands:
+        raise HTTPException(status_code=404, detail="Stand not found")
+    if stand.project_id not in projects:
+        raise HTTPException(status_code=404, detail="Project not found")
+    stands[stand_id] = stand
+    return stand
+
+
+@app.delete("/stands/{stand_id}", response_model=Stand)
+def archive_stand(stand_id: int):
+    if stand_id not in stands:
+        raise HTTPException(status_code=404, detail="Stand not found")
+    stand = stands[stand_id]
+    stand.status = PropertyStatus.ARCHIVED
+    stands[stand_id] = stand
+    return stand
+
+
+@app.post("/stands/{stand_id}/mandate", response_model=Stand)
+def assign_mandate(stand_id: int, mandate: Mandate):
+    if stand_id not in stands:
+        raise HTTPException(status_code=404, detail="Stand not found")
+    stand = stands[stand_id]
+    stand.mandate_agent = mandate.agent
+    stands[stand_id] = stand
+    return stand

--- a/app/models.py
+++ b/app/models.py
@@ -1,0 +1,28 @@
+from enum import Enum
+from pydantic import BaseModel
+from typing import Optional
+
+
+class PropertyStatus(str, Enum):
+    AVAILABLE = "available"
+    RESERVED = "reserved"
+    SOLD = "sold"
+    ARCHIVED = "archived"
+
+
+class Project(BaseModel):
+    id: int
+    name: str
+    description: Optional[str] = None
+
+
+class Stand(BaseModel):
+    id: int
+    project_id: int
+    name: str
+    status: PropertyStatus = PropertyStatus.AVAILABLE
+    mandate_agent: Optional[str] = None
+
+
+class Mandate(BaseModel):
+    agent: str

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,6 @@
+fastapi
+uvicorn
+pydantic
+pytest
+httpx
+

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -1,0 +1,33 @@
+import sys
+
+sys.path.append(".")
+
+from fastapi.testclient import TestClient
+from app.main import app
+from app.models import PropertyStatus
+
+client = TestClient(app)
+
+
+def test_create_update_archive_and_mandate():
+    # Create project
+    project = {"id": 1, "name": "Project A"}
+    resp = client.post("/projects", json=project)
+    assert resp.status_code == 200
+    # Create stand
+    stand = {"id": 1, "project_id": 1, "name": "Stand 1"}
+    resp = client.post("/stands", json=stand)
+    assert resp.status_code == 200
+    # Update stand
+    stand_update = {"id": 1, "project_id": 1, "name": "Stand 1", "status": "reserved"}
+    resp = client.put("/stands/1", json=stand_update)
+    assert resp.status_code == 200
+    assert resp.json()["status"] == PropertyStatus.RESERVED.value
+    # Assign mandate
+    resp = client.post("/stands/1/mandate", json={"agent": "Agent A"})
+    assert resp.status_code == 200
+    assert resp.json()["mandate_agent"] == "Agent A"
+    # Archive stand
+    resp = client.delete("/stands/1")
+    assert resp.status_code == 200
+    assert resp.json()["status"] == PropertyStatus.ARCHIVED.value


### PR DESCRIPTION
## Summary
- define data models for projects, stands, property status, and mandate assignment
- implement FastAPI endpoints to create, update, archive stands and assign mandates
- add tests and documentation

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68c6ffc1f70c832c93a1faf35278d747