### PR TITLE
Implement loan application review workflow

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -556,6 +556,8 @@ def submit_loan_application(
         )
     if not application.documents:
         raise HTTPException(status_code=400, detail="Documentation required")
+    if application.property_id and not repos.stands.get(application.property_id):
+        raise HTTPException(status_code=404, detail="Property not found")
     repos.loan_applications.add(application)
     repos.notifications.append(
         f"Loan application {application.id} submitted by {application.realtor}"
@@ -576,6 +578,18 @@ def get_loan_application(
     return application
 
 
+@app.get("/loan-applications", response_model=List[LoanApplication])
+def list_loan_applications(
+    status: Optional[SubmissionStatus] = None,
+    _: Agent = Depends(require_admin),
+    repos: Repositories = Depends(get_repositories),
+):
+    apps = repos.loan_applications.list()
+    if status:
+        apps = [a for a in apps if a.status == status]
+    return apps
+
+
 @app.put("/loan-applications/{app_id}/decision", response_model=LoanApplication)
 def decide_loan_application(
     app_id: int,
@@ -590,6 +604,23 @@ def decide_loan_application(
     application.reason = decision.reason
     if decision.decision == LoanDecision.APPROVED:
         application.status = SubmissionStatus.COMPLETED
+        if application.property_id:
+            if repos.agreements.get(application.id):
+                raise HTTPException(status_code=400, detail="Agreement ID exists")
+            stand = repos.stands.get(application.property_id)
+            if stand:
+                content = f"Agreement for property {stand.name} with loan {application.id}"
+                timestamp = datetime.utcnow().isoformat()
+                agreement = Agreement(
+                    id=application.id,
+                    loan_application_id=application.id,
+                    property_id=application.property_id,
+                    realtor=application.realtor,
+                    document=content,
+                    versions=[content],
+                    audit_log=[f"{timestamp}: generated"],
+                )
+                repos.agreements.add(agreement)
     else:
         application.status = SubmissionStatus.REJECTED
     repos.loan_applications.add(application)

--- a/app/models.py
+++ b/app/models.py
@@ -104,6 +104,7 @@ class LoanApplication(BaseModel):
     id: int
     realtor: str
     account_id: int
+    property_id: Optional[int] = None
     documents: List[str] = Field(default_factory=list)
     status: SubmissionStatus = SubmissionStatus.SUBMITTED
     decision: Optional[LoanDecision] = None

--- a/dashboard/src/App.tsx
+++ b/dashboard/src/App.tsx
@@ -8,6 +8,7 @@ import Dashboard from './pages/Dashboard';
 import MultiStepForm from './pages/MultiStepForm';
 import AccountOpenings from './pages/AccountOpenings';
 import AccountOpeningDetail from './pages/AccountOpeningDetail';
+import LoanApplications from './pages/LoanApplications';
 import { ProtectedRoute, useAuth } from './auth';
 
 const App: React.FC = () => {
@@ -22,6 +23,7 @@ const App: React.FC = () => {
               <Link to="/stands">Stands</Link> |{' '}
               <Link to="/mandates">Mandates</Link> |{' '}
               <Link to="/account-openings">Account Openings</Link> |{' '}
+              <Link to="/loan-applications">Loan Applications</Link> |{' '}
             </>
           )}
           {auth.role === 'agent' && (
@@ -64,6 +66,14 @@ const App: React.FC = () => {
           element={
             <ProtectedRoute roles={["admin"]}>
               <AccountOpenings />
+            </ProtectedRoute>
+          }
+        />
+        <Route
+          path="/loan-applications"
+          element={
+            <ProtectedRoute roles={["admin"]}>
+              <LoanApplications />
             </ProtectedRoute>
           }
         />

--- a/dashboard/src/api.ts
+++ b/dashboard/src/api.ts
@@ -168,3 +168,37 @@ export async function recordDeposit(token: string, id: number, amount: number) {
   if (!res.ok) throw new Error('Failed to record deposit');
   return res.json();
 }
+
+export async function getLoanApplications(token: string, status?: string) {
+  const url = status ? `/loan-applications?status=${status}` : '/loan-applications';
+  const res = await fetch(url, { headers: headers(token) });
+  if (!res.ok) throw new Error('Failed to load loan applications');
+  return res.json();
+}
+
+export async function decideLoanApplication(
+  token: string,
+  id: number,
+  decision: { decision: string; reason?: string }
+) {
+  const res = await fetch(`/loan-applications/${id}/decision`, {
+    method: 'PUT',
+    headers: headers(token),
+    body: JSON.stringify(decision),
+  });
+  if (!res.ok) throw new Error('Failed to decide loan application');
+  return res.json();
+}
+
+export async function generateAgreement(
+  token: string,
+  data: { id: number; loan_application_id: number; property_id: number }
+) {
+  const res = await fetch('/agreements/generate', {
+    method: 'POST',
+    headers: headers(token),
+    body: JSON.stringify(data),
+  });
+  if (!res.ok) throw new Error('Failed to generate agreement');
+  return res.json();
+}

--- a/dashboard/src/pages/LoanApplications.tsx
+++ b/dashboard/src/pages/LoanApplications.tsx
@@ -1,0 +1,105 @@
+import React from 'react';
+import { useAuth } from '../auth';
+import { getLoanApplications, decideLoanApplication, generateAgreement } from '../api';
+
+interface LoanApp {
+  id: number;
+  realtor: string;
+  account_id: number;
+  property_id?: number;
+  status: string;
+}
+
+const LoanApplications: React.FC = () => {
+  const { auth } = useAuth();
+  const [apps, setApps] = React.useState<LoanApp[]>([]);
+  const [error, setError] = React.useState('');
+  const [sortKey, setSortKey] = React.useState<keyof LoanApp>('id');
+  const [ascending, setAscending] = React.useState(true);
+  const [comments, setComments] = React.useState<Record<number, string>>({});
+
+  React.useEffect(() => {
+    if (auth) {
+      getLoanApplications(auth.token, 'submitted')
+        .then(setApps)
+        .catch(() => setError('Failed to load applications'));
+    }
+  }, [auth]);
+
+  const sortBy = (key: keyof LoanApp) => {
+    const asc = key === sortKey ? !ascending : true;
+    setSortKey(key);
+    setAscending(asc);
+    const sorted = [...apps].sort((a, b) => {
+      const av = a[key];
+      const bv = b[key];
+      if (av < bv) return asc ? -1 : 1;
+      if (av > bv) return asc ? 1 : -1;
+      return 0;
+    });
+    setApps(sorted);
+  };
+
+  const handleDecision = (id: number, decision: 'approved' | 'rejected') => {
+    if (!auth) return;
+    const reason = comments[id];
+    decideLoanApplication(auth.token, id, { decision, reason })
+      .then(app => {
+        if (decision === 'approved' && app.property_id) {
+          generateAgreement(auth.token, {
+            id: app.id,
+            loan_application_id: app.id,
+            property_id: app.property_id,
+          }).catch(() => setError('Failed to generate agreement'));
+        }
+        setApps(prev => prev.filter(a => a.id !== id));
+      })
+      .catch(() => setError('Failed to submit decision'));
+  };
+
+  return (
+    <div>
+      <h2>Loan Applications Queue</h2>
+      {error && <p>{error}</p>}
+      {apps.length === 0 && <p>No pending applications.</p>}
+      {apps.length > 0 && (
+        <table>
+          <thead>
+            <tr>
+              <th onClick={() => sortBy('id')}>ID</th>
+              <th onClick={() => sortBy('realtor')}>Realtor</th>
+              <th onClick={() => sortBy('account_id')}>Account</th>
+            </tr>
+          </thead>
+          <tbody>
+            {apps.map(app => (
+              <tr key={app.id}>
+                <td>{app.id}</td>
+                <td>{app.realtor}</td>
+                <td>{app.account_id}</td>
+                <td>
+                  <input
+                    type="text"
+                    value={comments[app.id] || ''}
+                    onChange={e =>
+                      setComments({ ...comments, [app.id]: e.target.value })
+                    }
+                    placeholder="Comment"
+                  />
+                  <button onClick={() => handleDecision(app.id, 'approved')}>
+                    Approve
+                  </button>
+                  <button onClick={() => handleDecision(app.id, 'rejected')}>
+                    Reject
+                  </button>
+                </td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      )}
+    </div>
+  );
+};
+
+export default LoanApplications;

--- a/tests/test_submissions.py
+++ b/tests/test_submissions.py
@@ -229,3 +229,62 @@ def test_account_opening_queue_listing():
     assert resp.status_code == 200
     ids = {r["id"] for r in resp.json()}
     assert ids == {10, 20}
+
+
+def test_loan_application_queue_listing_and_agreement_generation():
+    tokens = setup_agents()
+    admin_headers = {"X-Token": tokens["admin"]}
+    realtor_headers = {"X-Token": tokens["realtor"]}
+
+    client.post("/projects", json={"id": 1, "name": "P"}, headers=admin_headers)
+    client.post(
+        "/stands",
+        json={"id": 1, "project_id": 1, "name": "S", "size": 100, "price": 1000},
+        headers=admin_headers,
+    )
+
+    client.post(
+        "/account-openings",
+        json={"id": 1, "realtor": "realtor"},
+        headers=realtor_headers,
+    )
+    client.put(
+        "/account-openings/1/open",
+        json={"account_number": "A1", "deposit_threshold": 100},
+        headers=admin_headers,
+    )
+    client.post(
+        "/account-openings/1/deposit",
+        json={"amount": 100},
+        headers=admin_headers,
+    )
+
+    loan_app = {
+        "id": 10,
+        "realtor": "realtor",
+        "account_id": 1,
+        "documents": ["doc"],
+        "property_id": 1,
+    }
+    client.post("/loan-applications", json=loan_app, headers=realtor_headers)
+
+    resp = client.get(
+        "/loan-applications",
+        params={"status": SubmissionStatus.SUBMITTED.value},
+        headers=admin_headers,
+    )
+    assert resp.status_code == 200
+    data = resp.json()
+    assert len(data) == 1 and data[0]["id"] == 10
+
+    resp = client.put(
+        "/loan-applications/10/decision",
+        json={"decision": "approved", "reason": "ok"},
+        headers=admin_headers,
+    )
+    assert resp.status_code == 200
+    assert resp.json()["status"] == SubmissionStatus.COMPLETED.value
+
+    resp = client.get("/agreements/10", headers=admin_headers)
+    assert resp.status_code == 200
+    assert resp.json()["loan_application_id"] == 10


### PR DESCRIPTION
## Summary
- add optional `property_id` to loan applications
- list and approve loan applications with automatic agreement generation
- create React loan application queue with sortable columns and decision forms

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68c72e0f90e8832cbf676d5f182fbb1d