### PR TITLE
Add dashboards and audit logging

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -1,4 +1,4 @@
-from fastapi import FastAPI, HTTPException, Depends, Header
+from fastapi import FastAPI, HTTPException, Depends, Header, Request
 from typing import Dict, List
 from datetime import datetime
 from .models import (
@@ -37,6 +37,7 @@ loan_applications: Dict[int, LoanApplication] = {}
 notifications: List[str] = []
 agreements: Dict[int, Agreement] = {}
 customer_loan_accounts: Dict[str, List[str]] = {}
+audit_log: List[str] = []
 
 
 def get_current_agent(x_token: str = Header(...)) -> Agent:
@@ -50,6 +51,23 @@ def require_admin(agent: Agent = Depends(get_current_agent)) -> Agent:
         raise HTTPException(status_code=403, detail="Admin privileges required")
     return agent
 
+
+def require_compliance(agent: Agent = Depends(get_current_agent)) -> Agent:
+    if agent.role not in ("compliance", "admin"):
+        raise HTTPException(status_code=403, detail="Compliance privileges required")
+    return agent
+
+
+@app.middleware("http")
+async def log_request(request: Request, call_next):
+    token = request.headers.get("x-token")
+    username = agents.get(token).username if token in agents else "anonymous"
+    timestamp = datetime.utcnow().isoformat()
+    response = await call_next(request)
+    audit_log.append(
+        f"{timestamp} - {username} - {request.method} {request.url.path} - {response.status_code}"
+    )
+    return response
 
 @app.post("/agents", response_model=Agent)
 def create_agent(agent: Agent):
@@ -319,6 +337,49 @@ def decide_loan_application(
 @app.get("/notifications", response_model=List[str])
 def list_notifications(_: Agent = Depends(require_admin)):
     return notifications
+
+
+@app.get("/dashboard")
+def dashboard(agent: Agent = Depends(get_current_agent)):
+    data = {}
+    if agent.role in ("manager", "admin"):
+        prop_counts = {
+            status.value: sum(1 for s in stands.values() if s.status == status)
+            for status in PropertyStatus
+        }
+        mandate_counts = {
+            status.value: sum(
+                1
+                for s in stands.values()
+                if s.mandate and s.mandate.status == status
+            )
+            for status in MandateStatus
+        }
+        data["property_status"] = prop_counts
+        data["mandates"] = mandate_counts
+    if agent.role in ("compliance", "admin"):
+        total_deposits = sum(sum(req.deposits) for req in account_openings.values())
+        approvals = sum(
+            1
+            for app in loan_applications.values()
+            if app.decision == LoanDecision.APPROVED
+        )
+        rejections = sum(
+            1
+            for app in loan_applications.values()
+            if app.decision == LoanDecision.REJECTED
+        )
+        data["deposits"] = total_deposits
+        data["loan_approvals"] = {
+            "approved": approvals,
+            "rejected": rejections,
+        }
+    return data
+
+
+@app.get("/audit-log", response_model=List[str])
+def get_audit_log(_: Agent = Depends(require_compliance)):
+    return audit_log
 
 
 # ---- Agreement endpoints ----

--- a/tests/test_dashboard.py
+++ b/tests/test_dashboard.py
@@ -1,0 +1,116 @@
+import sys
+sys.path.append('.')
+
+from fastapi.testclient import TestClient
+from app.main import (
+    app,
+    projects,
+    stands,
+    agents,
+    offers,
+    applications,
+    account_openings,
+    loan_applications,
+    notifications,
+    agreements,
+    customer_loan_accounts,
+    audit_log,
+)
+
+client = TestClient(app)
+
+
+def reset_state():
+    projects.clear()
+    stands.clear()
+    agents.clear()
+    offers.clear()
+    applications.clear()
+    account_openings.clear()
+    loan_applications.clear()
+    notifications.clear()
+    agreements.clear()
+    customer_loan_accounts.clear()
+    audit_log.clear()
+
+
+def register_agents():
+    client.post("/agents", json={"username": "admin", "role": "admin"})
+    client.post("/agents", json={"username": "manager", "role": "manager"})
+    client.post("/agents", json={"username": "compliance", "role": "compliance"})
+    client.post("/agents", json={"username": "agentA", "role": "agent"})
+
+
+def setup_data(admin_headers, agent_headers):
+    project = {"id": 100, "name": "Proj"}
+    client.post("/projects", json=project, headers=admin_headers)
+    stand = {"id": 100, "project_id": 100, "name": "Stand1"}
+    client.post("/stands", json=stand, headers=admin_headers)
+    client.post(
+        "/stands/100/mandate",
+        json={"agent": "agentA", "document": "m.pdf"},
+        headers=admin_headers,
+    )
+    client.put("/stands/100/mandate/accept", headers=agent_headers)
+    client.post(
+        "/account-openings",
+        json={"id": 100, "realtor": "agentA"},
+        headers=agent_headers,
+    )
+    client.put(
+        "/account-openings/100/open",
+        json={"account_number": "A1", "deposit_threshold": 100},
+        headers=admin_headers,
+    )
+    client.post(
+        "/account-openings/100/deposit",
+        json={"amount": 100},
+        headers=admin_headers,
+    )
+    client.post(
+        "/loan-applications",
+        json={
+            "id": 100,
+            "realtor": "agentA",
+            "account_id": 100,
+            "documents": ["doc"],
+        },
+        headers=agent_headers,
+    )
+    client.put(
+        "/loan-applications/100/decision",
+        json={"decision": "approved"},
+        headers=admin_headers,
+    )
+
+
+def test_dashboards_and_audit_log():
+    reset_state()
+    register_agents()
+    admin_headers = {"X-Token": "admin"}
+    manager_headers = {"X-Token": "manager"}
+    compliance_headers = {"X-Token": "compliance"}
+    agent_headers = {"X-Token": "agentA"}
+
+    setup_data(admin_headers, agent_headers)
+
+    resp = client.get("/dashboard", headers=manager_headers)
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["property_status"]["available"] == 1
+    assert data["mandates"]["accepted"] == 1
+    assert "deposits" not in data
+
+    resp = client.get("/dashboard", headers=compliance_headers)
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["deposits"] == 100
+    assert data["loan_approvals"]["approved"] == 1
+    assert "property_status" not in data
+
+    resp = client.get("/audit-log", headers=compliance_headers)
+    assert resp.status_code == 200
+    log = resp.json()
+    assert any("/projects" in entry for entry in log)
+    reset_state()
+


### PR DESCRIPTION
## Summary
- add request middleware to keep audit trail
- provide role-aware dashboard aggregating property and loan metrics
- expose audit log for compliance review
- cover dashboard and audit log with tests

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c7099a014c832ca853b0e607b81b6a