### PR TITLE
Add agreement document generation and signing workflow

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -1,5 +1,6 @@
 from fastapi import FastAPI, HTTPException, Depends, Header
 from typing import Dict, List
+from datetime import datetime
 from .models import (
     Project,
     Stand,
@@ -17,6 +18,9 @@ from .models import (
     LoanApplication,
     LoanDecisionUpdate,
     LoanDecision,
+    Agreement,
+    AgreementCreate,
+    AgreementUpload,
 )
 
 app = FastAPI(title="Property Management API")
@@ -30,6 +34,7 @@ applications: Dict[int, PropertyApplication] = {}
 account_openings: Dict[int, AccountOpening] = {}
 loan_applications: Dict[int, LoanApplication] = {}
 notifications: List[str] = []
+agreements: Dict[int, Agreement] = {}
 
 
 def get_current_agent(x_token: str = Header(...)) -> Agent:
@@ -303,3 +308,77 @@ def decide_loan_application(
 @app.get("/notifications", response_model=List[str])
 def list_notifications(_: Agent = Depends(require_admin)):
     return notifications
+
+
+# ---- Agreement endpoints ----
+
+
+@app.post("/agreements/generate", response_model=Agreement)
+def generate_agreement(
+    data: AgreementCreate, _: Agent = Depends(require_admin)
+):
+    if data.id in agreements:
+        raise HTTPException(status_code=400, detail="Agreement ID exists")
+    if data.loan_application_id not in loan_applications:
+        raise HTTPException(status_code=404, detail="Loan application not found")
+    if data.property_id not in stands:
+        raise HTTPException(status_code=404, detail="Property not found")
+    loan = loan_applications[data.loan_application_id]
+    stand = stands[data.property_id]
+    content = f"Agreement for property {stand.name} with loan {loan.id}"
+    timestamp = datetime.utcnow().isoformat()
+    agreement = Agreement(
+        id=data.id,
+        loan_application_id=data.loan_application_id,
+        property_id=data.property_id,
+        document=content,
+        versions=[content],
+        audit_log=[f"{timestamp}: generated"],
+    )
+    agreements[data.id] = agreement
+    return agreement
+
+
+@app.get("/agreements/{agreement_id}", response_model=Agreement)
+def get_agreement(agreement_id: int, _: Agent = Depends(get_current_agent)):
+    if agreement_id not in agreements:
+        raise HTTPException(status_code=404, detail="Agreement not found")
+    return agreements[agreement_id]
+
+
+@app.put("/agreements/{agreement_id}/sign", response_model=Agreement)
+def sign_agreement(agreement_id: int, agent: Agent = Depends(get_current_agent)):
+    if agreement_id not in agreements:
+        raise HTTPException(status_code=404, detail="Agreement not found")
+    agreement = agreements[agreement_id]
+    timestamp = datetime.utcnow().isoformat()
+    if agent.role == "admin":
+        agreement.bank_signature = f"signed by {agent.username} at {timestamp}"
+        agreement.audit_log.append(
+            f"{timestamp}: bank signed by {agent.username}"
+        )
+    else:
+        agreement.customer_signature = f"signed by {agent.username} at {timestamp}"
+        agreement.audit_log.append(
+            f"{timestamp}: customer signed by {agent.username}"
+        )
+    agreements[agreement_id] = agreement
+    return agreement
+
+
+@app.post("/agreements/{agreement_id}/upload", response_model=Agreement)
+def upload_agreement(
+    agreement_id: int,
+    upload: AgreementUpload,
+    agent: Agent = Depends(get_current_agent),
+):
+    if agreement_id not in agreements:
+        raise HTTPException(status_code=404, detail="Agreement not found")
+    agreement = agreements[agreement_id]
+    agreement.versions.append(upload.document)
+    agreement.document = upload.document
+    timestamp = datetime.utcnow().isoformat()
+    role = "bank" if agent.role == "admin" else "customer"
+    agreement.audit_log.append(f"{timestamp}: {role} uploaded new version")
+    agreements[agreement_id] = agreement
+    return agreement

--- a/app/models.py
+++ b/app/models.py
@@ -106,3 +106,24 @@ class Deposit(BaseModel):
 class LoanDecisionUpdate(BaseModel):
     decision: LoanDecision
     reason: Optional[str] = None
+
+
+class AgreementCreate(BaseModel):
+    id: int
+    loan_application_id: int
+    property_id: int
+
+
+class AgreementUpload(BaseModel):
+    document: str
+
+
+class Agreement(BaseModel):
+    id: int
+    loan_application_id: int
+    property_id: int
+    document: str
+    versions: List[str] = Field(default_factory=list)
+    bank_signature: Optional[str] = None
+    customer_signature: Optional[str] = None
+    audit_log: List[str] = Field(default_factory=list)

--- a/tests/test_agreements.py
+++ b/tests/test_agreements.py
@@ -1,0 +1,100 @@
+import sys
+sys.path.append(".")
+
+from fastapi.testclient import TestClient
+from app.main import (
+    app,
+    projects,
+    stands,
+    agents,
+    offers,
+    applications,
+    account_openings,
+    loan_applications,
+    notifications,
+    agreements,
+)
+
+client = TestClient(app)
+
+
+def setup_data():
+    reset_state()
+    client.post("/agents", json={"username": "admin", "role": "admin"})
+    client.post("/agents", json={"username": "realtor", "role": "agent"})
+
+    admin_headers = {"X-Token": "admin"}
+    realtor_headers = {"X-Token": "realtor"}
+
+    client.post("/projects", json={"id": 1, "name": "Proj"}, headers=admin_headers)
+    client.post(
+        "/stands",
+        json={"id": 1, "project_id": 1, "name": "Stand1"},
+        headers=admin_headers,
+    )
+
+    client.post(
+        "/account-openings",
+        json={"id": 1, "realtor": "realtor"},
+        headers=realtor_headers,
+    )
+    client.put(
+        "/account-openings/1/open",
+        json={"account_number": "ACC1", "deposit_threshold": 100},
+        headers=admin_headers,
+    )
+    client.post(
+        "/account-openings/1/deposit",
+        json={"amount": 100},
+        headers=admin_headers,
+    )
+    client.post(
+        "/loan-applications",
+        json={"id": 1, "realtor": "realtor", "account_id": 1, "documents": ["doc"]},
+        headers=realtor_headers,
+    )
+    return admin_headers, realtor_headers
+
+
+def reset_state():
+    projects.clear()
+    stands.clear()
+    agents.clear()
+    offers.clear()
+    applications.clear()
+    account_openings.clear()
+    loan_applications.clear()
+    notifications.clear()
+    agreements.clear()
+
+
+def test_agreement_flow():
+    admin_headers, realtor_headers = setup_data()
+
+    resp = client.post(
+        "/agreements/generate",
+        json={"id": 1, "loan_application_id": 1, "property_id": 1},
+        headers=admin_headers,
+    )
+    assert resp.status_code == 200
+    assert "Stand1" in resp.json()["document"]
+
+    resp = client.put("/agreements/1/sign", headers=realtor_headers)
+    assert resp.status_code == 200
+    assert resp.json()["customer_signature"] is not None
+
+    resp = client.put("/agreements/1/sign", headers=admin_headers)
+    assert resp.status_code == 200
+    assert resp.json()["bank_signature"] is not None
+
+    resp = client.post(
+        "/agreements/1/upload",
+        json={"document": "Updated"},
+        headers=admin_headers,
+    )
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["document"] == "Updated"
+    assert len(data["versions"]) == 2
+    assert len(data["audit_log"]) >= 3
+    reset_state()


### PR DESCRIPTION
## Summary
- add models and endpoints for generating, signing, and uploading property loan agreements
- track agreement versions with audit logs
- cover agreement workflow with new test

## Testing
- `python -m pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c70549788c832cbc7f4c8f070ff508