### PR TITLE
Add mandate management with history and frontend hooks

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -21,6 +21,8 @@ from .models import (
     Stand,
     PropertyStatus,
     Mandate,
+    MandateRecord,
+    MandateHistoryEntry,
     Agent,
     AgentCreate,
     AgentInDB,
@@ -322,6 +324,88 @@ def get_stand(
     if not stand:
         raise HTTPException(status_code=404, detail="Stand not found")
     return stand
+
+
+# Mandate endpoints
+
+
+@app.post("/mandates", response_model=MandateRecord)
+def create_mandate(
+    mandate: MandateRecord,
+    _: Agent = Depends(require_admin),
+    repos: Repositories = Depends(get_repositories),
+):
+    if repos.mandates.get(mandate.id):
+        raise HTTPException(status_code=400, detail="Mandate exists")
+    if not repos.projects.get(mandate.project_id):
+        raise HTTPException(status_code=404, detail="Project not found")
+    if not repos.agents.get(mandate.agent):
+        raise HTTPException(status_code=404, detail="Agent not found")
+    repos.mandates.add(mandate)
+    repos.mandate_history.set(
+        mandate.id,
+        [
+            {
+                "timestamp": datetime.utcnow().isoformat(),
+                "status": mandate.status.value,
+            }
+        ],
+    )
+    return mandate
+
+
+@app.put("/mandates/{mandate_id}", response_model=MandateRecord)
+def update_mandate(
+    mandate_id: int,
+    mandate: MandateRecord,
+    _: Agent = Depends(require_admin),
+    repos: Repositories = Depends(get_repositories),
+):
+    existing = repos.mandates.get(mandate_id)
+    if not existing:
+        raise HTTPException(status_code=404, detail="Mandate not found")
+    if mandate.id != mandate_id:
+        raise HTTPException(status_code=400, detail="Mandate ID mismatch")
+    if not repos.projects.get(mandate.project_id):
+        raise HTTPException(status_code=404, detail="Project not found")
+    if not repos.agents.get(mandate.agent):
+        raise HTTPException(status_code=404, detail="Agent not found")
+    if mandate.status != existing.status:
+        history = repos.mandate_history.get(mandate_id, [])
+        history.append(
+            {
+                "timestamp": datetime.utcnow().isoformat(),
+                "status": mandate.status.value,
+            }
+        )
+        repos.mandate_history.set(mandate_id, history)
+    repos.mandates.add(mandate)
+    return mandate
+
+
+@app.get("/mandates", response_model=List[MandateRecord])
+def list_mandates(
+    _: Agent = Depends(get_current_agent),
+    repos: Repositories = Depends(get_repositories),
+):
+    return repos.mandates.list()
+
+
+@app.get("/mandates/{mandate_id}/history", response_model=List[MandateHistoryEntry])
+def get_mandate_history(
+    mandate_id: int,
+    _: Agent = Depends(get_current_agent),
+    repos: Repositories = Depends(get_repositories),
+):
+    if not repos.mandates.get(mandate_id):
+        raise HTTPException(status_code=404, detail="Mandate not found")
+    history = repos.mandate_history.get(mandate_id, [])
+    return [
+        MandateHistoryEntry(
+            timestamp=h["timestamp"], status=MandateStatus(h["status"])
+        )
+        for h in history
+    ]
 
 
 @app.post("/import/properties", response_model=ImportResult)

--- a/app/models.py
+++ b/app/models.py
@@ -32,6 +32,20 @@ class Mandate(BaseModel):
     expiration_date: Optional[datetime] = None
 
 
+class MandateRecord(Mandate):
+    """Persistent mandate linking an agent to a project."""
+
+    id: int
+    project_id: int
+
+
+class MandateHistoryEntry(BaseModel):
+    """Represents a status change in a mandate's lifecycle."""
+
+    timestamp: datetime
+    status: MandateStatus
+
+
 class Stand(BaseModel):
     id: int
     project_id: int

--- a/app/repositories.py
+++ b/app/repositories.py
@@ -89,6 +89,7 @@ from .models import (
     AgentInDB,
     Project,
     Stand,
+    MandateRecord,
     Offer,
     PropertyApplication,
     AccountOpening,
@@ -102,6 +103,8 @@ class Repositories:
         self.agents = Repository(session, 'agents', AgentInDB)
         self.projects = Repository(session, 'projects', Project)
         self.stands = Repository(session, 'stands', Stand)
+        self.mandates = Repository(session, 'mandates', MandateRecord)
+        self.mandate_history = SimpleRepository(session, 'mandate_history')
         self.offers = Repository(session, 'offers', Offer)
         self.applications = Repository(session, 'applications', PropertyApplication)
         self.account_openings = Repository(session, 'account_openings', AccountOpening)

--- a/dashboard/src/api.ts
+++ b/dashboard/src/api.ts
@@ -81,6 +81,45 @@ export async function assignMandate(token: string, standId: number, agent: strin
   return res.json();
 }
 
+export async function listMandates(token: string) {
+  const res = await fetch('/mandates', { headers: headers(token) });
+  if (!res.ok) throw new Error('Failed to load mandates');
+  return res.json();
+}
+
+export async function createMandate(
+  token: string,
+  mandate: { id: number; project_id: number; agent: string; status?: string },
+) {
+  const res = await fetch('/mandates', {
+    method: 'POST',
+    headers: headers(token),
+    body: JSON.stringify(mandate),
+  });
+  if (!res.ok) throw new Error('Failed to create mandate');
+  return res.json();
+}
+
+export async function updateMandate(
+  token: string,
+  id: number,
+  mandate: { id: number; project_id: number; agent: string; status: string },
+) {
+  const res = await fetch(`/mandates/${id}`, {
+    method: 'PUT',
+    headers: headers(token),
+    body: JSON.stringify(mandate),
+  });
+  if (!res.ok) throw new Error('Failed to update mandate');
+  return res.json();
+}
+
+export async function getMandateHistory(token: string, id: number) {
+  const res = await fetch(`/mandates/${id}/history`, { headers: headers(token) });
+  if (!res.ok) throw new Error('Failed to load mandate history');
+  return res.json();
+}
+
 export async function submitOffer(
   token: string,
   offer: { id: number; realtor: string; property_id: number; details?: string; file?: File }

--- a/dashboard/src/pages/Mandates.tsx
+++ b/dashboard/src/pages/Mandates.tsx
@@ -1,35 +1,67 @@
 import React from 'react';
 import { useAuth } from '../auth';
-import { getStands, assignMandate } from '../api';
+import {
+  listMandates,
+  createMandate,
+  updateMandate,
+  getMandateHistory,
+} from '../api';
 
-interface Stand {
+interface Mandate {
   id: number;
-  name: string;
-  mandate?: { agent: string; status: string };
+  project_id: number;
+  agent: string;
+  status: string;
 }
 
 const Mandates: React.FC = () => {
   const { auth } = useAuth();
-  const [stands, setStands] = React.useState<Stand[]>([]);
-  const [search, setSearch] = React.useState('');
-  const [inputs, setInputs] = React.useState<Record<number, string>>({});
+  const [mandates, setMandates] = React.useState<Mandate[]>([]);
+  const [form, setForm] = React.useState({ id: '', project_id: '', agent: '' });
+  const [statusInputs, setStatusInputs] = React.useState<Record<number, string>>({});
+  const [history, setHistory] = React.useState<Record<number, { timestamp: string; status: string }[]>>({});
 
   React.useEffect(() => {
     if (auth) {
-      getStands(auth.token).then(setStands).catch(console.error);
+      listMandates(auth.token).then(setMandates).catch(console.error);
     }
   }, [auth]);
 
-  const filtered = stands.filter(s => s.name.toLowerCase().includes(search.toLowerCase()));
-
-  const assign = async (standId: number) => {
+  const submit = async () => {
     if (!auth) return;
-    const agent = inputs[standId];
-    if (!agent) return;
     try {
-      const stand = await assignMandate(auth.token, standId, agent);
-      setStands(stands.map(s => (s.id === standId ? stand : s)));
-      setInputs({ ...inputs, [standId]: '' });
+      const m = await createMandate(auth.token, {
+        id: Number(form.id),
+        project_id: Number(form.project_id),
+        agent: form.agent,
+        status: 'pending',
+      });
+      setMandates([...mandates, m]);
+      setForm({ id: '', project_id: '', agent: '' });
+    } catch (err) {
+      console.error(err);
+    }
+  };
+
+  const update = async (id: number) => {
+    if (!auth) return;
+    const m = mandates.find(x => x.id === id);
+    const status = statusInputs[id];
+    if (!m || !status) return;
+    try {
+      const updated = await updateMandate(auth.token, id, { ...m, status });
+      setMandates(mandates.map(x => (x.id === id ? updated : x)));
+      setStatusInputs({ ...statusInputs, [id]: '' });
+    } catch (err) {
+      console.error(err);
+    }
+  };
+
+  const loadHistory = async (id: number) => {
+    if (!auth) return;
+    try {
+      const h = await getMandateHistory(auth.token, id);
+      setHistory({ ...history, [id]: h });
     } catch (err) {
       console.error(err);
     }
@@ -38,29 +70,70 @@ const Mandates: React.FC = () => {
   return (
     <div>
       <h2>Mandates</h2>
-      <input placeholder="Search" value={search} onChange={e => setSearch(e.target.value)} />
+      <div>
+        <input
+          placeholder="ID"
+          value={form.id}
+          onChange={e => setForm({ ...form, id: e.target.value })}
+        />
+        <input
+          placeholder="Project ID"
+          value={form.project_id}
+          onChange={e => setForm({ ...form, project_id: e.target.value })}
+        />
+        <input
+          placeholder="Agent"
+          value={form.agent}
+          onChange={e => setForm({ ...form, agent: e.target.value })}
+        />
+        <button
+          onClick={submit}
+          disabled={!form.id || !form.project_id || !form.agent}
+        >
+          Create
+        </button>
+      </div>
       <table>
         <thead>
           <tr>
             <th>ID</th>
-            <th>Name</th>
-            <th>Mandate</th>
-            <th>Assign</th>
+            <th>Project</th>
+            <th>Agent</th>
+            <th>Status</th>
+            <th>Update</th>
+            <th>History</th>
           </tr>
         </thead>
         <tbody>
-          {filtered.map(s => (
-            <tr key={s.id}>
-              <td>{s.id}</td>
-              <td>{s.name}</td>
-              <td>{s.mandate ? `${s.mandate.agent} (${s.mandate.status})` : '-'}</td>
+          {mandates.map(m => (
+            <tr key={m.id}>
+              <td>{m.id}</td>
+              <td>{m.project_id}</td>
+              <td>{m.agent}</td>
+              <td>{m.status}</td>
               <td>
                 <input
-                  placeholder="Agent"
-                  value={inputs[s.id] || ''}
-                  onChange={e => setInputs({ ...inputs, [s.id]: e.target.value })}
+                  placeholder="Status"
+                  value={statusInputs[m.id] || ''}
+                  onChange={e =>
+                    setStatusInputs({ ...statusInputs, [m.id]: e.target.value })
+                  }
                 />
-                <button onClick={() => assign(s.id)} disabled={!inputs[s.id]}>Assign</button>
+                <button onClick={() => update(m.id)} disabled={!statusInputs[m.id]}>
+                  Update
+                </button>
+              </td>
+              <td>
+                <button onClick={() => loadHistory(m.id)}>Load</button>
+                {history[m.id] && (
+                  <ul>
+                    {history[m.id].map((h, i) => (
+                      <li key={i}>
+                        {new Date(h.timestamp).toLocaleString()} - {h.status}
+                      </li>
+                    ))}
+                  </ul>
+                )}
               </td>
             </tr>
           ))}

--- a/frontend/src/api/mandates.ts
+++ b/frontend/src/api/mandates.ts
@@ -1,0 +1,62 @@
+import { useEffect, useState } from 'react';
+
+export interface Mandate {
+  id: number;
+  project_id: number;
+  agent: string;
+  status: string;
+  document?: string;
+  agreement_status?: string;
+  expiration_date?: string;
+}
+
+export interface MandateHistoryEntry {
+  timestamp: string;
+  status: string;
+}
+
+const jsonHeaders = (token: string) => ({
+  'Content-Type': 'application/json',
+  'X-Token': token,
+});
+
+export async function listMandates(token: string): Promise<Mandate[]> {
+  const res = await fetch('/mandates', { headers: jsonHeaders(token) });
+  if (!res.ok) throw new Error('Failed to load mandates');
+  return res.json();
+}
+
+export async function createMandate(token: string, mandate: Mandate): Promise<Mandate> {
+  const res = await fetch('/mandates', {
+    method: 'POST',
+    headers: jsonHeaders(token),
+    body: JSON.stringify(mandate),
+  });
+  if (!res.ok) throw new Error('Failed to create mandate');
+  return res.json();
+}
+
+export async function updateMandate(token: string, id: number, mandate: Mandate): Promise<Mandate> {
+  const res = await fetch(`/mandates/${id}`, {
+    method: 'PUT',
+    headers: jsonHeaders(token),
+    body: JSON.stringify(mandate),
+  });
+  if (!res.ok) throw new Error('Failed to update mandate');
+  return res.json();
+}
+
+export async function getMandateHistory(token: string, id: number): Promise<MandateHistoryEntry[]> {
+  const res = await fetch(`/mandates/${id}/history`, { headers: jsonHeaders(token) });
+  if (!res.ok) throw new Error('Failed to load mandate history');
+  return res.json();
+}
+
+export function useMandates(token: string | undefined) {
+  const [mandates, setMandates] = useState<Mandate[]>([]);
+  useEffect(() => {
+    if (!token) return;
+    listMandates(token).then(setMandates).catch(console.error);
+  }, [token]);
+  return { mandates, setMandates };
+}


### PR DESCRIPTION
## Summary
- add `MandateRecord` models and repository support
- implement `/mandates` CRUD and history endpoints
- expose React hooks and dashboards for mandate management

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c7a0f42038832cb4bf3460559e6c50