### PR TITLE
Finalize agreements with loan account tracking

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -21,6 +21,7 @@ from .models import (
     Agreement,
     AgreementCreate,
     AgreementUpload,
+    AgreementExecution,
 )
 
 app = FastAPI(title="Property Management API")
@@ -35,6 +36,7 @@ account_openings: Dict[int, AccountOpening] = {}
 loan_applications: Dict[int, LoanApplication] = {}
 notifications: List[str] = []
 agreements: Dict[int, Agreement] = {}
+customer_loan_accounts: Dict[str, List[str]] = {}
 
 
 def get_current_agent(x_token: str = Header(...)) -> Agent:
@@ -84,6 +86,9 @@ def create_stand(stand: Stand, _: Agent = Depends(require_admin)):
 def update_stand(stand_id: int, stand: Stand, _: Agent = Depends(require_admin)):
     if stand_id not in stands:
         raise HTTPException(status_code=404, detail="Stand not found")
+    existing = stands[stand_id]
+    if existing.status == PropertyStatus.SOLD:
+        raise HTTPException(status_code=400, detail="Stand already sold")
     if stand.project_id not in projects:
         raise HTTPException(status_code=404, detail="Project not found")
     stands[stand_id] = stand
@@ -95,6 +100,8 @@ def archive_stand(stand_id: int, _: Agent = Depends(require_admin)):
     if stand_id not in stands:
         raise HTTPException(status_code=404, detail="Stand not found")
     stand = stands[stand_id]
+    if stand.status == PropertyStatus.SOLD:
+        raise HTTPException(status_code=400, detail="Stand already sold")
     stand.status = PropertyStatus.ARCHIVED
     stands[stand_id] = stand
     return stand
@@ -105,6 +112,8 @@ def assign_mandate(stand_id: int, mandate: Mandate, _: Agent = Depends(require_a
     if stand_id not in stands:
         raise HTTPException(status_code=404, detail="Stand not found")
     stand = stands[stand_id]
+    if stand.status == PropertyStatus.SOLD:
+        raise HTTPException(status_code=400, detail="Stand already sold")
     stand.mandate = mandate
     stand.mandate.status = MandateStatus.PENDING
     stands[stand_id] = stand
@@ -116,6 +125,8 @@ def accept_mandate(stand_id: int, agent: Agent = Depends(get_current_agent)):
     if stand_id not in stands:
         raise HTTPException(status_code=404, detail="Stand not found")
     stand = stands[stand_id]
+    if stand.status == PropertyStatus.SOLD:
+        raise HTTPException(status_code=400, detail="Stand already sold")
     if not stand.mandate or stand.mandate.agent != agent.username:
         raise HTTPException(status_code=403, detail="Not authorized to accept this mandate")
     stand.mandate.status = MandateStatus.ACCEPTED
@@ -381,4 +392,31 @@ def upload_agreement(
     role = "bank" if agent.role == "admin" else "customer"
     agreement.audit_log.append(f"{timestamp}: {role} uploaded new version")
     agreements[agreement_id] = agreement
+    return agreement
+
+
+@app.put("/agreements/{agreement_id}/execute", response_model=Agreement)
+def execute_agreement(
+    agreement_id: int,
+    execution: AgreementExecution,
+    _: Agent = Depends(require_admin),
+):
+    if agreement_id not in agreements:
+        raise HTTPException(status_code=404, detail="Agreement not found")
+    agreement = agreements[agreement_id]
+    if not agreement.bank_signature or not agreement.customer_signature:
+        raise HTTPException(status_code=400, detail="Agreement not fully signed")
+    loan_application = loan_applications[agreement.loan_application_id]
+    loan_application.loan_account_number = execution.loan_account_number
+    loan_applications[agreement.loan_application_id] = loan_application
+    realtor = loan_application.realtor
+    customer_loan_accounts.setdefault(realtor, []).append(
+        execution.loan_account_number
+    )
+    stand = stands[agreement.property_id]
+    stand.status = PropertyStatus.SOLD
+    stands[agreement.property_id] = stand
+    notifications.append(
+        f"Agreement {agreement_id} executed; notify Loan Accounts Opening Team"
+    )
     return agreement

--- a/app/models.py
+++ b/app/models.py
@@ -88,6 +88,7 @@ class LoanApplication(BaseModel):
     status: SubmissionStatus = SubmissionStatus.SUBMITTED
     decision: Optional[LoanDecision] = None
     reason: Optional[str] = None
+    loan_account_number: Optional[str] = None
 
 
 class StatusUpdate(BaseModel):
@@ -127,3 +128,7 @@ class Agreement(BaseModel):
     bank_signature: Optional[str] = None
     customer_signature: Optional[str] = None
     audit_log: List[str] = Field(default_factory=list)
+
+
+class AgreementExecution(BaseModel):
+    loan_account_number: str

--- a/tests/test_agreements.py
+++ b/tests/test_agreements.py
@@ -13,7 +13,9 @@ from app.main import (
     loan_applications,
     notifications,
     agreements,
+    customer_loan_accounts,
 )
+from app.models import PropertyStatus
 
 client = TestClient(app)
 
@@ -66,6 +68,7 @@ def reset_state():
     loan_applications.clear()
     notifications.clear()
     agreements.clear()
+    customer_loan_accounts.clear()
 
 
 def test_agreement_flow():
@@ -97,4 +100,22 @@ def test_agreement_flow():
     assert data["document"] == "Updated"
     assert len(data["versions"]) == 2
     assert len(data["audit_log"]) >= 3
+
+    resp = client.put(
+        "/agreements/1/execute",
+        json={"loan_account_number": "LN1"},
+        headers=admin_headers,
+    )
+    assert resp.status_code == 200
+    assert stands[1].status == PropertyStatus.SOLD
+    assert loan_applications[1].loan_account_number == "LN1"
+    assert customer_loan_accounts["realtor"] == ["LN1"]
+    assert any("Loan Accounts Opening Team" in n for n in notifications)
+
+    resp = client.put(
+        "/stands/1",
+        json={"id": 1, "project_id": 1, "name": "New", "status": "available"},
+        headers=admin_headers,
+    )
+    assert resp.status_code == 400
     reset_state()


### PR DESCRIPTION
## Summary
- Track loan account numbers on loan applications
- Execute agreements to mark properties sold and notify Loan Accounts Opening Team
- Prevent further stand edits once property is sold

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c706a6e520832ca7560c321277c319