### PR TITLE
Load secret key from environment

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,3 @@
+# Example environment variables for Stands
+DATABASE_URL=sqlite:///data/app.db
+SECRET_KEY=change-me

--- a/README.md
+++ b/README.md
@@ -10,10 +10,17 @@ basic status tracking and notification storage.
 pip install -r requirements.txt
 ```
 
+Create a `.env` file based on `.env.example` and set a strong value for `SECRET_KEY`.
+
+```bash
+cp .env.example .env
+# edit .env and provide a SECRET_KEY
+```
+
 ## Running
 
 ```
-uvicorn app.main:app --reload
+SECRET_KEY=your-secret-key uvicorn app.main:app --reload
 ```
 
 Interactive docs will be available at `http://127.0.0.1:8000/docs`.
@@ -50,6 +57,7 @@ docker compose up --build
 ```
 
 This builds the image from the included `Dockerfile`, starts the `web` service on port 8000, and persists the SQLite database using a named volume (`sqlite_data`) mounted at `/app/data`. The environment variable `DATABASE_URL=sqlite:///data/app.db` is provided to the container.
+The `SECRET_KEY` used for JWT signing is also read from the environment.
 
 ## Authentication
 

--- a/app/main.py
+++ b/app/main.py
@@ -8,6 +8,7 @@ import hmac
 import csv
 import base64
 import uuid
+import os
 from io import BytesIO
 import jwt
 from pydantic import BaseModel
@@ -55,7 +56,7 @@ from .models import (
     UploadedFile,
 )
 
-SECRET_KEY = "changeme"
+SECRET_KEY = os.environ["SECRET_KEY"]
 
 app = FastAPI(title="Property Management API")
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,6 +5,7 @@ services:
       - "8000:8000"
     environment:
       DATABASE_URL: "sqlite:///data/app.db"
+      SECRET_KEY: "${SECRET_KEY}"
     volumes:
       - sqlite_data:/app/data
 volumes:


### PR DESCRIPTION
## Summary
- Read SECRET_KEY from the environment instead of a hard-coded value.
- Document SECRET_KEY usage in README and provide a `.env.example`.
- Pass SECRET_KEY into the container via docker-compose.

## Testing
- `pip install -r requirements.txt`
- `SECRET_KEY=testing pytest`


------
https://chatgpt.com/codex/tasks/task_e_68c7ee633240832c959a6ce39b6a03d2