### PR TITLE
Add React admin dashboard with property management

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,6 @@
 __pycache__/
 *.pyc
 *.db
+node_modules/
+dist/
 

--- a/README.md
+++ b/README.md
@@ -18,6 +18,18 @@ uvicorn app.main:app --reload
 
 Interactive docs will be available at `http://127.0.0.1:8000/docs`.
 
+## Admin Dashboard
+
+A simple React + TypeScript dashboard is available in the `dashboard/` directory. It offers role-based routing and CRUD views for projects, stands, and mandate assignments.
+
+```
+cd dashboard
+npm install
+npm run dev
+```
+
+The dev server proxies API requests to the FastAPI backend running on port 8000.
+
 ## Importing Projects and Stands
 
 Administrators can bulk import projects and stand/unit details from a CSV or Excel file:

--- a/dashboard/index.html
+++ b/dashboard/index.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Property Dashboard</title>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/src/main.tsx"></script>
+  </body>
+</html>

--- a/dashboard/package.json
+++ b/dashboard/package.json
@@ -1,0 +1,23 @@
+{
+  "name": "property-admin-dashboard",
+  "version": "1.0.0",
+  "private": true,
+  "scripts": {
+    "dev": "vite",
+    "build": "vite build",
+    "preview": "vite preview"
+  },
+  "dependencies": {
+    "react": "^18.2.0",
+    "react-dom": "^18.2.0",
+    "react-router-dom": "^6.23.0"
+  },
+  "devDependencies": {
+    "@types/react": "^18.2.15",
+    "@types/react-dom": "^18.2.7",
+    "@types/react-router-dom": "^6.20.9",
+    "@vitejs/plugin-react": "^4.0.0",
+    "typescript": "^5.2.2",
+    "vite": "^5.0.0"
+  }
+}

--- a/dashboard/src/App.tsx
+++ b/dashboard/src/App.tsx
@@ -1,0 +1,53 @@
+import React from 'react';
+import { Routes, Route, Link, Navigate } from 'react-router-dom';
+import Login from './pages/Login';
+import Projects from './pages/Projects';
+import Stands from './pages/Stands';
+import Mandates from './pages/Mandates';
+import { ProtectedRoute, useAuth } from './auth';
+
+const App: React.FC = () => {
+  const { auth, logout } = useAuth();
+  return (
+    <div>
+      {auth && (
+        <nav>
+          <Link to="/projects">Projects</Link> |{' '}
+          <Link to="/stands">Stands</Link> |{' '}
+          <Link to="/mandates">Mandates</Link> |{' '}
+          <button onClick={logout}>Logout</button>
+        </nav>
+      )}
+      <Routes>
+        <Route path="/login" element={<Login />} />
+        <Route
+          path="/projects"
+          element={
+            <ProtectedRoute roles={["admin"]}>
+              <Projects />
+            </ProtectedRoute>
+          }
+        />
+        <Route
+          path="/stands"
+          element={
+            <ProtectedRoute roles={["admin"]}>
+              <Stands />
+            </ProtectedRoute>
+          }
+        />
+        <Route
+          path="/mandates"
+          element={
+            <ProtectedRoute roles={["admin"]}>
+              <Mandates />
+            </ProtectedRoute>
+          }
+        />
+        <Route path="*" element={<Navigate to={auth ? '/projects' : '/login'} replace />} />
+      </Routes>
+    </div>
+  );
+};
+
+export default App;

--- a/dashboard/src/api.ts
+++ b/dashboard/src/api.ts
@@ -1,0 +1,65 @@
+export const headers = (token: string) => ({
+  'Content-Type': 'application/json',
+  'X-Token': token,
+});
+
+export async function getProjects(token: string) {
+  const res = await fetch('/projects', { headers: headers(token) });
+  if (!res.ok) throw new Error('Failed to load projects');
+  return res.json();
+}
+
+export async function createProject(token: string, project: { id: number; name: string }) {
+  const res = await fetch('/projects', {
+    method: 'POST',
+    headers: headers(token),
+    body: JSON.stringify(project),
+  });
+  if (!res.ok) throw new Error('Failed to create project');
+  return res.json();
+}
+
+export async function getStands(token: string) {
+  const res = await fetch('/stands/available', { headers: headers(token) });
+  if (!res.ok) throw new Error('Failed to load stands');
+  return res.json();
+}
+
+export async function createStand(token: string, stand: { id: number; project_id: number; name: string; size: number; price: number }) {
+  const res = await fetch('/stands', {
+    method: 'POST',
+    headers: headers(token),
+    body: JSON.stringify(stand),
+  });
+  if (!res.ok) throw new Error('Failed to create stand');
+  return res.json();
+}
+
+export async function updateStand(token: string, id: number, stand: { project_id: number; name: string; size: number; price: number }) {
+  const res = await fetch(`/stands/${id}`, {
+    method: 'PUT',
+    headers: headers(token),
+    body: JSON.stringify(stand),
+  });
+  if (!res.ok) throw new Error('Failed to update stand');
+  return res.json();
+}
+
+export async function deleteStand(token: string, id: number) {
+  const res = await fetch(`/stands/${id}`, {
+    method: 'DELETE',
+    headers: headers(token),
+  });
+  if (!res.ok) throw new Error('Failed to delete stand');
+  return res.json();
+}
+
+export async function assignMandate(token: string, standId: number, agent: string) {
+  const res = await fetch(`/stands/${standId}/mandate`, {
+    method: 'POST',
+    headers: headers(token),
+    body: JSON.stringify({ agent }),
+  });
+  if (!res.ok) throw new Error('Failed to assign mandate');
+  return res.json();
+}

--- a/dashboard/src/auth.tsx
+++ b/dashboard/src/auth.tsx
@@ -1,0 +1,43 @@
+import React from 'react';
+import { Navigate } from 'react-router-dom';
+
+export interface Auth {
+  token: string;
+  role: string;
+}
+
+interface AuthContextType {
+  auth: Auth | null;
+  login: (token: string, role: string) => void;
+  logout: () => void;
+}
+
+const AuthContext = React.createContext<AuthContextType>({
+  auth: null,
+  login: () => {},
+  logout: () => {},
+});
+
+export const AuthProvider: React.FC<{ children: React.ReactNode }> = ({ children }) => {
+  const [auth, setAuth] = React.useState<Auth | null>(null);
+  const login = (token: string, role: string) => setAuth({ token, role });
+  const logout = () => setAuth(null);
+  return (
+    <AuthContext.Provider value={{ auth, login, logout }}>
+      {children}
+    </AuthContext.Provider>
+  );
+};
+
+export const useAuth = () => React.useContext(AuthContext);
+
+export const ProtectedRoute: React.FC<{ roles?: string[]; children: React.ReactElement }> = ({ roles, children }) => {
+  const { auth } = useAuth();
+  if (!auth) {
+    return <Navigate to="/login" replace />;
+  }
+  if (roles && !roles.includes(auth.role)) {
+    return <Navigate to="/login" replace />;
+  }
+  return children;
+};

--- a/dashboard/src/main.tsx
+++ b/dashboard/src/main.tsx
@@ -1,0 +1,15 @@
+import React from 'react';
+import ReactDOM from 'react-dom/client';
+import { BrowserRouter } from 'react-router-dom';
+import App from './App';
+import { AuthProvider } from './auth';
+
+ReactDOM.createRoot(document.getElementById('root') as HTMLElement).render(
+  <React.StrictMode>
+    <AuthProvider>
+      <BrowserRouter>
+        <App />
+      </BrowserRouter>
+    </AuthProvider>
+  </React.StrictMode>
+);

--- a/dashboard/src/pages/Login.tsx
+++ b/dashboard/src/pages/Login.tsx
@@ -1,0 +1,58 @@
+import React from 'react';
+import { useAuth } from '../auth';
+
+const Login: React.FC = () => {
+  const { login } = useAuth();
+  const [username, setUsername] = React.useState('');
+  const [password, setPassword] = React.useState('');
+  const [role, setRole] = React.useState('admin');
+  const [error, setError] = React.useState('');
+
+  const submit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    setError('');
+    try {
+      const res = await fetch('/login', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ username, password }),
+      });
+      if (!res.ok) throw new Error('Login failed');
+      const data = await res.json();
+      login(data.token, role);
+    } catch (err: any) {
+      setError(err.message);
+    }
+  };
+
+  return (
+    <div>
+      <h2>Login</h2>
+      <form onSubmit={submit}>
+        <input
+          placeholder="Username"
+          value={username}
+          onChange={e => setUsername(e.target.value)}
+          required
+        />
+        <input
+          type="password"
+          placeholder="Password"
+          value={password}
+          onChange={e => setPassword(e.target.value)}
+          required
+        />
+        <select value={role} onChange={e => setRole(e.target.value)}>
+          <option value="admin">Admin</option>
+          <option value="agent">Agent</option>
+          <option value="manager">Manager</option>
+          <option value="compliance">Compliance</option>
+        </select>
+        <button type="submit">Login</button>
+      </form>
+      {error && <p>{error}</p>}
+    </div>
+  );
+};
+
+export default Login;

--- a/dashboard/src/pages/Mandates.tsx
+++ b/dashboard/src/pages/Mandates.tsx
@@ -1,0 +1,73 @@
+import React from 'react';
+import { useAuth } from '../auth';
+import { getStands, assignMandate } from '../api';
+
+interface Stand {
+  id: number;
+  name: string;
+  mandate?: { agent: string; status: string };
+}
+
+const Mandates: React.FC = () => {
+  const { auth } = useAuth();
+  const [stands, setStands] = React.useState<Stand[]>([]);
+  const [search, setSearch] = React.useState('');
+  const [inputs, setInputs] = React.useState<Record<number, string>>({});
+
+  React.useEffect(() => {
+    if (auth) {
+      getStands(auth.token).then(setStands).catch(console.error);
+    }
+  }, [auth]);
+
+  const filtered = stands.filter(s => s.name.toLowerCase().includes(search.toLowerCase()));
+
+  const assign = async (standId: number) => {
+    if (!auth) return;
+    const agent = inputs[standId];
+    if (!agent) return;
+    try {
+      const stand = await assignMandate(auth.token, standId, agent);
+      setStands(stands.map(s => (s.id === standId ? stand : s)));
+      setInputs({ ...inputs, [standId]: '' });
+    } catch (err) {
+      console.error(err);
+    }
+  };
+
+  return (
+    <div>
+      <h2>Mandates</h2>
+      <input placeholder="Search" value={search} onChange={e => setSearch(e.target.value)} />
+      <table>
+        <thead>
+          <tr>
+            <th>ID</th>
+            <th>Name</th>
+            <th>Mandate</th>
+            <th>Assign</th>
+          </tr>
+        </thead>
+        <tbody>
+          {filtered.map(s => (
+            <tr key={s.id}>
+              <td>{s.id}</td>
+              <td>{s.name}</td>
+              <td>{s.mandate ? `${s.mandate.agent} (${s.mandate.status})` : '-'}</td>
+              <td>
+                <input
+                  placeholder="Agent"
+                  value={inputs[s.id] || ''}
+                  onChange={e => setInputs({ ...inputs, [s.id]: e.target.value })}
+                />
+                <button onClick={() => assign(s.id)} disabled={!inputs[s.id]}>Assign</button>
+              </td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+  );
+};
+
+export default Mandates;

--- a/dashboard/src/pages/Projects.tsx
+++ b/dashboard/src/pages/Projects.tsx
@@ -1,0 +1,79 @@
+import React from 'react';
+import { useAuth } from '../auth';
+import { getProjects, createProject } from '../api';
+
+interface Project {
+  id: number;
+  name: string;
+}
+
+const Projects: React.FC = () => {
+  const { auth } = useAuth();
+  const [projects, setProjects] = React.useState<Project[]>([]);
+  const [search, setSearch] = React.useState('');
+  const [form, setForm] = React.useState({ id: '', name: '' });
+
+  React.useEffect(() => {
+    if (auth) {
+      getProjects(auth.token).then(setProjects).catch(console.error);
+    }
+  }, [auth]);
+
+  const filtered = projects.filter(p => p.name.toLowerCase().includes(search.toLowerCase()));
+
+  const submit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    if (!form.id || !form.name || !auth) return;
+    try {
+      const project = await createProject(auth.token, { id: Number(form.id), name: form.name });
+      setProjects([...projects, project]);
+      setForm({ id: '', name: '' });
+    } catch (err) {
+      console.error(err);
+    }
+  };
+
+  return (
+    <div>
+      <h2>Projects</h2>
+      <form onSubmit={submit}>
+        <input
+          placeholder="ID"
+          value={form.id}
+          onChange={e => setForm({ ...form, id: e.target.value })}
+          required
+        />
+        <input
+          placeholder="Name"
+          value={form.name}
+          onChange={e => setForm({ ...form, name: e.target.value })}
+          required
+        />
+        <button type="submit">Add</button>
+      </form>
+      <input
+        placeholder="Search"
+        value={search}
+        onChange={e => setSearch(e.target.value)}
+      />
+      <table>
+        <thead>
+          <tr>
+            <th>ID</th>
+            <th>Name</th>
+          </tr>
+        </thead>
+        <tbody>
+          {filtered.map(p => (
+            <tr key={p.id}>
+              <td>{p.id}</td>
+              <td>{p.name}</td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+  );
+};
+
+export default Projects;

--- a/dashboard/src/pages/Stands.tsx
+++ b/dashboard/src/pages/Stands.tsx
@@ -1,0 +1,98 @@
+import React from 'react';
+import { useAuth } from '../auth';
+import { getStands, createStand, deleteStand } from '../api';
+
+interface Stand {
+  id: number;
+  project_id: number;
+  name: string;
+  size: number;
+  price: number;
+}
+
+const Stands: React.FC = () => {
+  const { auth } = useAuth();
+  const [stands, setStands] = React.useState<Stand[]>([]);
+  const [search, setSearch] = React.useState('');
+  const [form, setForm] = React.useState({ id: '', project_id: '', name: '', size: '', price: '' });
+
+  React.useEffect(() => {
+    if (auth) {
+      getStands(auth.token).then(setStands).catch(console.error);
+    }
+  }, [auth]);
+
+  const filtered = stands.filter(s => s.name.toLowerCase().includes(search.toLowerCase()));
+
+  const submit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    if (!auth) return;
+    const payload = {
+      id: Number(form.id),
+      project_id: Number(form.project_id),
+      name: form.name,
+      size: Number(form.size),
+      price: Number(form.price),
+    };
+    try {
+      const stand = await createStand(auth.token, payload);
+      setStands([...stands, stand]);
+      setForm({ id: '', project_id: '', name: '', size: '', price: '' });
+    } catch (err) {
+      console.error(err);
+    }
+  };
+
+  const remove = async (id: number) => {
+    if (!auth) return;
+    try {
+      await deleteStand(auth.token, id);
+      setStands(stands.filter(s => s.id !== id));
+    } catch (err) {
+      console.error(err);
+    }
+  };
+
+  return (
+    <div>
+      <h2>Stands</h2>
+      <form onSubmit={submit}>
+        <input placeholder="ID" value={form.id} onChange={e => setForm({ ...form, id: e.target.value })} required />
+        <input placeholder="Project ID" value={form.project_id} onChange={e => setForm({ ...form, project_id: e.target.value })} required />
+        <input placeholder="Name" value={form.name} onChange={e => setForm({ ...form, name: e.target.value })} required />
+        <input placeholder="Size" value={form.size} onChange={e => setForm({ ...form, size: e.target.value })} required />
+        <input placeholder="Price" value={form.price} onChange={e => setForm({ ...form, price: e.target.value })} required />
+        <button type="submit">Add</button>
+      </form>
+      <input placeholder="Search" value={search} onChange={e => setSearch(e.target.value)} />
+      <table>
+        <thead>
+          <tr>
+            <th>ID</th>
+            <th>Name</th>
+            <th>Project</th>
+            <th>Size</th>
+            <th>Price</th>
+            <th></th>
+          </tr>
+        </thead>
+        <tbody>
+          {filtered.map(s => (
+            <tr key={s.id}>
+              <td>{s.id}</td>
+              <td>{s.name}</td>
+              <td>{s.project_id}</td>
+              <td>{s.size}</td>
+              <td>{s.price}</td>
+              <td>
+                <button onClick={() => remove(s.id)}>Delete</button>
+              </td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+  );
+};
+
+export default Stands;

--- a/dashboard/tsconfig.json
+++ b/dashboard/tsconfig.json
@@ -1,0 +1,14 @@
+{
+  "compilerOptions": {
+    "target": "ESNext",
+    "useDefineForClassFields": true,
+    "module": "ESNext",
+    "moduleResolution": "Node",
+    "strict": true,
+    "jsx": "react-jsx",
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true
+  },
+  "include": ["src"]
+}

--- a/dashboard/vite.config.ts
+++ b/dashboard/vite.config.ts
@@ -1,0 +1,16 @@
+import { defineConfig } from 'vite';
+import react from '@vitejs/plugin-react';
+
+export default defineConfig({
+  plugins: [react()],
+  server: {
+    port: 5173,
+    proxy: {
+      '/': {
+        target: 'http://localhost:8000',
+        changeOrigin: true,
+        secure: false
+      }
+    }
+  }
+});


### PR DESCRIPTION
## Summary
- add React + TypeScript dashboard with role-based routing for projects, stands and mandate assignments
- document dashboard usage in README
## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68c725cddd24832cada72a29549b4689