### PR TITLE
Add multi-step submission form with file uploads

### DIFF
--- a/dashboard/src/App.tsx
+++ b/dashboard/src/App.tsx
@@ -5,6 +5,7 @@ import Projects from './pages/Projects';
 import Stands from './pages/Stands';
 import Mandates from './pages/Mandates';
 import Dashboard from './pages/Dashboard';
+import MultiStepForm from './pages/MultiStepForm';
 import { ProtectedRoute, useAuth } from './auth';
 
 const App: React.FC = () => {
@@ -23,6 +24,7 @@ const App: React.FC = () => {
           {auth.role === 'agent' && (
             <>
               <Link to="/dashboard">Dashboard</Link> |{' '}
+              <Link to="/submit">New Submission</Link> |{' '}
             </>
           )}
           <button onClick={logout}>Logout</button>
@@ -59,6 +61,14 @@ const App: React.FC = () => {
           element={
             <ProtectedRoute roles={["agent"]}>
               <Dashboard />
+            </ProtectedRoute>
+          }
+        />
+        <Route
+          path="/submit"
+          element={
+            <ProtectedRoute roles={["agent"]}>
+              <MultiStepForm />
             </ProtectedRoute>
           }
         />

--- a/dashboard/src/api.ts
+++ b/dashboard/src/api.ts
@@ -66,39 +66,68 @@ export async function assignMandate(token: string, standId: number, agent: strin
 
 export async function submitOffer(
   token: string,
-  offer: { id: number; realtor: string; property_id: number; details?: string }
+  offer: { id: number; realtor: string; property_id: number; details?: string; file?: File }
 ) {
-  const res = await fetch('/offers', {
-    method: 'POST',
-    headers: headers(token),
-    body: JSON.stringify(offer),
-  });
+  const opts: RequestInit = { method: 'POST' };
+  if (offer.file) {
+    const form = new FormData();
+    form.append('id', String(offer.id));
+    form.append('realtor', offer.realtor);
+    form.append('property_id', String(offer.property_id));
+    if (offer.details) form.append('details', offer.details);
+    form.append('file', offer.file);
+    opts.body = form;
+    opts.headers = { 'X-Token': token };
+  } else {
+    opts.body = JSON.stringify(offer);
+    opts.headers = headers(token);
+  }
+  const res = await fetch('/offers', opts);
   if (!res.ok) throw new Error('Failed to submit offer');
   return res.json();
 }
 
 export async function submitAccountOpening(
   token: string,
-  req: { id: number; realtor: string; details?: string }
+  req: { id: number; realtor: string; details?: string; file?: File }
 ) {
-  const res = await fetch('/account-openings', {
-    method: 'POST',
-    headers: headers(token),
-    body: JSON.stringify(req),
-  });
+  const opts: RequestInit = { method: 'POST' };
+  if (req.file) {
+    const form = new FormData();
+    form.append('id', String(req.id));
+    form.append('realtor', req.realtor);
+    if (req.details) form.append('details', req.details);
+    form.append('file', req.file);
+    opts.body = form;
+    opts.headers = { 'X-Token': token };
+  } else {
+    opts.body = JSON.stringify(req);
+    opts.headers = headers(token);
+  }
+  const res = await fetch('/account-openings', opts);
   if (!res.ok) throw new Error('Failed to submit account opening');
   return res.json();
 }
 
 export async function submitPropertyApplication(
   token: string,
-  app: { id: number; realtor: string; property_id: number; details?: string }
+  app: { id: number; realtor: string; property_id: number; details?: string; file?: File }
 ) {
-  const res = await fetch('/property-applications', {
-    method: 'POST',
-    headers: headers(token),
-    body: JSON.stringify(app),
-  });
+  const opts: RequestInit = { method: 'POST' };
+  if (app.file) {
+    const form = new FormData();
+    form.append('id', String(app.id));
+    form.append('realtor', app.realtor);
+    form.append('property_id', String(app.property_id));
+    if (app.details) form.append('details', app.details);
+    form.append('file', app.file);
+    opts.body = form;
+    opts.headers = { 'X-Token': token };
+  } else {
+    opts.body = JSON.stringify(app);
+    opts.headers = headers(token);
+  }
+  const res = await fetch('/property-applications', opts);
   if (!res.ok) throw new Error('Failed to submit property application');
   return res.json();
 }

--- a/dashboard/src/pages/MultiStepForm.tsx
+++ b/dashboard/src/pages/MultiStepForm.tsx
@@ -1,0 +1,163 @@
+import React from 'react';
+import { useAuth } from '../auth';
+import { submitOffer, submitPropertyApplication, submitAccountOpening } from '../api';
+
+interface FileData {
+  file?: File;
+  details: string;
+  propertyId?: string;
+}
+
+const MultiStepForm: React.FC = () => {
+  const { auth } = useAuth();
+  const [step, setStep] = React.useState(1);
+  const [offer, setOffer] = React.useState<FileData>({ details: '', propertyId: '' });
+  const [application, setApplication] = React.useState<FileData>({ details: '', propertyId: '' });
+  const [account, setAccount] = React.useState<FileData>({ details: '' });
+  const [error, setError] = React.useState<string | null>(null);
+  const [success, setSuccess] = React.useState<string | null>(null);
+
+  if (!auth) return null;
+
+  const validateFile = (f?: File) => {
+    if (!f) return 'File is required';
+    const ext = f.name.split('.').pop()?.toLowerCase();
+    return ext === 'pdf' || ext === 'csv' ? null : 'File must be PDF or CSV';
+  };
+
+  const next = () => {
+    setError(null);
+    setSuccess(null);
+    setStep(s => s + 1);
+  };
+
+  const submitOfferStep = async (e: React.FormEvent) => {
+    e.preventDefault();
+    if (!offer.propertyId) return setError('Property ID is required');
+    if (!offer.details) return setError('Details are required');
+    const fileErr = validateFile(offer.file);
+    if (fileErr) return setError(fileErr);
+    try {
+      await submitOffer(auth.token, {
+        id: Date.now(),
+        realtor: auth.username,
+        property_id: Number(offer.propertyId),
+        details: offer.details,
+        file: offer.file,
+      });
+      setSuccess('Offer submitted successfully');
+      next();
+    } catch (err: any) {
+      setError(err.message);
+    }
+  };
+
+  const submitApplicationStep = async (e: React.FormEvent) => {
+    e.preventDefault();
+    if (!application.propertyId) return setError('Property ID is required');
+    if (!application.details) return setError('Details are required');
+    const fileErr = validateFile(application.file);
+    if (fileErr) return setError(fileErr);
+    try {
+      await submitPropertyApplication(auth.token, {
+        id: Date.now(),
+        realtor: auth.username,
+        property_id: Number(application.propertyId),
+        details: application.details,
+        file: application.file,
+      });
+      setSuccess('Property application submitted');
+      next();
+    } catch (err: any) {
+      setError(err.message);
+    }
+  };
+
+  const submitAccountStep = async (e: React.FormEvent) => {
+    e.preventDefault();
+    if (!account.details) return setError('Details are required');
+    const fileErr = validateFile(account.file);
+    if (fileErr) return setError(fileErr);
+    try {
+      await submitAccountOpening(auth.token, {
+        id: Date.now(),
+        realtor: auth.username,
+        details: account.details,
+        file: account.file,
+      });
+      setSuccess('Account opening submitted');
+      next();
+    } catch (err: any) {
+      setError(err.message);
+    }
+  };
+
+  return (
+    <div>
+      <h2>New Submission</h2>
+      {error && <p style={{ color: 'red' }}>{error}</p>}
+      {success && <p style={{ color: 'green' }}>{success}</p>}
+      {step === 1 && (
+        <form onSubmit={submitOfferStep}>
+          <h3>Offer Details</h3>
+          <input
+            placeholder="Property ID"
+            value={offer.propertyId}
+            onChange={e => setOffer({ ...offer, propertyId: e.target.value })}
+          />
+          <textarea
+            placeholder="Details"
+            value={offer.details}
+            onChange={e => setOffer({ ...offer, details: e.target.value })}
+          />
+          <input
+            type="file"
+            accept=".pdf,.csv"
+            onChange={e => setOffer({ ...offer, file: e.target.files?.[0] })}
+          />
+          <button type="submit">Next</button>
+        </form>
+      )}
+      {step === 2 && (
+        <form onSubmit={submitApplicationStep}>
+          <h3>Property Application</h3>
+          <input
+            placeholder="Property ID"
+            value={application.propertyId}
+            onChange={e => setApplication({ ...application, propertyId: e.target.value })}
+          />
+          <textarea
+            placeholder="Details"
+            value={application.details}
+            onChange={e => setApplication({ ...application, details: e.target.value })}
+          />
+          <input
+            type="file"
+            accept=".pdf,.csv"
+            onChange={e => setApplication({ ...application, file: e.target.files?.[0] })}
+          />
+          <button type="submit">Next</button>
+        </form>
+      )}
+      {step === 3 && (
+        <form onSubmit={submitAccountStep}>
+          <h3>Account Opening</h3>
+          <textarea
+            placeholder="Details"
+            value={account.details}
+            onChange={e => setAccount({ ...account, details: e.target.value })}
+          />
+          <input
+            type="file"
+            accept=".pdf,.csv"
+            onChange={e => setAccount({ ...account, file: e.target.files?.[0] })}
+          />
+          <button type="submit">Submit</button>
+        </form>
+      )}
+      {step > 3 && <p>All steps completed.</p>}
+    </div>
+  );
+};
+
+export default MultiStepForm;


### PR DESCRIPTION
## Summary
- add agent-only multi-step form for offers, property applications, and account openings
- support optional PDF/CSV uploads and client-side validation
- extend API helpers to submit multipart form data

## Testing
- `npm install` *(fails: No matching version found for @types/react-router-dom@^6.20.9)*
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68c7289472dc832cb6477a9c86dd3e6e