### PR TITLE
Add deposit tracking for account openings

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -12,6 +12,8 @@ from .models import (
     PropertyApplication,
     AccountOpening,
     StatusUpdate,
+    AccountSetup,
+    Deposit,
 )
 
 app = FastAPI(title="Property Management API")
@@ -218,6 +220,30 @@ def update_account_opening_status(req_id: int, update: StatusUpdate, _: Agent = 
         raise HTTPException(status_code=404, detail="Request not found")
     request = account_openings[req_id]
     request.status = update.status
+    account_openings[req_id] = request
+    return request
+
+
+@app.put("/account-openings/{req_id}/open", response_model=AccountOpening)
+def open_account(req_id: int, details: AccountSetup, _: Agent = Depends(require_admin)):
+    if req_id not in account_openings:
+        raise HTTPException(status_code=404, detail="Request not found")
+    request = account_openings[req_id]
+    request.account_number = details.account_number
+    request.deposit_threshold = details.deposit_threshold
+    request.status = SubmissionStatus.IN_PROGRESS
+    account_openings[req_id] = request
+    return request
+
+
+@app.post("/account-openings/{req_id}/deposit", response_model=AccountOpening)
+def record_deposit(req_id: int, deposit: Deposit, _: Agent = Depends(require_admin)):
+    if req_id not in account_openings:
+        raise HTTPException(status_code=404, detail="Request not found")
+    request = account_openings[req_id]
+    request.deposits.append(deposit.amount)
+    if request.deposit_threshold is not None and sum(request.deposits) >= request.deposit_threshold:
+        request.status = SubmissionStatus.COMPLETED
     account_openings[req_id] = request
     return request
 

--- a/app/models.py
+++ b/app/models.py
@@ -1,6 +1,7 @@
 from enum import Enum
-from pydantic import BaseModel
-from typing import Optional
+from typing import List, Optional
+
+from pydantic import BaseModel, Field
 
 
 class PropertyStatus(str, Enum):
@@ -69,7 +70,19 @@ class AccountOpening(BaseModel):
     realtor: str
     details: Optional[str] = None
     status: SubmissionStatus = SubmissionStatus.SUBMITTED
+    account_number: Optional[str] = None
+    deposit_threshold: Optional[float] = None
+    deposits: List[float] = Field(default_factory=list)
 
 
 class StatusUpdate(BaseModel):
     status: SubmissionStatus
+
+
+class AccountSetup(BaseModel):
+    account_number: str
+    deposit_threshold: float
+
+
+class Deposit(BaseModel):
+    amount: float

--- a/tests/test_submissions.py
+++ b/tests/test_submissions.py
@@ -62,3 +62,38 @@ def test_submissions_and_status_updates():
     # Realtor checks account opening status
     resp = client.get("/account-openings/1", headers=realtor_headers)
     assert resp.json()["status"] == SubmissionStatus.COMPLETED.value
+
+
+def test_account_opening_deposit_tracking():
+    setup_agents()
+    admin_headers = {"X-Token": "admin"}
+    realtor_headers = {"X-Token": "realtor"}
+
+    account = {"id": 2, "realtor": "realtor"}
+    resp = client.post("/account-openings", json=account, headers=realtor_headers)
+    assert resp.status_code == 200
+
+    resp = client.put(
+        "/account-openings/2/open",
+        json={"account_number": "ACC123", "deposit_threshold": 100},
+        headers=admin_headers,
+    )
+    assert resp.status_code == 200
+    assert resp.json()["account_number"] == "ACC123"
+    assert resp.json()["status"] == SubmissionStatus.IN_PROGRESS.value
+
+    resp = client.post(
+        "/account-openings/2/deposit",
+        json={"amount": 40},
+        headers=admin_headers,
+    )
+    assert resp.status_code == 200
+    assert resp.json()["status"] == SubmissionStatus.IN_PROGRESS.value
+
+    resp = client.post(
+        "/account-openings/2/deposit",
+        json={"amount": 60},
+        headers=admin_headers,
+    )
+    assert resp.status_code == 200
+    assert resp.json()["status"] == SubmissionStatus.COMPLETED.value


### PR DESCRIPTION
## Summary
- extend account-opening model with account number and deposit tracking fields
- allow admins to assign account numbers, deposit thresholds, and record deposits
- mark account openings complete once deposits meet required threshold

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c702fabd98832cb022e71212f64b60