### PR TITLE
Add deposit management endpoints and dashboard views

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -836,6 +836,57 @@ def record_deposit(
     return request
 
 
+@app.get("/accounts/deposits/pending", response_model=List[AccountOpening])
+def list_pending_deposits(
+    _: Agent = Depends(require_admin),
+    repos: Repositories = Depends(get_repositories),
+):
+    openings = repos.account_openings.list()
+    return [
+        o
+        for o in openings
+        if o.status in (SubmissionStatus.SUBMITTED, SubmissionStatus.IN_PROGRESS)
+    ]
+
+
+@app.post("/accounts/deposits/{req_id}/open", response_model=AccountOpening)
+def open_deposit_account(
+    req_id: int,
+    details: AccountSetup,
+    _: Agent = Depends(require_admin),
+    repos: Repositories = Depends(get_repositories),
+):
+    request = repos.account_openings.get(req_id)
+    if not request:
+        raise HTTPException(status_code=404, detail="Request not found")
+    if details.deposit_threshold <= 0:
+        raise HTTPException(status_code=400, detail="Deposit threshold must be positive")
+    request.account_number = details.account_number
+    request.deposit_threshold = details.deposit_threshold
+    request.status = SubmissionStatus.IN_PROGRESS
+    repos.account_openings.add(request)
+    return request
+
+
+@app.post("/accounts/deposits/{req_id}/deposit", response_model=AccountOpening)
+def record_account_deposit(
+    req_id: int,
+    deposit: Deposit,
+    _: Agent = Depends(require_admin),
+    repos: Repositories = Depends(get_repositories),
+):
+    request = repos.account_openings.get(req_id)
+    if not request:
+        raise HTTPException(status_code=404, detail="Request not found")
+    if deposit.amount <= 0:
+        raise HTTPException(status_code=400, detail="Deposit amount must be positive")
+    request.deposits.append(deposit.amount)
+    if request.deposit_threshold is not None and sum(request.deposits) >= request.deposit_threshold:
+        request.status = SubmissionStatus.COMPLETED
+    repos.account_openings.add(request)
+    return request
+
+
 @app.post("/loan-applications", response_model=LoanApplication)
 def submit_loan_application(
     application: LoanApplication,

--- a/dashboard/src/App.tsx
+++ b/dashboard/src/App.tsx
@@ -11,6 +11,8 @@ import AccountOpeningDetail from './pages/AccountOpeningDetail';
 import LoanApplications from './pages/LoanApplications';
 import AdminDashboard from './pages/AdminDashboard';
 import ComplianceDashboard from './pages/ComplianceDashboard';
+import Deposits from './pages/Deposits';
+import DepositDetail from './pages/DepositDetail';
 import { ProtectedRoute, useAuth } from './auth';
 
 const App: React.FC = () => {
@@ -27,6 +29,7 @@ const App: React.FC = () => {
               <Link to="/mandates">Mandates</Link> |{' '}
               <Link to="/account-openings">Account Openings</Link> |{' '}
               <Link to="/loan-applications">Loan Applications</Link> |{' '}
+              <Link to="/deposits">Deposits</Link> |{' '}
             </>
           )}
           {auth.role === 'manager' && (
@@ -87,6 +90,22 @@ const App: React.FC = () => {
           element={
             <ProtectedRoute roles={["admin"]}>
               <LoanApplications />
+            </ProtectedRoute>
+          }
+        />
+        <Route
+          path="/deposits"
+          element={
+            <ProtectedRoute roles={["admin"]}>
+              <Deposits />
+            </ProtectedRoute>
+          }
+        />
+        <Route
+          path="/deposits/:id"
+          element={
+            <ProtectedRoute roles={["admin"]}>
+              <DepositDetail />
             </ProtectedRoute>
           }
         />

--- a/dashboard/src/api.ts
+++ b/dashboard/src/api.ts
@@ -225,6 +225,36 @@ export async function recordDeposit(token: string, id: number, amount: number) {
   return res.json();
 }
 
+export async function getPendingDeposits(token: string) {
+  const res = await fetch('/accounts/deposits/pending', { headers: headers(token) });
+  if (!res.ok) throw new Error('Failed to load pending deposits');
+  return res.json();
+}
+
+export async function openDepositAccount(
+  token: string,
+  id: number,
+  data: { account_number: string; deposit_threshold: number },
+) {
+  const res = await fetch(`/accounts/deposits/${id}/open`, {
+    method: 'POST',
+    headers: headers(token),
+    body: JSON.stringify(data),
+  });
+  if (!res.ok) throw new Error('Failed to open account');
+  return res.json();
+}
+
+export async function recordAccountDeposit(token: string, id: number, amount: number) {
+  const res = await fetch(`/accounts/deposits/${id}/deposit`, {
+    method: 'POST',
+    headers: headers(token),
+    body: JSON.stringify({ amount }),
+  });
+  if (!res.ok) throw new Error('Failed to record deposit');
+  return res.json();
+}
+
 export async function getLoanApplications(token: string, status?: string) {
   const url = status ? `/loan-applications?status=${status}` : '/loan-applications';
   const res = await fetch(url, { headers: headers(token) });

--- a/dashboard/src/pages/DepositDetail.tsx
+++ b/dashboard/src/pages/DepositDetail.tsx
@@ -1,0 +1,121 @@
+import React from 'react';
+import { useParams } from 'react-router-dom';
+import { useAuth } from '../auth';
+import {
+  getAccountOpening,
+  openDepositAccount,
+  recordAccountDeposit,
+} from '../api';
+
+interface AccountOpening {
+  id: number;
+  realtor: string;
+  status: string;
+  account_number?: string;
+  deposit_threshold?: number;
+  deposits: number[];
+}
+
+const DepositDetail: React.FC = () => {
+  const { id } = useParams();
+  const { auth } = useAuth();
+  const [opening, setOpening] = React.useState<AccountOpening | null>(null);
+  const [accountNumber, setAccountNumber] = React.useState('');
+  const [threshold, setThreshold] = React.useState('');
+  const [deposit, setDeposit] = React.useState('');
+  const [error, setError] = React.useState('');
+
+  const load = () => {
+    if (auth && id) {
+      getAccountOpening(auth.token, Number(id))
+        .then(setOpening)
+        .catch(() => setError('Failed to load request'));
+    }
+  };
+
+  React.useEffect(load, [auth, id]);
+
+  const totalDeposits = opening?.deposits.reduce((s, d) => s + d, 0) || 0;
+
+  const handleOpen = async () => {
+    if (!auth || !id) return;
+    try {
+      const req = await openDepositAccount(auth.token, Number(id), {
+        account_number: accountNumber,
+        deposit_threshold: Number(threshold),
+      });
+      setOpening(req);
+      setAccountNumber('');
+      setThreshold('');
+    } catch {
+      setError('Failed to open account');
+    }
+  };
+
+  const handleDeposit = async () => {
+    if (!auth || !id) return;
+    try {
+      const req = await recordAccountDeposit(auth.token, Number(id), Number(deposit));
+      setOpening(req);
+      setDeposit('');
+    } catch {
+      setError('Failed to record deposit');
+    }
+  };
+
+  if (!opening) return <div>{error || 'Loading...'}</div>;
+
+  return (
+    <div>
+      <h2>Deposit Request {opening.id}</h2>
+      <p>Realtor: {opening.realtor}</p>
+      <p>Status: {opening.status}</p>
+
+      {!opening.account_number && (
+        <div>
+          <h3>Open Account</h3>
+          <input
+            placeholder="Account Number"
+            value={accountNumber}
+            onChange={e => setAccountNumber(e.target.value)}
+          />
+          <input
+            placeholder="Deposit Threshold"
+            type="number"
+            value={threshold}
+            onChange={e => setThreshold(e.target.value)}
+          />
+          <button onClick={handleOpen} disabled={!accountNumber || !threshold}>
+            Save
+          </button>
+        </div>
+      )}
+
+      {opening.account_number && (
+        <div>
+          <h3>Deposit Tracking</h3>
+          <p>Account: {opening.account_number}</p>
+          <p>
+            Received {totalDeposits} / {opening.deposit_threshold}
+          </p>
+          {opening.status !== 'completed' && (
+            <div>
+              <input
+                placeholder="Deposit Amount"
+                type="number"
+                value={deposit}
+                onChange={e => setDeposit(e.target.value)}
+              />
+              <button onClick={handleDeposit} disabled={!deposit}>
+                Record
+              </button>
+            </div>
+          )}
+        </div>
+      )}
+      {error && <p>{error}</p>}
+    </div>
+  );
+};
+
+export default DepositDetail;

--- a/dashboard/src/pages/Deposits.tsx
+++ b/dashboard/src/pages/Deposits.tsx
@@ -1,0 +1,42 @@
+import React from 'react';
+import { Link } from 'react-router-dom';
+import { useAuth } from '../auth';
+import { getPendingDeposits } from '../api';
+
+interface AccountOpening {
+  id: number;
+  realtor: string;
+  status: string;
+}
+
+const Deposits: React.FC = () => {
+  const { auth } = useAuth();
+  const [requests, setRequests] = React.useState<AccountOpening[]>([]);
+  const [error, setError] = React.useState('');
+
+  React.useEffect(() => {
+    if (auth) {
+      getPendingDeposits(auth.token)
+        .then(setRequests)
+        .catch(() => setError('Failed to load requests'));
+    }
+  }, [auth]);
+
+  return (
+    <div>
+      <h2>Deposits Queue</h2>
+      {error && <p>{error}</p>}
+      {requests.length === 0 && <p>No pending requests.</p>}
+      <ul>
+        {requests.map(r => (
+          <li key={r.id}>
+            #{r.id} - {r.realtor} - {r.status}{' '}
+            <Link to={`/deposits/${r.id}`}>Details</Link>
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+};
+
+export default Deposits;

--- a/tests/test_deposits_api.py
+++ b/tests/test_deposits_api.py
@@ -1,0 +1,56 @@
+from fastapi.testclient import TestClient
+from app.main import app
+from app.database import drop_db, init_db
+
+client = TestClient(app)
+
+def setup_function(_):
+    drop_db()
+    init_db()
+
+def register_users():
+    client.post("/agents", json={"username": "admin", "role": "admin", "password": "admin"})
+    admin_token = client.post("/login", json={"username": "admin", "password": "admin"}).json()["token"]
+    client.post("/agents", json={"username": "agent", "role": "agent", "password": "agent"})
+    agent_token = client.post("/login", json={"username": "agent", "password": "agent"}).json()["token"]
+    return {"admin": admin_token, "agent": agent_token}
+
+def test_deposit_workflow():
+    tokens = register_users()
+    admin_headers = {"X-Token": tokens["admin"]}
+    agent_headers = {"X-Token": tokens["agent"]}
+
+    # Agent submits account opening
+    client.post("/account-openings", json={"id": 1, "realtor": "agent"}, headers=agent_headers)
+
+    # Pending deposits should list the submission
+    resp = client.get("/accounts/deposits/pending", headers=admin_headers)
+    assert resp.status_code == 200
+    data = resp.json()
+    assert len(data) == 1
+    assert data[0]["status"] == "submitted"
+
+    # Open account via deposits endpoint
+    resp = client.post(
+        "/accounts/deposits/1/open",
+        json={"account_number": "A1", "deposit_threshold": 100},
+        headers=admin_headers,
+    )
+    assert resp.status_code == 200
+    assert resp.json()["status"] == "in_progress"
+
+    # Record deposit reaching threshold
+    resp = client.post(
+        "/accounts/deposits/1/deposit",
+        json={"amount": 100},
+        headers=admin_headers,
+    )
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["status"] == "completed"
+    assert data["deposits"] == [100]
+
+    # Completed request should not appear in pending list
+    resp = client.get("/accounts/deposits/pending", headers=admin_headers)
+    assert resp.status_code == 200
+    assert resp.json() == []


### PR DESCRIPTION
## Summary
- add `/accounts/deposits` endpoints to list pending accounts and track deposits
- create React views and API helpers for deposit queue and detail
- cover deposit workflow with new unit test

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c7c9afe3c4832cab202900424279fa