### PR TITLE
Initialize DB on startup and update tests

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -70,7 +70,11 @@ app.add_middleware(
     allow_methods=["*"],
     allow_headers=["*"],
 )
-init_db()
+
+
+@app.on_event("startup")
+def on_startup() -> None:
+    init_db()
 
 
 def get_repositories(session=Depends(get_session)) -> Repositories:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,17 @@
+import os
+import sys
+sys.path.append('.')
+
+import pytest
+from fastapi.testclient import TestClient
+
+os.environ.setdefault("SECRET_KEY", "test")
+
+from app.main import app
+
+
+@pytest.fixture()
+def client() -> TestClient:
+    with TestClient(app) as c:
+        yield c
+

--- a/tests/test_agent_roles.py
+++ b/tests/test_agent_roles.py
@@ -1,11 +1,7 @@
 import sys
 sys.path.append('.')
 
-from fastapi.testclient import TestClient
-from app.main import app
 from app.database import drop_db, init_db
-
-client = TestClient(app)
 
 
 def setup_function():
@@ -13,8 +9,10 @@ def setup_function():
     init_db()
 
 
-def test_unknown_role_rejected():
-    resp = client.post("/agents", json={"username": "bad", "role": "ghost", "password": "x"})
+def test_unknown_role_rejected(client):
+    resp = client.post(
+        "/agents", json={"username": "bad", "role": "ghost", "password": "x"}
+    )
     assert resp.status_code == 422
     detail = resp.json()["detail"]
     assert detail and "Input should" in detail[0]["msg"]

--- a/tests/test_agreements.py
+++ b/tests/test_agreements.py
@@ -1,16 +1,13 @@
 import sys
 sys.path.append(".")
 
-from fastapi.testclient import TestClient
-from app.main import app
 from app.models import PropertyStatus
 from app.database import drop_db, init_db
 
-client = TestClient(app)
 
-
-def setup_data():
+def setup_data(client):
     reset_state()
+
     def create_and_login(username, role, headers=None):
         client.post(
             "/agents",
@@ -61,8 +58,8 @@ def reset_state():
     init_db()
 
 
-def test_agreement_flow():
-    admin_headers, realtor_headers, intruder_headers = setup_data()
+def test_agreement_flow(client):
+    admin_headers, realtor_headers, intruder_headers = setup_data(client)
 
     resp = client.post(
         "/agreements",

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -1,13 +1,8 @@
 import sys
-
 sys.path.append(".")
 
-from fastapi.testclient import TestClient
-from app.main import app
 from app.models import PropertyStatus
 from app.database import drop_db, init_db
-
-client = TestClient(app)
 
 
 def setup_function():
@@ -15,7 +10,7 @@ def setup_function():
     init_db()
 
 
-def test_auth_mandate_and_available_view():
+def test_auth_mandate_and_available_view(client):
     # register agents
     resp = client.post(
         "/agents", json={"username": "admin", "role": "admin", "password": "a"}

--- a/tests/test_application_uploads.py
+++ b/tests/test_application_uploads.py
@@ -1,14 +1,10 @@
 import sys
 sys.path.append('.')
 
-from fastapi.testclient import TestClient
-from app.main import app
 from app.database import drop_db, init_db
 
-client = TestClient(app)
 
-
-def setup_agents():
+def setup_agents(client):
     drop_db()
     init_db()
     client.post(
@@ -29,8 +25,8 @@ def setup_agents():
     return {"admin": admin_token, "realtor": realtor_token}
 
 
-def test_upload_applications():
-    tokens = setup_agents()
+def test_upload_applications(client):
+    tokens = setup_agents(client)
     realtor_headers = {"Authorization": f"Bearer {tokens['realtor']}"}
 
     files = {"file": ("offer.pdf", b"data", "application/pdf")}

--- a/tests/test_dashboard.py
+++ b/tests/test_dashboard.py
@@ -1,11 +1,7 @@
 import sys
 sys.path.append('.')
 
-from fastapi.testclient import TestClient
-from app.main import app
 from app.database import drop_db, init_db
-
-client = TestClient(app)
 
 
 def reset_state():
@@ -13,7 +9,7 @@ def reset_state():
     init_db()
 
 
-def register_agents():
+def register_agents(client):
     creds = {
         "admin": "admin",
         "manager": "manager",
@@ -43,7 +39,7 @@ def register_agents():
     return tokens
 
 
-def setup_data(admin_headers, agent_headers):
+def setup_data(client, admin_headers, agent_headers):
     project = {"id": 100, "name": "Proj"}
     client.post("/projects", json=project, headers=admin_headers)
     stand = {"id": 100, "project_id": 100, "name": "Stand1", "size": 100, "price": 1000}
@@ -86,15 +82,15 @@ def setup_data(admin_headers, agent_headers):
     )
 
 
-def test_dashboards_and_audit_log():
+def test_dashboards_and_audit_log(client):
     reset_state()
-    tokens = register_agents()
+    tokens = register_agents(client)
     admin_headers = {"Authorization": f"Bearer {tokens['admin']}"}
     manager_headers = {"Authorization": f"Bearer {tokens['manager']}"}
     compliance_headers = {"Authorization": f"Bearer {tokens['compliance']}"}
     agent_headers = {"Authorization": f"Bearer {tokens['agentA']}"}
 
-    setup_data(admin_headers, agent_headers)
+    setup_data(client, admin_headers, agent_headers)
 
     resp = client.get("/dashboard", headers=manager_headers)
     assert resp.status_code == 200

--- a/tests/test_deposits_api.py
+++ b/tests/test_deposits_api.py
@@ -1,14 +1,13 @@
-from fastapi.testclient import TestClient
-from app.main import app
-from app.database import drop_db, init_db
+import sys
+sys.path.append('.')
 
-client = TestClient(app)
+from app.database import drop_db, init_db
 
 def setup_function(_):
     drop_db()
     init_db()
 
-def register_users():
+def register_users(client):
     client.post("/agents", json={"username": "admin", "role": "admin", "password": "admin"})
     admin_token = client.post(
         "/auth/login", json={"username": "admin", "password": "admin"}
@@ -24,8 +23,8 @@ def register_users():
     ).json()["token"]
     return {"admin": admin_token, "agent": agent_token}
 
-def test_deposit_workflow():
-    tokens = register_users()
+def test_deposit_workflow(client):
+    tokens = register_users(client)
     admin_headers = {"Authorization": f"Bearer {tokens['admin']}"}
     agent_headers = {"Authorization": f"Bearer {tokens['agent']}"}
 

--- a/tests/test_import.py
+++ b/tests/test_import.py
@@ -1,14 +1,14 @@
 import sys
+import sys
 sys.path.append('.')
 
-from fastapi.testclient import TestClient
-from app.main import app
+import pytest
+
 from app.database import drop_db, init_db
 
-client = TestClient(app)
 
-
-def setup_function():
+@pytest.fixture()
+def admin_headers(client):
     drop_db()
     init_db()
     client.post(
@@ -17,11 +17,10 @@ def setup_function():
     token = client.post(
         "/auth/login", json={"username": "admin", "password": "a"}
     ).json()["token"]
-    global admin_headers
-    admin_headers = {"Authorization": f"Bearer {token}"}
+    return {"Authorization": f"Bearer {token}"}
 
 
-def test_import_csv_with_errors():
+def test_import_csv_with_errors(client, admin_headers):
     csv_content = (
         "project_id,project_name,stand_id,stand_name,size,price\n"
         "1,Proj,1,Stand1,100,1000\n"

--- a/tests/test_loans_api.py
+++ b/tests/test_loans_api.py
@@ -1,15 +1,11 @@
 import sys
 sys.path.append('.')
 
-from fastapi.testclient import TestClient
-from app.main import app
 from app.database import drop_db, init_db
 from app.models import LoanStatus
 
-client = TestClient(app)
 
-
-def setup_agents():
+def setup_agents(client):
     drop_db()
     init_db()
     client.post(
@@ -30,8 +26,8 @@ def setup_agents():
     return {"admin": admin_token, "user": user_token}
 
 
-def test_loan_flow():
-    tokens = setup_agents()
+def test_loan_flow(client):
+    tokens = setup_agents(client)
     admin_headers = {"Authorization": f"Bearer {tokens['admin']}"}
     user_headers = {"Authorization": f"Bearer {tokens['user']}"}
 

--- a/tests/test_projects_api.py
+++ b/tests/test_projects_api.py
@@ -1,11 +1,7 @@
 import sys
 sys.path.append('.')
 
-from fastapi.testclient import TestClient
-from app.main import app
 from app.database import drop_db, init_db
-
-client = TestClient(app)
 
 
 def setup_function():
@@ -13,7 +9,7 @@ def setup_function():
     init_db()
 
 
-def auth_headers(username: str):
+def auth_headers(client, username: str):
     client.post(
         "/agents",
         json={"username": username, "role": "admin", "password": username},
@@ -24,8 +20,8 @@ def auth_headers(username: str):
     return {"Authorization": f"Bearer {token}"}
 
 
-def test_project_and_stand_crud():
-    headers = auth_headers("admin")
+def test_project_and_stand_crud(client):
+    headers = auth_headers(client, "admin")
 
     # create project
     project = {"id": 1, "name": "P"}

--- a/tests/test_reporting.py
+++ b/tests/test_reporting.py
@@ -1,13 +1,8 @@
-import sys
 import csv
-
+import sys
 sys.path.append('.')
 
-from fastapi.testclient import TestClient
-from app.main import app
 from app.database import drop_db, init_db
-
-client = TestClient(app)
 
 
 def setup_function():
@@ -15,7 +10,7 @@ def setup_function():
     init_db()
 
 
-def setup_data():
+def setup_data(client):
     client.post("/agents", json={"username": "admin", "role": "admin", "password": "a"})
     admin_token = client.post("/auth/login", json={"username": "admin", "password": "a"}).json()["token"]
     admin_headers = {"Authorization": f"Bearer {admin_token}"}
@@ -67,8 +62,8 @@ def setup_data():
     return admin_headers
 
 
-def test_report_headers_and_rows():
-    admin_headers = setup_data()
+def test_report_headers_and_rows(client):
+    admin_headers = setup_data(client)
     resp = client.get("/reports/properties", headers=admin_headers)
     assert resp.status_code == 200
     lines = resp.text.strip().splitlines()
@@ -82,8 +77,8 @@ def test_report_headers_and_rows():
     assert row["mandate_status"] == "accepted"
 
 
-def test_report_filtering():
-    admin_headers = setup_data()
+def test_report_filtering(client):
+    admin_headers = setup_data(client)
     resp = client.get("/reports/properties?status=sold", headers=admin_headers)
     assert resp.status_code == 200
     data = list(csv.DictReader(resp.text.splitlines()))
@@ -91,8 +86,8 @@ def test_report_filtering():
     assert data[0]["status"] == "sold"
 
 
-def test_mandate_and_loan_reports():
-    admin_headers = setup_data()
+def test_mandate_and_loan_reports(client):
+    admin_headers = setup_data(client)
     resp = client.get("/reports/mandates", headers=admin_headers)
     assert resp.status_code == 200
     data = list(csv.DictReader(resp.text.splitlines()))

--- a/tests/test_submissions.py
+++ b/tests/test_submissions.py
@@ -1,15 +1,11 @@
 import sys
 sys.path.append(".")
 
-from fastapi.testclient import TestClient
-from app.main import app
 from app.models import SubmissionStatus
 from app.database import drop_db, init_db
 
-client = TestClient(app)
 
-
-def setup_agents():
+def setup_agents(client):
     drop_db()
     init_db()
     client.post(
@@ -30,8 +26,8 @@ def setup_agents():
     return {"admin": admin_token, "realtor": realtor_token}
 
 
-def test_submissions_and_status_updates():
-    tokens = setup_agents()
+def test_submissions_and_status_updates(client):
+    tokens = setup_agents(client)
     admin_headers = {"Authorization": f"Bearer {tokens['admin']}"}
     realtor_headers = {"Authorization": f"Bearer {tokens['realtor']}"}
 
@@ -81,8 +77,8 @@ def test_submissions_and_status_updates():
     assert resp.json()["status"] == SubmissionStatus.COMPLETED.value
 
 
-def test_account_opening_deposit_tracking():
-    tokens = setup_agents()
+def test_account_opening_deposit_tracking(client):
+    tokens = setup_agents(client)
     admin_headers = {"Authorization": f"Bearer {tokens['admin']}"}
     realtor_headers = {"Authorization": f"Bearer {tokens['realtor']}"}
 
@@ -116,8 +112,8 @@ def test_account_opening_deposit_tracking():
     assert resp.json()["status"] == SubmissionStatus.COMPLETED.value
 
 
-def test_loan_application_flow():
-    tokens = setup_agents()
+def test_loan_application_flow(client):
+    tokens = setup_agents(client)
     admin_headers = {"Authorization": f"Bearer {tokens['admin']}"}
     realtor_headers = {"Authorization": f"Bearer {tokens['realtor']}"}
 
@@ -197,8 +193,8 @@ def test_loan_application_flow():
     assert resp.json()["reason"] == "Insufficient credit"
 
 
-def test_account_opening_queue_listing():
-    tokens = setup_agents()
+def test_account_opening_queue_listing(client):
+    tokens = setup_agents(client)
     admin_headers = {"Authorization": f"Bearer {tokens['admin']}"}
     realtor_headers = {"Authorization": f"Bearer {tokens['realtor']}"}
 
@@ -234,8 +230,8 @@ def test_account_opening_queue_listing():
     assert ids == {10, 20}
 
 
-def test_loan_application_queue_listing_and_agreement_generation():
-    tokens = setup_agents()
+def test_loan_application_queue_listing_and_agreement_generation(client):
+    tokens = setup_agents(client)
     admin_headers = {"Authorization": f"Bearer {tokens['admin']}"}
     realtor_headers = {"Authorization": f"Bearer {tokens['realtor']}"}
 


### PR DESCRIPTION
## Summary
- initialize DB using a FastAPI startup event
- add test client fixture to trigger startup events
- update tests to rely on the fixture

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68c7f31b12f4832c819bcbdb57dd15af