### PR TITLE
Support configurable frontend CORS origins

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,10 +20,15 @@ cp .env.example .env
 ## Running
 
 ```
-SECRET_KEY=your-secret-key uvicorn app.main:app --reload
+SECRET_KEY=your-secret-key \
+FRONTEND_ORIGINS="http://localhost:5173" \
+uvicorn app.main:app --reload
 ```
 
 Interactive docs will be available at `http://127.0.0.1:8000/docs`.
+
+Set `FRONTEND_ORIGINS` to a comma-separated list of allowed origins if your frontend runs somewhere other than
+`http://localhost:5173`.
 
 ## Admin Dashboard
 
@@ -60,7 +65,8 @@ docker compose up --build
 ```
 
 This builds the image from the included `Dockerfile`, starts the `web` service on port 8000, and persists the SQLite database using a named volume (`sqlite_data`) mounted at `/app/data`. The environment variable `DATABASE_URL=sqlite:///data/app.db` is provided to the container.
-The `SECRET_KEY` used for JWT signing is also read from the environment.
+The `SECRET_KEY` used for JWT signing is also read from the environment. Use `FRONTEND_ORIGINS` to expose a comma-separated list
+of allowed CORS origins (defaults to `http://localhost:5173`).
 
 ## Authentication
 

--- a/app/main.py
+++ b/app/main.py
@@ -9,6 +9,7 @@ import csv
 import base64
 import uuid
 import os
+import logging
 from io import BytesIO
 import jwt
 from passlib.context import CryptContext
@@ -57,7 +58,22 @@ from .models import (
     UploadedFile,
 )
 
+logger = logging.getLogger(__name__)
+
+DEFAULT_FRONTEND_ORIGINS = ["http://localhost:5173"]
+
+
+def resolve_frontend_origins() -> List[str]:
+    raw_origins = os.environ.get("FRONTEND_ORIGINS")
+    if not raw_origins:
+        return DEFAULT_FRONTEND_ORIGINS.copy()
+    parsed_origins = [origin.strip() for origin in raw_origins.split(",") if origin.strip()]
+    return parsed_origins or DEFAULT_FRONTEND_ORIGINS.copy()
+
+
 SECRET_KEY = os.environ["SECRET_KEY"]
+
+FRONTEND_ORIGINS = resolve_frontend_origins()
 
 pwd_context = CryptContext(schemes=["bcrypt"], deprecated="auto")
 
@@ -65,7 +81,7 @@ app = FastAPI(title="Property Management API")
 
 app.add_middleware(
     CORSMiddleware,
-    allow_origins=["http://localhost:5173"],
+    allow_origins=FRONTEND_ORIGINS,
     allow_credentials=True,
     allow_methods=["*"],
     allow_headers=["*"],
@@ -74,6 +90,7 @@ app.add_middleware(
 
 @app.on_event("startup")
 def on_startup() -> None:
+    logger.info("Configured frontend origins: %s", ", ".join(FRONTEND_ORIGINS))
     init_db()
 
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,6 +8,7 @@ services:
     environment:
       DATABASE_URL: "sqlite:///data/app.db"
       SECRET_KEY: "${SECRET_KEY}"
+      FRONTEND_ORIGINS: "${FRONTEND_ORIGINS:-http://localhost:5173}"
     volumes:
       - sqlite_data:/app/data
 volumes:


### PR DESCRIPTION
## Summary
- allow configuring CORS origins through the `FRONTEND_ORIGINS` environment variable and log the resolved value on startup
- document the new variable and propagate it through Docker Compose for container deployments

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68c9ae5031a8832cb17042929d36e2ca