### PR TITLE
Validate positive deposit inputs

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -270,6 +270,8 @@ def open_account(req_id: int, details: AccountSetup, _: Agent = Depends(require_
     if req_id not in account_openings:
         raise HTTPException(status_code=404, detail="Request not found")
     request = account_openings[req_id]
+    if details.deposit_threshold <= 0:
+        raise HTTPException(status_code=400, detail="Deposit threshold must be positive")
     request.account_number = details.account_number
     request.deposit_threshold = details.deposit_threshold
     request.status = SubmissionStatus.IN_PROGRESS
@@ -282,6 +284,8 @@ def record_deposit(req_id: int, deposit: Deposit, _: Agent = Depends(require_adm
     if req_id not in account_openings:
         raise HTTPException(status_code=404, detail="Request not found")
     request = account_openings[req_id]
+    if deposit.amount <= 0:
+        raise HTTPException(status_code=400, detail="Deposit amount must be positive")
     request.deposits.append(deposit.amount)
     if request.deposit_threshold is not None and sum(request.deposits) >= request.deposit_threshold:
         request.status = SubmissionStatus.COMPLETED

--- a/app/models.py
+++ b/app/models.py
@@ -104,11 +104,11 @@ class StatusUpdate(BaseModel):
 
 class AccountSetup(BaseModel):
     account_number: str
-    deposit_threshold: float
+    deposit_threshold: float = Field(..., gt=0)
 
 
 class Deposit(BaseModel):
-    amount: float
+    amount: float = Field(..., gt=0)
 
 
 class LoanDecisionUpdate(BaseModel):


### PR DESCRIPTION
## Summary
- enforce positive deposit_threshold and deposit.amount in models
- reject non-positive deposit_threshold in open_account endpoint
- reject non-positive deposit amount in record_deposit

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c70c63e170832cb7826f0f7851503f