### PR TITLE
Add properties report endpoint and tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,16 @@ POST /login {"username": "alice", "password": "secret"}
 X-Token: <token from login>
 ```
 
+## Reports
+
+Download a CSV report of all properties and mandate statuses. Optionally filter by
+property status using the `status` query parameter:
+
+```bash
+curl -H "X-Token: <token>" -o properties.csv \
+  "http://127.0.0.1:8000/reports/properties?status=available"
+```
+
 ## Tests
 
 ```

--- a/app/main.py
+++ b/app/main.py
@@ -1,5 +1,5 @@
-from fastapi import FastAPI, HTTPException, Depends, Header, Request, UploadFile, File
-from typing import List
+from fastapi import FastAPI, HTTPException, Depends, Header, Request, UploadFile, File, Response
+from typing import List, Optional
 from datetime import datetime
 import secrets
 import hashlib
@@ -10,6 +10,7 @@ from pydantic import BaseModel
 from openpyxl import load_workbook
 from .database import init_db, get_session, SessionLocal
 from .repositories import Repositories
+from .reporting import generate_properties_report
 from .models import (
     Project,
     Stand,
@@ -330,6 +331,19 @@ def import_properties(
         imported += 1
 
     return ImportResult(imported=imported, errors=errors)
+
+
+# Reporting endpoints
+
+
+@app.get("/reports/properties")
+def properties_report(
+    status: Optional[PropertyStatus] = None,
+    _: Agent = Depends(require_admin),
+    repos: Repositories = Depends(get_repositories),
+):
+    csv_data = generate_properties_report(repos, status)
+    return Response(content=csv_data, media_type="text/csv")
 
 
 # ---- Submission endpoints ----

--- a/app/reporting.py
+++ b/app/reporting.py
@@ -1,0 +1,42 @@
+from io import StringIO
+import csv
+from typing import Optional
+
+from .repositories import Repositories
+from .models import PropertyStatus
+
+
+def generate_properties_report(
+    repos: Repositories, status: Optional[PropertyStatus] = None
+) -> str:
+    """Generate CSV report of properties and mandates."""
+    projects = {p.id: p.name for p in repos.projects.list()}
+    rows = []
+    for stand in repos.stands.list():
+        if status and stand.status != status:
+            continue
+        rows.append(
+            {
+                "project_id": stand.project_id,
+                "project_name": projects.get(stand.project_id, ""),
+                "stand_id": stand.id,
+                "stand_name": stand.name,
+                "price": stand.price,
+                "status": stand.status.value,
+                "mandate_status": stand.mandate.status.value if stand.mandate else "",
+            }
+        )
+    output = StringIO()
+    fieldnames = [
+        "project_id",
+        "project_name",
+        "stand_id",
+        "stand_name",
+        "price",
+        "status",
+        "mandate_status",
+    ]
+    writer = csv.DictWriter(output, fieldnames=fieldnames)
+    writer.writeheader()
+    writer.writerows(rows)
+    return output.getvalue()

--- a/tests/test_reporting.py
+++ b/tests/test_reporting.py
@@ -1,0 +1,62 @@
+import sys
+import csv
+
+sys.path.append('.')
+
+from fastapi.testclient import TestClient
+from app.main import app
+from app.database import drop_db, init_db
+
+client = TestClient(app)
+
+
+def setup_function():
+    drop_db()
+    init_db()
+
+
+def setup_data():
+    client.post("/agents", json={"username": "admin", "role": "admin", "password": "a"})
+    client.post("/agents", json={"username": "agent", "role": "agent", "password": "b"})
+    admin_token = client.post("/login", json={"username": "admin", "password": "a"}).json()["token"]
+    agent_token = client.post("/login", json={"username": "agent", "password": "b"}).json()["token"]
+    admin_headers = {"X-Token": admin_token}
+    agent_headers = {"X-Token": agent_token}
+    client.post("/projects", json={"id": 1, "name": "Proj"}, headers=admin_headers)
+    client.post(
+        "/stands",
+        json={"id": 1, "project_id": 1, "name": "S1", "size": 100, "price": 1000},
+        headers=admin_headers,
+    )
+    client.post(
+        "/stands",
+        json={"id": 2, "project_id": 1, "name": "S2", "size": 100, "price": 2000, "status": "sold"},
+        headers=admin_headers,
+    )
+    client.post("/stands/1/mandate", json={"agent": "agent"}, headers=admin_headers)
+    client.put("/stands/1/mandate/accept", headers=agent_headers)
+    return admin_headers
+
+
+def test_report_headers_and_rows():
+    admin_headers = setup_data()
+    resp = client.get("/reports/properties", headers=admin_headers)
+    assert resp.status_code == 200
+    lines = resp.text.strip().splitlines()
+    assert (
+        lines[0]
+        == "project_id,project_name,stand_id,stand_name,price,status,mandate_status"
+    )
+    data = list(csv.DictReader(lines))
+    assert len(data) == 2
+    row = next(r for r in data if r["stand_id"] == "1")
+    assert row["mandate_status"] == "accepted"
+
+
+def test_report_filtering():
+    admin_headers = setup_data()
+    resp = client.get("/reports/properties?status=sold", headers=admin_headers)
+    assert resp.status_code == 200
+    data = list(csv.DictReader(resp.text.splitlines()))
+    assert len(data) == 1
+    assert data[0]["status"] == "sold"


### PR DESCRIPTION
## Summary
- add CSV report generator for properties and mandates
- expose `/reports/properties` endpoint with optional status filter
- document report usage in README and test CSV output

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68c7220bde98832c81455384e52646e6