### PR TITLE
Ensure data directory exists in image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,6 +16,7 @@ COPY --from=builder /usr/local /usr/local
 COPY app/ ./app
 
 RUN adduser --disabled-password --gecos "" appuser && chown -R appuser /app
+RUN mkdir -p data && chown -R appuser:appuser data
 USER appuser
 
 EXPOSE 8000


### PR DESCRIPTION
## Summary
- ensure the image creates /app/data and assigns ownership to appuser before switching users so sqlite can be created at runtime

## Testing
- docker compose build --no-cache *(fails: docker not installed in execution environment)*
- python - <<'PY'
from app.database import init_db
init_db()
PY

------
https://chatgpt.com/codex/tasks/task_e_68c84fc81554832c8509232452bf47db