### PR TITLE
Add role dashboards, report exports, and audit log filters

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -7,10 +7,14 @@ import hmac
 import csv
 from io import BytesIO
 from pydantic import BaseModel
-from openpyxl import load_workbook
+from openpyxl import load_workbook, Workbook
 from .database import init_db, get_session, SessionLocal
 from .repositories import Repositories
-from .reporting import generate_properties_report
+from .reporting import (
+    generate_properties_report,
+    generate_deposits_report,
+    generate_loans_report,
+)
 from .models import (
     Project,
     Stand,
@@ -120,6 +124,13 @@ class LoginRequest(BaseModel):
 class ImportResult(BaseModel):
     imported: int
     errors: List[str]
+
+
+class AuditEntry(BaseModel):
+    timestamp: str
+    user: str
+    action: str
+    status: int
 
 
 @app.post("/login")
@@ -339,10 +350,64 @@ def import_properties(
 @app.get("/reports/properties")
 def properties_report(
     status: Optional[PropertyStatus] = None,
+    format: str = "csv",
     _: Agent = Depends(require_admin),
     repos: Repositories = Depends(get_repositories),
 ):
     csv_data = generate_properties_report(repos, status)
+    if format == "excel":
+        wb = Workbook()
+        ws = wb.active
+        for row in csv.reader(csv_data.splitlines()):
+            ws.append(row)
+        stream = BytesIO()
+        wb.save(stream)
+        return Response(
+            content=stream.getvalue(),
+            media_type="application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
+        )
+    return Response(content=csv_data, media_type="text/csv")
+
+
+@app.get("/reports/deposits")
+def deposits_report(
+    format: str = "csv",
+    _: Agent = Depends(require_admin),
+    repos: Repositories = Depends(get_repositories),
+):
+    csv_data = generate_deposits_report(repos)
+    if format == "excel":
+        wb = Workbook()
+        ws = wb.active
+        for row in csv.reader(csv_data.splitlines()):
+            ws.append(row)
+        stream = BytesIO()
+        wb.save(stream)
+        return Response(
+            content=stream.getvalue(),
+            media_type="application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
+        )
+    return Response(content=csv_data, media_type="text/csv")
+
+
+@app.get("/reports/loans")
+def loans_report(
+    format: str = "csv",
+    _: Agent = Depends(require_admin),
+    repos: Repositories = Depends(get_repositories),
+):
+    csv_data = generate_loans_report(repos)
+    if format == "excel":
+        wb = Workbook()
+        ws = wb.active
+        for row in csv.reader(csv_data.splitlines()):
+            ws.append(row)
+        stream = BytesIO()
+        wb.save(stream)
+        return Response(
+            content=stream.getvalue(),
+            media_type="application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
+        )
     return Response(content=csv_data, media_type="text/csv")
 
 
@@ -683,12 +748,36 @@ def dashboard(
     return data
 
 
-@app.get("/audit-log", response_model=List[str])
+@app.get("/audit-log", response_model=List[AuditEntry])
 def get_audit_log(
+    start: Optional[datetime] = None,
+    end: Optional[datetime] = None,
+    user: Optional[str] = None,
+    action: Optional[str] = None,
     _: Agent = Depends(require_compliance),
     repos: Repositories = Depends(get_repositories),
 ):
-    return repos.audit_log.list()
+    entries = []
+    for entry in repos.audit_log.list():
+        parts = entry.split(" - ")
+        if len(parts) != 4:
+            continue
+        ts_str, username, act, status_str = parts
+        ts = datetime.fromisoformat(ts_str)
+        if start and ts < start:
+            continue
+        if end and ts > end:
+            continue
+        if user and username != user:
+            continue
+        if action and action not in act:
+            continue
+        entries.append(
+            AuditEntry(
+                timestamp=ts_str, user=username, action=act, status=int(status_str)
+            )
+        )
+    return entries
 
 
 # ---- Agreement endpoints ----

--- a/app/reporting.py
+++ b/app/reporting.py
@@ -40,3 +40,43 @@ def generate_properties_report(
     writer.writeheader()
     writer.writerows(rows)
     return output.getvalue()
+
+
+def generate_deposits_report(repos: Repositories) -> str:
+    """Generate CSV report of account deposits."""
+    rows = []
+    for req in repos.account_openings.list():
+        rows.append(
+            {
+                "account_id": req.id,
+                "realtor": req.realtor,
+                "total_deposits": sum(req.deposits),
+            }
+        )
+    output = StringIO()
+    fieldnames = ["account_id", "realtor", "total_deposits"]
+    writer = csv.DictWriter(output, fieldnames=fieldnames)
+    writer.writeheader()
+    writer.writerows(rows)
+    return output.getvalue()
+
+
+def generate_loans_report(repos: Repositories) -> str:
+    """Generate CSV report of loan applications."""
+    rows = []
+    for app in repos.loan_applications.list():
+        rows.append(
+            {
+                "loan_id": app.id,
+                "realtor": app.realtor,
+                "account_id": app.account_id,
+                "status": app.status.value,
+                "decision": app.decision.value if app.decision else "",
+            }
+        )
+    output = StringIO()
+    fieldnames = ["loan_id", "realtor", "account_id", "status", "decision"]
+    writer = csv.DictWriter(output, fieldnames=fieldnames)
+    writer.writeheader()
+    writer.writerows(rows)
+    return output.getvalue()

--- a/dashboard/src/App.tsx
+++ b/dashboard/src/App.tsx
@@ -9,6 +9,8 @@ import MultiStepForm from './pages/MultiStepForm';
 import AccountOpenings from './pages/AccountOpenings';
 import AccountOpeningDetail from './pages/AccountOpeningDetail';
 import LoanApplications from './pages/LoanApplications';
+import AdminDashboard from './pages/AdminDashboard';
+import ComplianceDashboard from './pages/ComplianceDashboard';
 import { ProtectedRoute, useAuth } from './auth';
 
 const App: React.FC = () => {
@@ -19,11 +21,22 @@ const App: React.FC = () => {
         <nav>
           {auth.role === 'admin' && (
             <>
+              <Link to="/admin-dashboard">Dashboard</Link> |{' '}
               <Link to="/projects">Projects</Link> |{' '}
               <Link to="/stands">Stands</Link> |{' '}
               <Link to="/mandates">Mandates</Link> |{' '}
               <Link to="/account-openings">Account Openings</Link> |{' '}
               <Link to="/loan-applications">Loan Applications</Link> |{' '}
+            </>
+          )}
+          {auth.role === 'manager' && (
+            <>
+              <Link to="/admin-dashboard">Dashboard</Link> |{' '}
+            </>
+          )}
+          {auth.role === 'compliance' && (
+            <>
+              <Link to="/compliance-dashboard">Dashboard</Link> |{' '}
             </>
           )}
           {auth.role === 'agent' && (
@@ -86,6 +99,22 @@ const App: React.FC = () => {
           }
         />
         <Route
+          path="/admin-dashboard"
+          element={
+            <ProtectedRoute roles={["admin", "manager"]}>
+              <AdminDashboard />
+            </ProtectedRoute>
+          }
+        />
+        <Route
+          path="/compliance-dashboard"
+          element={
+            <ProtectedRoute roles={["compliance", "admin"]}>
+              <ComplianceDashboard />
+            </ProtectedRoute>
+          }
+        />
+        <Route
           path="/dashboard"
           element={
             <ProtectedRoute roles={["agent"]}>
@@ -109,7 +138,9 @@ const App: React.FC = () => {
                 auth
                   ? auth.role === 'agent'
                     ? '/dashboard'
-                    : '/projects'
+                    : auth.role === 'compliance'
+                      ? '/compliance-dashboard'
+                      : '/admin-dashboard'
                   : '/login'
               }
               replace

--- a/dashboard/src/api.ts
+++ b/dashboard/src/api.ts
@@ -3,6 +3,23 @@ export const headers = (token: string) => ({
   'X-Token': token,
 });
 
+export async function getDashboard(token: string) {
+  const res = await fetch('/dashboard', { headers: headers(token) });
+  if (!res.ok) throw new Error('Failed to load dashboard');
+  return res.json();
+}
+
+export async function getAuditLog(
+  token: string,
+  filters: { start?: string; end?: string; user?: string; action?: string } = {}
+) {
+  const params = new URLSearchParams(filters as Record<string, string>);
+  const url = params.toString() ? `/audit-log?${params}` : '/audit-log';
+  const res = await fetch(url, { headers: headers(token) });
+  if (!res.ok) throw new Error('Failed to load audit log');
+  return res.json();
+}
+
 export async function getProjects(token: string) {
   const res = await fetch('/projects', { headers: headers(token) });
   if (!res.ok) throw new Error('Failed to load projects');

--- a/dashboard/src/pages/AdminDashboard.tsx
+++ b/dashboard/src/pages/AdminDashboard.tsx
@@ -1,0 +1,69 @@
+import React from 'react';
+import { useAuth } from '../auth';
+import { getDashboard } from '../api';
+
+const AdminDashboard: React.FC = () => {
+  const { auth } = useAuth();
+  const [data, setData] = React.useState<any>(null);
+
+  React.useEffect(() => {
+    if (auth) {
+      getDashboard(auth.token).then(setData).catch(console.error);
+    }
+  }, [auth]);
+
+  if (!auth) return null;
+
+  const exportReport = (report: string, format: string) => {
+    window.location.href = `/reports/${report}?format=${format}`;
+  };
+
+  return (
+    <div>
+      <h2>Dashboard</h2>
+      {data?.property_status && (
+        <div>
+          <h3>Inventory</h3>
+          <ul>
+            {Object.entries(data.property_status).map(([k, v]) => (
+              <li key={k}>{k}: {v as number}</li>
+            ))}
+          </ul>
+          <button onClick={() => exportReport('properties', 'csv')}>Export CSV</button>
+          <button onClick={() => exportReport('properties', 'excel')}>Export Excel</button>
+        </div>
+      )}
+      {data?.mandates && (
+        <div>
+          <h3>Mandates</h3>
+          <ul>
+            {Object.entries(data.mandates).map(([k, v]) => (
+              <li key={k}>{k}: {v as number}</li>
+            ))}
+          </ul>
+        </div>
+      )}
+      {data?.deposits !== undefined && (
+        <div>
+          <h3>Deposits</h3>
+          <p>Total Deposits: {data.deposits}</p>
+          <button onClick={() => exportReport('deposits', 'csv')}>Export CSV</button>
+          <button onClick={() => exportReport('deposits', 'excel')}>Export Excel</button>
+        </div>
+      )}
+      {data?.loan_approvals && (
+        <div>
+          <h3>Loans</h3>
+          <ul>
+            <li>Approved: {data.loan_approvals.approved}</li>
+            <li>Rejected: {data.loan_approvals.rejected}</li>
+          </ul>
+          <button onClick={() => exportReport('loans', 'csv')}>Export CSV</button>
+          <button onClick={() => exportReport('loans', 'excel')}>Export Excel</button>
+        </div>
+      )}
+    </div>
+  );
+};
+
+export default AdminDashboard;

--- a/dashboard/src/pages/ComplianceDashboard.tsx
+++ b/dashboard/src/pages/ComplianceDashboard.tsx
@@ -1,0 +1,96 @@
+import React from 'react';
+import { useAuth } from '../auth';
+import { getDashboard, getAuditLog } from '../api';
+
+const ComplianceDashboard: React.FC = () => {
+  const { auth } = useAuth();
+  const [data, setData] = React.useState<any>(null);
+  const [logs, setLogs] = React.useState<any[]>([]);
+  const [filters, setFilters] = React.useState({ start: '', end: '', user: '', action: '' });
+
+  React.useEffect(() => {
+    if (auth) {
+      getDashboard(auth.token).then(setData).catch(console.error);
+      fetchLogs();
+    }
+  }, [auth]);
+
+  const fetchLogs = () => {
+    if (!auth) return;
+    const params: any = {};
+    if (filters.start) params.start = filters.start;
+    if (filters.end) params.end = filters.end;
+    if (filters.user) params.user = filters.user;
+    if (filters.action) params.action = filters.action;
+    getAuditLog(auth.token, params).then(setLogs).catch(console.error);
+  };
+
+  if (!auth) return null;
+
+  const exportReport = (report: string, format: string) => {
+    window.location.href = `/reports/${report}?format=${format}`;
+  };
+
+  return (
+    <div>
+      <h2>Compliance Dashboard</h2>
+      {data && (
+        <div>
+          <p>Total Deposits: {data.deposits}</p>
+          <p>Loans Approved: {data.loan_approvals?.approved || 0}</p>
+          <p>Loans Rejected: {data.loan_approvals?.rejected || 0}</p>
+          <button onClick={() => exportReport('deposits', 'csv')}>Export Deposits CSV</button>
+          <button onClick={() => exportReport('deposits', 'excel')}>Export Deposits Excel</button>
+          <button onClick={() => exportReport('loans', 'csv')}>Export Loans CSV</button>
+          <button onClick={() => exportReport('loans', 'excel')}>Export Loans Excel</button>
+        </div>
+      )}
+      <h3>Audit Log</h3>
+      <div>
+        <input
+          placeholder="User"
+          value={filters.user}
+          onChange={e => setFilters({ ...filters, user: e.target.value })}
+        />
+        <input
+          placeholder="Action"
+          value={filters.action}
+          onChange={e => setFilters({ ...filters, action: e.target.value })}
+        />
+        <input
+          type="date"
+          value={filters.start}
+          onChange={e => setFilters({ ...filters, start: e.target.value })}
+        />
+        <input
+          type="date"
+          value={filters.end}
+          onChange={e => setFilters({ ...filters, end: e.target.value })}
+        />
+        <button onClick={fetchLogs}>Filter</button>
+      </div>
+      <table>
+        <thead>
+          <tr>
+            <th>Timestamp</th>
+            <th>User</th>
+            <th>Action</th>
+            <th>Status</th>
+          </tr>
+        </thead>
+        <tbody>
+          {logs.map((l, i) => (
+            <tr key={i}>
+              <td>{l.timestamp}</td>
+              <td>{l.user}</td>
+              <td>{l.action}</td>
+              <td>{l.status}</td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+  );
+};
+
+export default ComplianceDashboard;

--- a/tests/test_dashboard.py
+++ b/tests/test_dashboard.py
@@ -102,6 +102,13 @@ def test_dashboards_and_audit_log():
     resp = client.get("/audit-log", headers=compliance_headers)
     assert resp.status_code == 200
     log = resp.json()
-    assert any("/projects" in entry for entry in log)
+    assert any(entry["action"].endswith("/projects") for entry in log)
+
+    resp = client.get(
+        "/audit-log", headers=compliance_headers, params={"user": "admin"}
+    )
+    assert resp.status_code == 200
+    filtered = resp.json()
+    assert all(entry["user"] == "admin" for entry in filtered)
     reset_state()
 

--- a/tests/test_reporting.py
+++ b/tests/test_reporting.py
@@ -35,6 +35,31 @@ def setup_data():
     )
     client.post("/stands/1/mandate", json={"agent": "agent"}, headers=admin_headers)
     client.put("/stands/1/mandate/accept", headers=agent_headers)
+    client.post(
+        "/account-openings",
+        json={"id": 1, "realtor": "agent"},
+        headers=agent_headers,
+    )
+    client.put(
+        "/account-openings/1/open",
+        json={"account_number": "A1", "deposit_threshold": 100},
+        headers=admin_headers,
+    )
+    client.post(
+        "/account-openings/1/deposit",
+        json={"amount": 100},
+        headers=admin_headers,
+    )
+    client.post(
+        "/loan-applications",
+        json={"id": 1, "realtor": "agent", "account_id": 1, "documents": ["d"]},
+        headers=agent_headers,
+    )
+    client.put(
+        "/loan-applications/1/decision",
+        json={"decision": "approved"},
+        headers=admin_headers,
+    )
     return admin_headers
 
 
@@ -60,3 +85,16 @@ def test_report_filtering():
     data = list(csv.DictReader(resp.text.splitlines()))
     assert len(data) == 1
     assert data[0]["status"] == "sold"
+
+
+def test_deposit_and_loan_reports():
+    admin_headers = setup_data()
+    resp = client.get("/reports/deposits", headers=admin_headers)
+    assert resp.status_code == 200
+    data = list(csv.DictReader(resp.text.splitlines()))
+    assert float(data[0]["total_deposits"]) == 100
+
+    resp = client.get("/reports/loans", headers=admin_headers)
+    assert resp.status_code == 200
+    data = list(csv.DictReader(resp.text.splitlines()))
+    assert data[0]["decision"] == "approved"


### PR DESCRIPTION
## Summary
- Provide CSV/Excel report endpoints for properties, deposits, and loans
- Add admin and compliance dashboards with report exports and audit log viewer
- Allow audit log filtering by date, user, and action type

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c79843a2cc832c94066520deafae12