### PR TITLE
Add account opening queue and deposit tracking in admin dashboard

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -459,6 +459,18 @@ def submit_account_opening(
     return request
 
 
+@app.get("/account-openings", response_model=List[AccountOpening])
+def list_account_openings(
+    status: Optional[SubmissionStatus] = None,
+    _: Agent = Depends(require_admin),
+    repos: Repositories = Depends(get_repositories),
+):
+    openings = repos.account_openings.list()
+    if status:
+        openings = [o for o in openings if o.status == status]
+    return openings
+
+
 @app.get("/account-openings/{req_id}", response_model=AccountOpening)
 def get_account_opening(
     req_id: int,

--- a/dashboard/src/App.tsx
+++ b/dashboard/src/App.tsx
@@ -6,6 +6,8 @@ import Stands from './pages/Stands';
 import Mandates from './pages/Mandates';
 import Dashboard from './pages/Dashboard';
 import MultiStepForm from './pages/MultiStepForm';
+import AccountOpenings from './pages/AccountOpenings';
+import AccountOpeningDetail from './pages/AccountOpeningDetail';
 import { ProtectedRoute, useAuth } from './auth';
 
 const App: React.FC = () => {
@@ -19,6 +21,7 @@ const App: React.FC = () => {
               <Link to="/projects">Projects</Link> |{' '}
               <Link to="/stands">Stands</Link> |{' '}
               <Link to="/mandates">Mandates</Link> |{' '}
+              <Link to="/account-openings">Account Openings</Link> |{' '}
             </>
           )}
           {auth.role === 'agent' && (
@@ -53,6 +56,22 @@ const App: React.FC = () => {
           element={
             <ProtectedRoute roles={["admin"]}>
               <Mandates />
+            </ProtectedRoute>
+          }
+        />
+        <Route
+          path="/account-openings"
+          element={
+            <ProtectedRoute roles={["admin"]}>
+              <AccountOpenings />
+            </ProtectedRoute>
+          }
+        />
+        <Route
+          path="/account-openings/:id"
+          element={
+            <ProtectedRoute roles={["admin"]}>
+              <AccountOpeningDetail />
             </ProtectedRoute>
           }
         />

--- a/dashboard/src/api.ts
+++ b/dashboard/src/api.ts
@@ -131,3 +131,40 @@ export async function submitPropertyApplication(
   if (!res.ok) throw new Error('Failed to submit property application');
   return res.json();
 }
+
+export async function getAccountOpenings(token: string, status?: string) {
+  const url = status ? `/account-openings?status=${status}` : '/account-openings';
+  const res = await fetch(url, { headers: headers(token) });
+  if (!res.ok) throw new Error('Failed to load account openings');
+  return res.json();
+}
+
+export async function getAccountOpening(token: string, id: number) {
+  const res = await fetch(`/account-openings/${id}`, { headers: headers(token) });
+  if (!res.ok) throw new Error('Failed to load account opening');
+  return res.json();
+}
+
+export async function openAccount(
+  token: string,
+  id: number,
+  data: { account_number: string; deposit_threshold: number }
+) {
+  const res = await fetch(`/account-openings/${id}/open`, {
+    method: 'PUT',
+    headers: headers(token),
+    body: JSON.stringify(data),
+  });
+  if (!res.ok) throw new Error('Failed to open account');
+  return res.json();
+}
+
+export async function recordDeposit(token: string, id: number, amount: number) {
+  const res = await fetch(`/account-openings/${id}/deposit`, {
+    method: 'POST',
+    headers: headers(token),
+    body: JSON.stringify({ amount }),
+  });
+  if (!res.ok) throw new Error('Failed to record deposit');
+  return res.json();
+}

--- a/dashboard/src/pages/AccountOpeningDetail.tsx
+++ b/dashboard/src/pages/AccountOpeningDetail.tsx
@@ -1,0 +1,128 @@
+import React from 'react';
+import { useParams } from 'react-router-dom';
+import { useAuth } from '../auth';
+import {
+  getAccountOpening,
+  openAccount,
+  recordDeposit,
+} from '../api';
+
+interface AccountOpening {
+  id: number;
+  realtor: string;
+  status: string;
+  account_number?: string;
+  deposit_threshold?: number;
+  deposits: number[];
+}
+
+const AccountOpeningDetail: React.FC = () => {
+  const { id } = useParams();
+  const { auth } = useAuth();
+  const [opening, setOpening] = React.useState<AccountOpening | null>(null);
+  const [accountNumber, setAccountNumber] = React.useState('');
+  const [threshold, setThreshold] = React.useState('');
+  const [deposit, setDeposit] = React.useState('');
+  const [error, setError] = React.useState('');
+
+  const load = () => {
+    if (auth && id) {
+      getAccountOpening(auth.token, Number(id))
+        .then(setOpening)
+        .catch(() => setError('Failed to load request'));
+    }
+  };
+
+  React.useEffect(load, [auth, id]);
+
+  const totalDeposits = opening?.deposits.reduce((s, d) => s + d, 0) || 0;
+
+  const handleOpen = async () => {
+    if (!auth || !id) return;
+    try {
+      const req = await openAccount(auth.token, Number(id), {
+        account_number: accountNumber,
+        deposit_threshold: Number(threshold),
+      });
+      setOpening(req);
+      setAccountNumber('');
+      setThreshold('');
+    } catch {
+      setError('Failed to open account');
+    }
+  };
+
+  const handleDeposit = async () => {
+    if (!auth || !id) return;
+    try {
+      const req = await recordDeposit(auth.token, Number(id), Number(deposit));
+      setOpening(req);
+      setDeposit('');
+    } catch {
+      setError('Failed to record deposit');
+    }
+  };
+
+  if (!opening) return <div>{error || 'Loading...'}</div>;
+
+  return (
+    <div>
+      <h2>Account Opening {opening.id}</h2>
+      <p>Realtor: {opening.realtor}</p>
+      <p>Status: {opening.status}</p>
+
+      {!opening.account_number && (
+        <div>
+          <h3>Open Account</h3>
+          <input
+            placeholder="Account Number"
+            value={accountNumber}
+            onChange={e => setAccountNumber(e.target.value)}
+          />
+          <input
+            placeholder="Deposit Threshold"
+            type="number"
+            value={threshold}
+            onChange={e => setThreshold(e.target.value)}
+          />
+          <button
+            onClick={handleOpen}
+            disabled={!accountNumber || !threshold}
+          >
+            Save
+          </button>
+        </div>
+      )}
+
+      {opening.account_number && (
+        <div>
+          <h3>Deposit Tracking</h3>
+          <p>Account: {opening.account_number}</p>
+          <p>
+            Received {totalDeposits} / {opening.deposit_threshold}
+          </p>
+          {opening.status !== 'completed' && (
+            <div>
+              <input
+                placeholder="Deposit Amount"
+                type="number"
+                value={deposit}
+                onChange={e => setDeposit(e.target.value)}
+              />
+              <button
+                onClick={handleDeposit}
+                disabled={!deposit}
+              >
+                Record
+              </button>
+            </div>
+          )}
+        </div>
+      )}
+      {error && <p>{error}</p>}
+    </div>
+  );
+};
+
+export default AccountOpeningDetail;
+

--- a/dashboard/src/pages/AccountOpenings.tsx
+++ b/dashboard/src/pages/AccountOpenings.tsx
@@ -1,0 +1,43 @@
+import React from 'react';
+import { Link } from 'react-router-dom';
+import { useAuth } from '../auth';
+import { getAccountOpenings } from '../api';
+
+interface AccountOpening {
+  id: number;
+  realtor: string;
+  status: string;
+}
+
+const AccountOpenings: React.FC = () => {
+  const { auth } = useAuth();
+  const [requests, setRequests] = React.useState<AccountOpening[]>([]);
+  const [error, setError] = React.useState('');
+
+  React.useEffect(() => {
+    if (auth) {
+      getAccountOpenings(auth.token, 'submitted')
+        .then(setRequests)
+        .catch(() => setError('Failed to load requests'));
+    }
+  }, [auth]);
+
+  return (
+    <div>
+      <h2>Account Opening Queue</h2>
+      {error && <p>{error}</p>}
+      {requests.length === 0 && <p>No pending requests.</p>}
+      <ul>
+        {requests.map(r => (
+          <li key={r.id}>
+            #{r.id} - {r.realtor} - {r.status}{' '}
+            <Link to={`/account-openings/${r.id}`}>Details</Link>
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+};
+
+export default AccountOpenings;
+

--- a/tests/test_submissions.py
+++ b/tests/test_submissions.py
@@ -192,3 +192,40 @@ def test_loan_application_flow():
     assert resp.json()["status"] == SubmissionStatus.REJECTED.value
     assert resp.json()["decision"] == "rejected"
     assert resp.json()["reason"] == "Insufficient credit"
+
+
+def test_account_opening_queue_listing():
+    tokens = setup_agents()
+    admin_headers = {"X-Token": tokens["admin"]}
+    realtor_headers = {"X-Token": tokens["realtor"]}
+
+    client.post(
+        "/account-openings",
+        json={"id": 10, "realtor": "realtor"},
+        headers=realtor_headers,
+    )
+    client.post(
+        "/account-openings",
+        json={"id": 20, "realtor": "realtor"},
+        headers=realtor_headers,
+    )
+    client.put(
+        "/account-openings/10/open",
+        json={"account_number": "ACC10", "deposit_threshold": 100},
+        headers=admin_headers,
+    )
+
+    resp = client.get(
+        "/account-openings",
+        params={"status": SubmissionStatus.SUBMITTED.value},
+        headers=admin_headers,
+    )
+    assert resp.status_code == 200
+    data = resp.json()
+    assert len(data) == 1
+    assert data[0]["id"] == 20
+
+    resp = client.get("/account-openings", headers=admin_headers)
+    assert resp.status_code == 200
+    ids = {r["id"] for r in resp.json()}
+    assert ids == {10, 20}


### PR DESCRIPTION
## Summary
- expose endpoint to list account-opening requests with optional status filter
- add admin queue and detail pages to open accounts and track deposits
- record deposits against required threshold via new API helpers

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68c72b081ee0832c807e0cae9b963a61