### PR TITLE
Implement agent authentication and mandate workflow

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -1,16 +1,44 @@
-from fastapi import FastAPI, HTTPException
+from fastapi import FastAPI, HTTPException, Depends, Header
 from typing import Dict, List
-from .models import Project, Stand, PropertyStatus, Mandate
+from .models import (
+    Project,
+    Stand,
+    PropertyStatus,
+    Mandate,
+    Agent,
+    MandateStatus,
+)
 
 app = FastAPI(title="Property Management API")
 
 # In-memory stores
 projects: Dict[int, Project] = {}
 stands: Dict[int, Stand] = {}
+agents: Dict[str, Agent] = {}
+
+
+def get_current_agent(x_token: str = Header(...)) -> Agent:
+    if x_token not in agents:
+        raise HTTPException(status_code=401, detail="Invalid authentication token")
+    return agents[x_token]
+
+
+def require_admin(agent: Agent = Depends(get_current_agent)) -> Agent:
+    if agent.role != "admin":
+        raise HTTPException(status_code=403, detail="Admin privileges required")
+    return agent
+
+
+@app.post("/agents", response_model=Agent)
+def create_agent(agent: Agent):
+    if agent.username in agents:
+        raise HTTPException(status_code=400, detail="Agent exists")
+    agents[agent.username] = agent
+    return agent
 
 
 @app.post("/projects", response_model=Project)
-def create_project(project: Project):
+def create_project(project: Project, _: Agent = Depends(require_admin)):
     if project.id in projects:
         raise HTTPException(status_code=400, detail="Project ID exists")
     projects[project.id] = project
@@ -18,12 +46,12 @@ def create_project(project: Project):
 
 
 @app.get("/projects", response_model=List[Project])
-def list_projects():
+def list_projects(_: Agent = Depends(get_current_agent)):
     return list(projects.values())
 
 
 @app.post("/stands", response_model=Stand)
-def create_stand(stand: Stand):
+def create_stand(stand: Stand, _: Agent = Depends(require_admin)):
     if stand.id in stands:
         raise HTTPException(status_code=400, detail="Stand ID exists")
     if stand.project_id not in projects:
@@ -33,7 +61,7 @@ def create_stand(stand: Stand):
 
 
 @app.put("/stands/{stand_id}", response_model=Stand)
-def update_stand(stand_id: int, stand: Stand):
+def update_stand(stand_id: int, stand: Stand, _: Agent = Depends(require_admin)):
     if stand_id not in stands:
         raise HTTPException(status_code=404, detail="Stand not found")
     if stand.project_id not in projects:
@@ -43,7 +71,7 @@ def update_stand(stand_id: int, stand: Stand):
 
 
 @app.delete("/stands/{stand_id}", response_model=Stand)
-def archive_stand(stand_id: int):
+def archive_stand(stand_id: int, _: Agent = Depends(require_admin)):
     if stand_id not in stands:
         raise HTTPException(status_code=404, detail="Stand not found")
     stand = stands[stand_id]
@@ -53,10 +81,35 @@ def archive_stand(stand_id: int):
 
 
 @app.post("/stands/{stand_id}/mandate", response_model=Stand)
-def assign_mandate(stand_id: int, mandate: Mandate):
+def assign_mandate(stand_id: int, mandate: Mandate, _: Agent = Depends(require_admin)):
     if stand_id not in stands:
         raise HTTPException(status_code=404, detail="Stand not found")
     stand = stands[stand_id]
-    stand.mandate_agent = mandate.agent
+    stand.mandate = mandate
+    stand.mandate.status = MandateStatus.PENDING
     stands[stand_id] = stand
     return stand
+
+
+@app.put("/stands/{stand_id}/mandate/accept", response_model=Stand)
+def accept_mandate(stand_id: int, agent: Agent = Depends(get_current_agent)):
+    if stand_id not in stands:
+        raise HTTPException(status_code=404, detail="Stand not found")
+    stand = stands[stand_id]
+    if not stand.mandate or stand.mandate.agent != agent.username:
+        raise HTTPException(status_code=403, detail="Not authorized to accept this mandate")
+    stand.mandate.status = MandateStatus.ACCEPTED
+    stands[stand_id] = stand
+    return stand
+
+
+@app.get("/stands/available", response_model=List[Stand])
+def available_stands(agent: Agent = Depends(get_current_agent)):
+    result = [s for s in stands.values() if s.status == PropertyStatus.AVAILABLE]
+    if agent.role == "agent":
+        result = [
+            s
+            for s in result
+            if s.mandate and s.mandate.agent == agent.username and s.mandate.status == MandateStatus.ACCEPTED
+        ]
+    return result

--- a/app/models.py
+++ b/app/models.py
@@ -16,13 +16,26 @@ class Project(BaseModel):
     description: Optional[str] = None
 
 
+class MandateStatus(str, Enum):
+    PENDING = "pending"
+    ACCEPTED = "accepted"
+    REJECTED = "rejected"
+
+
+class Mandate(BaseModel):
+    agent: str
+    document: Optional[str] = None
+    status: MandateStatus = MandateStatus.PENDING
+
+
 class Stand(BaseModel):
     id: int
     project_id: int
     name: str
     status: PropertyStatus = PropertyStatus.AVAILABLE
-    mandate_agent: Optional[str] = None
+    mandate: Optional[Mandate] = None
 
 
-class Mandate(BaseModel):
-    agent: str
+class Agent(BaseModel):
+    username: str
+    role: str

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -9,25 +9,58 @@ from app.models import PropertyStatus
 client = TestClient(app)
 
 
-def test_create_update_archive_and_mandate():
-    # Create project
+def test_auth_mandate_and_available_view():
+    # register agents
+    resp = client.post("/agents", json={"username": "admin", "role": "admin"})
+    assert resp.status_code == 200
+    resp = client.post("/agents", json={"username": "agentA", "role": "agent"})
+    assert resp.status_code == 200
+
+    admin_headers = {"X-Token": "admin"}
+    agent_headers = {"X-Token": "agentA"}
+
+    # Create project as admin
     project = {"id": 1, "name": "Project A"}
-    resp = client.post("/projects", json=project)
+    resp = client.post("/projects", json=project, headers=admin_headers)
     assert resp.status_code == 200
-    # Create stand
+
+    # Create stand as admin
     stand = {"id": 1, "project_id": 1, "name": "Stand 1"}
-    resp = client.post("/stands", json=stand)
+    resp = client.post("/stands", json=stand, headers=admin_headers)
     assert resp.status_code == 200
-    # Update stand
-    stand_update = {"id": 1, "project_id": 1, "name": "Stand 1", "status": "reserved"}
-    resp = client.put("/stands/1", json=stand_update)
+
+    # Agent cannot create stand
+    resp = client.post("/stands", json={"id": 2, "project_id": 1, "name": "Stand 2"}, headers=agent_headers)
+    assert resp.status_code == 403
+
+    # Update stand as admin
+    stand_update = {"id": 1, "project_id": 1, "name": "Stand 1 Updated", "status": "available"}
+    resp = client.put("/stands/1", json=stand_update, headers=admin_headers)
     assert resp.status_code == 200
-    assert resp.json()["status"] == PropertyStatus.RESERVED.value
-    # Assign mandate
-    resp = client.post("/stands/1/mandate", json={"agent": "Agent A"})
+    assert resp.json()["name"] == "Stand 1 Updated"
+
+    # Assign mandate with document
+    resp = client.post("/stands/1/mandate", json={"agent": "agentA", "document": "doc.pdf"}, headers=admin_headers)
     assert resp.status_code == 200
-    assert resp.json()["mandate_agent"] == "Agent A"
+    assert resp.json()["mandate"]["status"] == "pending"
+
+    # Agent accepts mandate
+    resp = client.put("/stands/1/mandate/accept", headers=agent_headers)
+    assert resp.status_code == 200
+    assert resp.json()["mandate"]["status"] == "accepted"
+
+    # Available stands for agent (filtered by mandate)
+    resp = client.get("/stands/available", headers=agent_headers)
+    assert resp.status_code == 200
+    assert len(resp.json()) == 1
+
+    # Available stands for admin (all available)
+    resp = client.get("/stands/available", headers=admin_headers)
+    assert resp.status_code == 200
+    assert len(resp.json()) == 1
+
     # Archive stand
-    resp = client.delete("/stands/1")
+    resp = client.delete("/stands/1", headers=admin_headers)
     assert resp.status_code == 200
     assert resp.json()["status"] == PropertyStatus.ARCHIVED.value
+


### PR DESCRIPTION
## Summary
- add agent model, mandate status, and agreement tracking
- secure project and stand operations with token-based roles
- expose filtered view of available stands for agents

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68c7009230e0832c9e61993406822a20