### PR TITLE
Add agreement document viewer and signing notifications

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -735,6 +735,18 @@ def get_agreement(
     return agreement
 
 
+@app.get("/agreements/{agreement_id}/document")
+def view_agreement_document(
+    agreement_id: int,
+    _: Agent = Depends(get_current_agent),
+    repos: Repositories = Depends(get_repositories),
+):
+    agreement = repos.agreements.get(agreement_id)
+    if not agreement:
+        raise HTTPException(status_code=404, detail="Agreement not found")
+    return Response(content=agreement.document, media_type="text/plain")
+
+
 @app.put("/agreements/{agreement_id}/sign", response_model=Agreement)
 def sign_agreement(
     agreement_id: int,
@@ -758,6 +770,14 @@ def sign_agreement(
             f"{timestamp}: customer signed by {agent.username}"
         )
     repos.agreements.add(agreement)
+
+    if agreement.bank_signature and agreement.customer_signature:
+        message = (
+            f"Agreement {agreement_id} fully signed; notify Loan Accounts Opening Team"
+        )
+        if message not in repos.notifications.list():
+            repos.notifications.append(message)
+
     return agreement
 
 
@@ -802,8 +822,5 @@ def execute_agreement(
     stand = repos.stands.get(agreement.property_id)
     stand.status = PropertyStatus.SOLD
     repos.stands.add(stand)
-    repos.notifications.append(
-        f"Agreement {agreement_id} executed; notify Loan Accounts Opening Team"
-    )
     repos.agreements.add(agreement)
     return agreement

--- a/tests/test_agreements.py
+++ b/tests/test_agreements.py
@@ -70,6 +70,10 @@ def test_agreement_flow():
     assert resp.status_code == 200
     assert "Stand1" in resp.json()["document"]
 
+    resp = client.get("/agreements/1/document", headers=admin_headers)
+    assert resp.status_code == 200
+    assert "Stand1" in resp.text
+
     resp = client.put("/agreements/1/sign", headers=intruder_headers)
     assert resp.status_code == 403
 
@@ -80,6 +84,9 @@ def test_agreement_flow():
     resp = client.put("/agreements/1/sign", headers=admin_headers)
     assert resp.status_code == 200
     assert resp.json()["bank_signature"] is not None
+
+    notes_resp = client.get("/notifications", headers=admin_headers)
+    assert any("Loan Accounts Opening Team" in n for n in notes_resp.json())
 
     resp = client.post(
         "/agreements/1/upload",
@@ -104,8 +111,6 @@ def test_agreement_flow():
     assert loan_resp.json()["loan_account_number"] == "LN1"
     acct_resp = client.get("/loan-accounts/realtor", headers=admin_headers)
     assert acct_resp.json() == ["LN1"]
-    notes_resp = client.get("/notifications", headers=admin_headers)
-    assert any("Loan Accounts Opening Team" in n for n in notes_resp.json())
 
     resp = client.put(
         "/stands/1",


### PR DESCRIPTION
## Summary
- support viewing agreement documents
- notify Loan Accounts Opening Team once agreements are fully signed
- finalize property sale with loan account recording

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c72f741bdc832cb1c8c7f5a2b57dc3