### PR TITLE
Enable loan application workflow after deposit completion

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -14,6 +14,9 @@ from .models import (
     StatusUpdate,
     AccountSetup,
     Deposit,
+    LoanApplication,
+    LoanDecisionUpdate,
+    LoanDecision,
 )
 
 app = FastAPI(title="Property Management API")
@@ -25,6 +28,7 @@ agents: Dict[str, Agent] = {}
 offers: Dict[int, Offer] = {}
 applications: Dict[int, PropertyApplication] = {}
 account_openings: Dict[int, AccountOpening] = {}
+loan_applications: Dict[int, LoanApplication] = {}
 notifications: List[str] = []
 
 
@@ -246,6 +250,54 @@ def record_deposit(req_id: int, deposit: Deposit, _: Agent = Depends(require_adm
         request.status = SubmissionStatus.COMPLETED
     account_openings[req_id] = request
     return request
+
+
+@app.post("/loan-applications", response_model=LoanApplication)
+def submit_loan_application(
+    application: LoanApplication, agent: Agent = Depends(get_current_agent)
+):
+    if application.id in loan_applications:
+        raise HTTPException(status_code=400, detail="Loan application ID exists")
+    if agent.username != application.realtor:
+        raise HTTPException(status_code=403, detail="Cannot submit for another realtor")
+    if application.account_id not in account_openings:
+        raise HTTPException(status_code=404, detail="Account not found")
+    account = account_openings[application.account_id]
+    if account.status != SubmissionStatus.COMPLETED:
+        raise HTTPException(status_code=400, detail="Deposits not sufficient for loan application")
+    if not application.documents:
+        raise HTTPException(status_code=400, detail="Documentation required")
+    loan_applications[application.id] = application
+    notifications.append(
+        f"Loan application {application.id} submitted by {application.realtor}"
+    )
+    return application
+
+
+@app.get("/loan-applications/{app_id}", response_model=LoanApplication)
+def get_loan_application(app_id: int, agent: Agent = Depends(get_current_agent)):
+    if app_id not in loan_applications:
+        raise HTTPException(status_code=404, detail="Loan application not found")
+    application = loan_applications[app_id]
+    _ensure_owner(application.realtor, agent)
+    return application
+
+
+@app.put("/loan-applications/{app_id}/decision", response_model=LoanApplication)
+def decide_loan_application(
+    app_id: int, decision: LoanDecisionUpdate, _: Agent = Depends(require_admin)
+):
+    if app_id not in loan_applications:
+        raise HTTPException(status_code=404, detail="Loan application not found")
+    application = loan_applications[app_id]
+    application.decision = decision.decision
+    application.reason = decision.reason
+    if decision.decision == LoanDecision.APPROVED:
+        application.status = SubmissionStatus.COMPLETED
+    else:
+        application.status = SubmissionStatus.REJECTED
+    loan_applications[app_id] = application
+    return application
 
 
 @app.get("/notifications", response_model=List[str])

--- a/app/models.py
+++ b/app/models.py
@@ -49,6 +49,11 @@ class SubmissionStatus(str, Enum):
     REJECTED = "rejected"
 
 
+class LoanDecision(str, Enum):
+    APPROVED = "approved"
+    REJECTED = "rejected"
+
+
 class Offer(BaseModel):
     id: int
     realtor: str
@@ -75,6 +80,16 @@ class AccountOpening(BaseModel):
     deposits: List[float] = Field(default_factory=list)
 
 
+class LoanApplication(BaseModel):
+    id: int
+    realtor: str
+    account_id: int
+    documents: List[str] = Field(default_factory=list)
+    status: SubmissionStatus = SubmissionStatus.SUBMITTED
+    decision: Optional[LoanDecision] = None
+    reason: Optional[str] = None
+
+
 class StatusUpdate(BaseModel):
     status: SubmissionStatus
 
@@ -86,3 +101,8 @@ class AccountSetup(BaseModel):
 
 class Deposit(BaseModel):
     amount: float
+
+
+class LoanDecisionUpdate(BaseModel):
+    decision: LoanDecision
+    reason: Optional[str] = None

--- a/tests/test_submissions.py
+++ b/tests/test_submissions.py
@@ -97,3 +97,84 @@ def test_account_opening_deposit_tracking():
     )
     assert resp.status_code == 200
     assert resp.json()["status"] == SubmissionStatus.COMPLETED.value
+
+
+def test_loan_application_flow():
+    setup_agents()
+    admin_headers = {"X-Token": "admin"}
+    realtor_headers = {"X-Token": "realtor"}
+
+    account = {"id": 3, "realtor": "realtor"}
+    resp = client.post("/account-openings", json=account, headers=realtor_headers)
+    assert resp.status_code == 200
+
+    resp = client.put(
+        "/account-openings/3/open",
+        json={"account_number": "ACC3", "deposit_threshold": 100},
+        headers=admin_headers,
+    )
+    assert resp.status_code == 200
+
+    resp = client.post(
+        "/account-openings/3/deposit",
+        json={"amount": 50},
+        headers=admin_headers,
+    )
+    assert resp.status_code == 200
+
+    loan_app = {"id": 1, "realtor": "realtor", "account_id": 3, "documents": ["doc"]}
+    resp = client.post("/loan-applications", json=loan_app, headers=realtor_headers)
+    assert resp.status_code == 400
+
+    resp = client.post(
+        "/account-openings/3/deposit",
+        json={"amount": 50},
+        headers=admin_headers,
+    )
+    assert resp.status_code == 200
+
+    loan_app_no_docs = {
+        "id": 1,
+        "realtor": "realtor",
+        "account_id": 3,
+        "documents": [],
+    }
+    resp = client.post(
+        "/loan-applications", json=loan_app_no_docs, headers=realtor_headers
+    )
+    assert resp.status_code == 400
+
+    resp = client.post(
+        "/loan-applications",
+        json={"id": 1, "realtor": "realtor", "account_id": 3, "documents": ["doc"]},
+        headers=realtor_headers,
+    )
+    assert resp.status_code == 200
+    assert resp.json()["status"] == SubmissionStatus.SUBMITTED.value
+
+    resp = client.put(
+        "/loan-applications/1/decision",
+        json={"decision": "approved", "reason": "All good"},
+        headers=admin_headers,
+    )
+    assert resp.status_code == 200
+    assert resp.json()["status"] == SubmissionStatus.COMPLETED.value
+    assert resp.json()["decision"] == "approved"
+    assert resp.json()["reason"] == "All good"
+
+    resp = client.post(
+        "/loan-applications",
+        json={"id": 2, "realtor": "realtor", "account_id": 3, "documents": ["doc2"]},
+        headers=realtor_headers,
+    )
+    assert resp.status_code == 200
+
+    resp = client.put(
+        "/loan-applications/2/decision",
+        json={"decision": "rejected", "reason": "Insufficient credit"},
+        headers=admin_headers,
+    )
+    assert resp.status_code == 200
+    assert resp.json()["status"] == SubmissionStatus.REJECTED.value
+    assert resp.json()["decision"] == "rejected"
+    assert resp.json()["reason"] == "Insufficient credit"


### PR DESCRIPTION
## Summary
- Allow loan applications once account-opening deposits meet threshold
- Require documentation and notify Loan Approval Team upon submission
- Capture approval or rejection decisions with reasons

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c703dc77a4832c86255aca20290c51