### PR TITLE
Restrict agreement signing to expected customer

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -541,6 +541,7 @@ def generate_agreement(
         id=data.id,
         loan_application_id=data.loan_application_id,
         property_id=data.property_id,
+        realtor=loan.realtor,
         document=content,
         versions=[content],
         audit_log=[f"{timestamp}: generated"],
@@ -577,6 +578,8 @@ def sign_agreement(
             f"{timestamp}: bank signed by {agent.username}"
         )
     else:
+        if agent.username != agreement.realtor:
+            raise HTTPException(status_code=403, detail="Agent not authorized to sign")
         agreement.customer_signature = f"signed by {agent.username} at {timestamp}"
         agreement.audit_log.append(
             f"{timestamp}: customer signed by {agent.username}"

--- a/app/models.py
+++ b/app/models.py
@@ -130,6 +130,7 @@ class Agreement(BaseModel):
     id: int
     loan_application_id: int
     property_id: int
+    realtor: str
     document: str
     versions: List[str] = Field(default_factory=list)
     bank_signature: Optional[str] = None

--- a/tests/test_agreements.py
+++ b/tests/test_agreements.py
@@ -13,9 +13,11 @@ def setup_data():
     reset_state()
     client.post("/agents", json={"username": "admin", "role": "admin"})
     client.post("/agents", json={"username": "realtor", "role": "agent"})
+    client.post("/agents", json={"username": "intruder", "role": "agent"})
 
     admin_headers = {"X-Token": "admin"}
     realtor_headers = {"X-Token": "realtor"}
+    intruder_headers = {"X-Token": "intruder"}
 
     client.post("/projects", json={"id": 1, "name": "Proj"}, headers=admin_headers)
     client.post(
@@ -44,7 +46,7 @@ def setup_data():
         json={"id": 1, "realtor": "realtor", "account_id": 1, "documents": ["doc"]},
         headers=realtor_headers,
     )
-    return admin_headers, realtor_headers
+    return admin_headers, realtor_headers, intruder_headers
 
 
 def reset_state():
@@ -53,7 +55,7 @@ def reset_state():
 
 
 def test_agreement_flow():
-    admin_headers, realtor_headers = setup_data()
+    admin_headers, realtor_headers, intruder_headers = setup_data()
 
     resp = client.post(
         "/agreements/generate",
@@ -62,6 +64,9 @@ def test_agreement_flow():
     )
     assert resp.status_code == 200
     assert "Stand1" in resp.json()["document"]
+
+    resp = client.put("/agreements/1/sign", headers=intruder_headers)
+    assert resp.status_code == 403
 
     resp = client.put("/agreements/1/sign", headers=realtor_headers)
     assert resp.status_code == 200


### PR DESCRIPTION
## Summary
- Track the expected realtor on each Agreement
- Allow only the designated realtor to sign agreements as customer
- Test unauthorized customer sign attempts are rejected with 403

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c70f60e644832c8baedeff8b50acd8