### PR TITLE
Add Docker Compose setup for web service

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,16 @@ uvicorn app.main:app --reload
 
 Interactive docs will be available at `http://127.0.0.1:8000/docs`.
 
+## Docker Compose
+
+To build and run the application with Docker Compose:
+
+```bash
+ docker-compose up --build
+```
+
+This will build the image from the included `Dockerfile`, start the `web` service on port 8000, and persist the SQLite database in a named volume (`sqlite_data`). The environment variable `DATABASE_URL=sqlite:///app.db` is provided to the container.
+
 ## Authentication
 
 Agents are created with a password hash:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,12 @@
+version: "3.8"
+services:
+  web:
+    build: .
+    ports:
+      - "8000:8000"
+    environment:
+      DATABASE_URL: "sqlite:///app.db"
+    volumes:
+      - sqlite_data:/app/app.db
+volumes:
+  sqlite_data:


### PR DESCRIPTION
## Summary
- add docker-compose.yml defining a web service
- document docker-compose workflow in README

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c71d091168832c8a28fb1e7d073cbf