### PR TITLE
Add realtor submission workflows

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 # Stands
 
 Simple FastAPI service that allows a Property Sales Manager to manage real estate projects and stands.
+It also supports submission workflows for offers, property applications, and account opening requests with
+basic status tracking and notification storage.
 
 ## Setup
 

--- a/app/main.py
+++ b/app/main.py
@@ -7,6 +7,11 @@ from .models import (
     Mandate,
     Agent,
     MandateStatus,
+    SubmissionStatus,
+    Offer,
+    PropertyApplication,
+    AccountOpening,
+    StatusUpdate,
 )
 
 app = FastAPI(title="Property Management API")
@@ -15,6 +20,10 @@ app = FastAPI(title="Property Management API")
 projects: Dict[int, Project] = {}
 stands: Dict[int, Stand] = {}
 agents: Dict[str, Agent] = {}
+offers: Dict[int, Offer] = {}
+applications: Dict[int, PropertyApplication] = {}
+account_openings: Dict[int, AccountOpening] = {}
+notifications: List[str] = []
 
 
 def get_current_agent(x_token: str = Header(...)) -> Agent:
@@ -113,3 +122,106 @@ def available_stands(agent: Agent = Depends(get_current_agent)):
             if s.mandate and s.mandate.agent == agent.username and s.mandate.status == MandateStatus.ACCEPTED
         ]
     return result
+
+
+# ---- Submission endpoints ----
+
+
+def _ensure_owner(obj_realtor: str, agent: Agent):
+    if agent.role != "admin" and obj_realtor != agent.username:
+        raise HTTPException(status_code=403, detail="Not authorized")
+
+
+@app.post("/offers", response_model=Offer)
+def submit_offer(offer: Offer, agent: Agent = Depends(get_current_agent)):
+    if offer.id in offers:
+        raise HTTPException(status_code=400, detail="Offer ID exists")
+    if agent.username != offer.realtor:
+        raise HTTPException(status_code=403, detail="Cannot submit for another realtor")
+    offers[offer.id] = offer
+    notifications.append(f"Offer {offer.id} submitted by {offer.realtor}")
+    return offer
+
+
+@app.get("/offers/{offer_id}", response_model=Offer)
+def get_offer(offer_id: int, agent: Agent = Depends(get_current_agent)):
+    if offer_id not in offers:
+        raise HTTPException(status_code=404, detail="Offer not found")
+    offer = offers[offer_id]
+    _ensure_owner(offer.realtor, agent)
+    return offer
+
+
+@app.put("/offers/{offer_id}/status", response_model=Offer)
+def update_offer_status(offer_id: int, update: StatusUpdate, _: Agent = Depends(require_admin)):
+    if offer_id not in offers:
+        raise HTTPException(status_code=404, detail="Offer not found")
+    offer = offers[offer_id]
+    offer.status = update.status
+    offers[offer_id] = offer
+    return offer
+
+
+@app.post("/property-applications", response_model=PropertyApplication)
+def submit_property_application(application: PropertyApplication, agent: Agent = Depends(get_current_agent)):
+    if application.id in applications:
+        raise HTTPException(status_code=400, detail="Application ID exists")
+    if agent.username != application.realtor:
+        raise HTTPException(status_code=403, detail="Cannot submit for another realtor")
+    applications[application.id] = application
+    notifications.append(f"Property application {application.id} submitted by {application.realtor}")
+    return application
+
+
+@app.get("/property-applications/{app_id}", response_model=PropertyApplication)
+def get_property_application(app_id: int, agent: Agent = Depends(get_current_agent)):
+    if app_id not in applications:
+        raise HTTPException(status_code=404, detail="Application not found")
+    application = applications[app_id]
+    _ensure_owner(application.realtor, agent)
+    return application
+
+
+@app.put("/property-applications/{app_id}/status", response_model=PropertyApplication)
+def update_property_application_status(app_id: int, update: StatusUpdate, _: Agent = Depends(require_admin)):
+    if app_id not in applications:
+        raise HTTPException(status_code=404, detail="Application not found")
+    application = applications[app_id]
+    application.status = update.status
+    applications[app_id] = application
+    return application
+
+
+@app.post("/account-openings", response_model=AccountOpening)
+def submit_account_opening(request: AccountOpening, agent: Agent = Depends(get_current_agent)):
+    if request.id in account_openings:
+        raise HTTPException(status_code=400, detail="Request ID exists")
+    if agent.username != request.realtor:
+        raise HTTPException(status_code=403, detail="Cannot submit for another realtor")
+    account_openings[request.id] = request
+    notifications.append(f"Account opening {request.id} submitted by {request.realtor}")
+    return request
+
+
+@app.get("/account-openings/{req_id}", response_model=AccountOpening)
+def get_account_opening(req_id: int, agent: Agent = Depends(get_current_agent)):
+    if req_id not in account_openings:
+        raise HTTPException(status_code=404, detail="Request not found")
+    request = account_openings[req_id]
+    _ensure_owner(request.realtor, agent)
+    return request
+
+
+@app.put("/account-openings/{req_id}/status", response_model=AccountOpening)
+def update_account_opening_status(req_id: int, update: StatusUpdate, _: Agent = Depends(require_admin)):
+    if req_id not in account_openings:
+        raise HTTPException(status_code=404, detail="Request not found")
+    request = account_openings[req_id]
+    request.status = update.status
+    account_openings[req_id] = request
+    return request
+
+
+@app.get("/notifications", response_model=List[str])
+def list_notifications(_: Agent = Depends(require_admin)):
+    return notifications

--- a/app/models.py
+++ b/app/models.py
@@ -39,3 +39,37 @@ class Stand(BaseModel):
 class Agent(BaseModel):
     username: str
     role: str
+
+
+class SubmissionStatus(str, Enum):
+    SUBMITTED = "submitted"
+    IN_PROGRESS = "in_progress"
+    COMPLETED = "completed"
+    REJECTED = "rejected"
+
+
+class Offer(BaseModel):
+    id: int
+    realtor: str
+    property_id: int
+    details: Optional[str] = None
+    status: SubmissionStatus = SubmissionStatus.SUBMITTED
+
+
+class PropertyApplication(BaseModel):
+    id: int
+    realtor: str
+    property_id: int
+    details: Optional[str] = None
+    status: SubmissionStatus = SubmissionStatus.SUBMITTED
+
+
+class AccountOpening(BaseModel):
+    id: int
+    realtor: str
+    details: Optional[str] = None
+    status: SubmissionStatus = SubmissionStatus.SUBMITTED
+
+
+class StatusUpdate(BaseModel):
+    status: SubmissionStatus

--- a/tests/test_submissions.py
+++ b/tests/test_submissions.py
@@ -1,0 +1,64 @@
+import sys
+sys.path.append(".")
+
+from fastapi.testclient import TestClient
+from app.main import app
+from app.models import SubmissionStatus
+
+client = TestClient(app)
+
+
+def setup_agents():
+    client.post("/agents", json={"username": "admin", "role": "admin"})
+    client.post("/agents", json={"username": "realtor", "role": "agent"})
+
+
+def test_submissions_and_status_updates():
+    setup_agents()
+    admin_headers = {"X-Token": "admin"}
+    realtor_headers = {"X-Token": "realtor"}
+
+    # Submit offer
+    offer = {"id": 1, "realtor": "realtor", "property_id": 1}
+    resp = client.post("/offers", json=offer, headers=realtor_headers)
+    assert resp.status_code == 200
+    assert resp.json()["status"] == SubmissionStatus.SUBMITTED.value
+
+    # Submit property application
+    application = {"id": 1, "realtor": "realtor", "property_id": 1}
+    resp = client.post("/property-applications", json=application, headers=realtor_headers)
+    assert resp.status_code == 200
+
+    # Submit account opening
+    account = {"id": 1, "realtor": "realtor"}
+    resp = client.post("/account-openings", json=account, headers=realtor_headers)
+    assert resp.status_code == 200
+
+    # Notifications should include all three submissions
+    resp = client.get("/notifications", headers=admin_headers)
+    assert resp.status_code == 200
+    assert len(resp.json()) == 3
+
+    # Admin updates status
+    resp = client.put(
+        "/offers/1/status",
+        json={"status": SubmissionStatus.IN_PROGRESS.value},
+        headers=admin_headers,
+    )
+    assert resp.status_code == 200
+
+    # Realtor retrieves updated offer
+    resp = client.get("/offers/1", headers=realtor_headers)
+    assert resp.json()["status"] == SubmissionStatus.IN_PROGRESS.value
+
+    # Admin completes account opening
+    resp = client.put(
+        "/account-openings/1/status",
+        json={"status": SubmissionStatus.COMPLETED.value},
+        headers=admin_headers,
+    )
+    assert resp.status_code == 200
+
+    # Realtor checks account opening status
+    resp = client.get("/account-openings/1", headers=realtor_headers)
+    assert resp.json()["status"] == SubmissionStatus.COMPLETED.value


### PR DESCRIPTION
## Summary
- support offers, property applications, and account opening requests
- store submissions, track status, and collect notifications
- test submission lifecycle and status updates

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c70206f324832c9cdaa4c0ec63a0df