### PR TITLE
Add Dockerfile for FastAPI service

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,11 @@
+tests
+venv
+.venv
+__pycache__
+*.pyc
+*.pyo
+*.pyd
+*.swp
+*.swo
+.vscode
+.idea

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,13 @@
+FROM python:3.11-slim
+
+WORKDIR /app
+
+COPY requirements.txt .
+RUN pip install --no-cache-dir -r requirements.txt
+
+COPY app/ ./app
+COPY app.db ./app.db
+
+EXPOSE 8000
+
+CMD ["uvicorn", "app.main:app", "--host", "0.0.0.0", "--port", "8000"]


### PR DESCRIPTION
## Summary
- add Dockerfile based on Python 3.11-slim to run FastAPI app with uvicorn
- add .dockerignore excluding tests, virtualenvs, and editor files

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68c71c2234b4832c850e7846afc1129b