### PR TITLE
Add agent dashboard and submission flows

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -129,7 +129,7 @@ def login(data: LoginRequest, repos: Repositories = Depends(get_repositories)):
         raise HTTPException(status_code=401, detail="Invalid username or password")
     token = secrets.token_hex(16)
     repos.tokens.set(hash_token(token), agent.username)
-    return {"token": token}
+    return {"token": token, "role": agent.role, "username": agent.username}
 
 
 @app.post("/projects", response_model=Project)

--- a/app/models.py
+++ b/app/models.py
@@ -1,5 +1,6 @@
 from enum import Enum
 from typing import List, Optional
+from datetime import datetime
 
 from pydantic import BaseModel, Field
 
@@ -27,6 +28,8 @@ class Mandate(BaseModel):
     agent: str
     document: Optional[str] = None
     status: MandateStatus = MandateStatus.PENDING
+    agreement_status: Optional[str] = None
+    expiration_date: Optional[datetime] = None
 
 
 class Stand(BaseModel):

--- a/dashboard/src/App.tsx
+++ b/dashboard/src/App.tsx
@@ -4,6 +4,7 @@ import Login from './pages/Login';
 import Projects from './pages/Projects';
 import Stands from './pages/Stands';
 import Mandates from './pages/Mandates';
+import Dashboard from './pages/Dashboard';
 import { ProtectedRoute, useAuth } from './auth';
 
 const App: React.FC = () => {
@@ -12,9 +13,18 @@ const App: React.FC = () => {
     <div>
       {auth && (
         <nav>
-          <Link to="/projects">Projects</Link> |{' '}
-          <Link to="/stands">Stands</Link> |{' '}
-          <Link to="/mandates">Mandates</Link> |{' '}
+          {auth.role === 'admin' && (
+            <>
+              <Link to="/projects">Projects</Link> |{' '}
+              <Link to="/stands">Stands</Link> |{' '}
+              <Link to="/mandates">Mandates</Link> |{' '}
+            </>
+          )}
+          {auth.role === 'agent' && (
+            <>
+              <Link to="/dashboard">Dashboard</Link> |{' '}
+            </>
+          )}
           <button onClick={logout}>Logout</button>
         </nav>
       )}
@@ -44,7 +54,29 @@ const App: React.FC = () => {
             </ProtectedRoute>
           }
         />
-        <Route path="*" element={<Navigate to={auth ? '/projects' : '/login'} replace />} />
+        <Route
+          path="/dashboard"
+          element={
+            <ProtectedRoute roles={["agent"]}>
+              <Dashboard />
+            </ProtectedRoute>
+          }
+        />
+        <Route
+          path="*"
+          element={
+            <Navigate
+              to={
+                auth
+                  ? auth.role === 'agent'
+                    ? '/dashboard'
+                    : '/projects'
+                  : '/login'
+              }
+              replace
+            />
+          }
+        />
       </Routes>
     </div>
   );

--- a/dashboard/src/api.ts
+++ b/dashboard/src/api.ts
@@ -63,3 +63,42 @@ export async function assignMandate(token: string, standId: number, agent: strin
   if (!res.ok) throw new Error('Failed to assign mandate');
   return res.json();
 }
+
+export async function submitOffer(
+  token: string,
+  offer: { id: number; realtor: string; property_id: number; details?: string }
+) {
+  const res = await fetch('/offers', {
+    method: 'POST',
+    headers: headers(token),
+    body: JSON.stringify(offer),
+  });
+  if (!res.ok) throw new Error('Failed to submit offer');
+  return res.json();
+}
+
+export async function submitAccountOpening(
+  token: string,
+  req: { id: number; realtor: string; details?: string }
+) {
+  const res = await fetch('/account-openings', {
+    method: 'POST',
+    headers: headers(token),
+    body: JSON.stringify(req),
+  });
+  if (!res.ok) throw new Error('Failed to submit account opening');
+  return res.json();
+}
+
+export async function submitPropertyApplication(
+  token: string,
+  app: { id: number; realtor: string; property_id: number; details?: string }
+) {
+  const res = await fetch('/property-applications', {
+    method: 'POST',
+    headers: headers(token),
+    body: JSON.stringify(app),
+  });
+  if (!res.ok) throw new Error('Failed to submit property application');
+  return res.json();
+}

--- a/dashboard/src/auth.tsx
+++ b/dashboard/src/auth.tsx
@@ -4,11 +4,12 @@ import { Navigate } from 'react-router-dom';
 export interface Auth {
   token: string;
   role: string;
+  username: string;
 }
 
 interface AuthContextType {
   auth: Auth | null;
-  login: (token: string, role: string) => void;
+  login: (token: string, role: string, username: string) => void;
   logout: () => void;
 }
 
@@ -20,7 +21,8 @@ const AuthContext = React.createContext<AuthContextType>({
 
 export const AuthProvider: React.FC<{ children: React.ReactNode }> = ({ children }) => {
   const [auth, setAuth] = React.useState<Auth | null>(null);
-  const login = (token: string, role: string) => setAuth({ token, role });
+  const login = (token: string, role: string, username: string) =>
+    setAuth({ token, role, username });
   const logout = () => setAuth(null);
   return (
     <AuthContext.Provider value={{ auth, login, logout }}>

--- a/dashboard/src/pages/Dashboard.tsx
+++ b/dashboard/src/pages/Dashboard.tsx
@@ -1,0 +1,174 @@
+import React from 'react';
+import { useAuth } from '../auth';
+import {
+  getStands,
+  submitOffer,
+  submitAccountOpening,
+  submitPropertyApplication,
+} from '../api';
+
+interface MandateInfo {
+  agreement_status?: string;
+  expiration_date?: string;
+}
+
+interface Stand {
+  id: number;
+  project_id: number;
+  name: string;
+  size: number;
+  price: number;
+  status: string;
+  mandate?: MandateInfo;
+}
+
+const Dashboard: React.FC = () => {
+  const { auth } = useAuth();
+  const [stands, setStands] = React.useState<Stand[]>([]);
+  const [project, setProject] = React.useState('');
+  const [price, setPrice] = React.useState('');
+  const [status, setStatus] = React.useState('');
+
+  React.useEffect(() => {
+    if (auth) {
+      getStands(auth.token).then(setStands).catch(console.error);
+    }
+  }, [auth]);
+
+  const filtered = stands.filter(s =>
+    (!project || s.project_id === Number(project)) &&
+    (!price || s.price <= Number(price)) &&
+    (!status || s.status === status)
+  );
+
+  const UploadForm: React.FC<{
+    label: string;
+    onSubmit: (details: string) => Promise<void>;
+  }> = ({ label, onSubmit }) => {
+    const [details, setDetails] = React.useState('');
+    const [progress, setProgress] = React.useState(0);
+
+    const submit = async (e: React.FormEvent) => {
+      e.preventDefault();
+      setProgress(0);
+      const interval = setInterval(
+        () => setProgress(p => Math.min(p + 10, 90)),
+        200
+      );
+      try {
+        await onSubmit(details);
+      } finally {
+        clearInterval(interval);
+        setProgress(100);
+        setTimeout(() => setProgress(0), 500);
+      }
+    };
+
+    return (
+      <form onSubmit={submit}>
+        <input
+          placeholder="Details"
+          value={details}
+          onChange={e => setDetails(e.target.value)}
+          required
+        />
+        <button type="submit">{label}</button>
+        {progress > 0 && <progress value={progress} max={100} />}
+      </form>
+    );
+  };
+
+  if (!auth) return null;
+
+  return (
+    <div>
+      <h2>Dashboard</h2>
+      <div>
+        <input
+          placeholder="Project ID"
+          value={project}
+          onChange={e => setProject(e.target.value)}
+        />
+        <input
+          placeholder="Max Price"
+          value={price}
+          onChange={e => setPrice(e.target.value)}
+        />
+        <select value={status} onChange={e => setStatus(e.target.value)}>
+          <option value="">All</option>
+          <option value="available">Available</option>
+          <option value="reserved">Reserved</option>
+          <option value="sold">Sold</option>
+        </select>
+      </div>
+      <table>
+        <thead>
+          <tr>
+            <th>ID</th>
+            <th>Project</th>
+            <th>Name</th>
+            <th>Price</th>
+            <th>Status</th>
+            <th>Agreement Status</th>
+            <th>Expires</th>
+            <th>Actions</th>
+          </tr>
+        </thead>
+        <tbody>
+          {filtered.map(s => (
+            <tr key={s.id}>
+              <td>{s.id}</td>
+              <td>{s.project_id}</td>
+              <td>{s.name}</td>
+              <td>{s.price}</td>
+              <td>{s.status}</td>
+              <td>{s.mandate?.agreement_status || 'N/A'}</td>
+              <td>
+                {s.mandate?.expiration_date
+                  ? new Date(s.mandate.expiration_date).toLocaleDateString()
+                  : 'N/A'}
+              </td>
+              <td>
+                <UploadForm
+                  label="Offer"
+                  onSubmit={details =>
+                    submitOffer(auth.token, {
+                      id: Date.now(),
+                      realtor: auth.username,
+                      property_id: s.id,
+                      details,
+                    })
+                  }
+                />
+                <UploadForm
+                  label="Account Opening"
+                  onSubmit={details =>
+                    submitAccountOpening(auth.token, {
+                      id: Date.now(),
+                      realtor: auth.username,
+                      details,
+                    })
+                  }
+                />
+                <UploadForm
+                  label="Property Application"
+                  onSubmit={details =>
+                    submitPropertyApplication(auth.token, {
+                      id: Date.now(),
+                      realtor: auth.username,
+                      property_id: s.id,
+                      details,
+                    })
+                  }
+                />
+              </td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+  );
+};
+
+export default Dashboard;
+

--- a/dashboard/src/pages/Login.tsx
+++ b/dashboard/src/pages/Login.tsx
@@ -1,11 +1,12 @@
 import React from 'react';
 import { useAuth } from '../auth';
+import { useNavigate } from 'react-router-dom';
 
 const Login: React.FC = () => {
   const { login } = useAuth();
+  const navigate = useNavigate();
   const [username, setUsername] = React.useState('');
   const [password, setPassword] = React.useState('');
-  const [role, setRole] = React.useState('admin');
   const [error, setError] = React.useState('');
 
   const submit = async (e: React.FormEvent) => {
@@ -19,7 +20,12 @@ const Login: React.FC = () => {
       });
       if (!res.ok) throw new Error('Login failed');
       const data = await res.json();
-      login(data.token, role);
+      login(data.token, data.role, data.username);
+      if (data.role === 'agent') {
+        navigate('/dashboard');
+      } else {
+        navigate('/projects');
+      }
     } catch (err: any) {
       setError(err.message);
     }
@@ -42,12 +48,6 @@ const Login: React.FC = () => {
           onChange={e => setPassword(e.target.value)}
           required
         />
-        <select value={role} onChange={e => setRole(e.target.value)}>
-          <option value="admin">Admin</option>
-          <option value="agent">Agent</option>
-          <option value="manager">Manager</option>
-          <option value="compliance">Compliance</option>
-        </select>
         <button type="submit">Login</button>
       </form>
       {error && <p>{error}</p>}


### PR DESCRIPTION
## Summary
- Return agent role and username from `/login`
- Extend mandates with agreement status and expiration date
- Add agent dashboard with filtering, upload forms, and progress indicators

## Testing
- `pytest -q`
- `npm --prefix dashboard test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_68c7271b3c74832c919ad44c4513c8d7