### PR TITLE
Add Dockerized dashboard build and compose frontend service

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ npm run dev
 The dev server proxies API requests to the FastAPI backend using the `/api` prefix.
 Set `VITE_API_PROXY_TARGET` to control where that proxy points (defaults to `http://localhost:8000`).
 Client requests use the `VITE_API_BASE` prefix (defaults to `/api`), which lets the dashboard talk to a backend hosted elsewhere.
-When running with Docker Compose, set `VITE_API_PROXY_TARGET=http://web:8000` so the proxy reaches the existing `web` service container.
+When running the dev server against Docker Compose, set `VITE_API_PROXY_TARGET=http://web:8000` so the proxy reaches the existing `web` service container.
 
 ## Importing Projects and Stands
 
@@ -58,15 +58,21 @@ Rows missing required fields are reported with clear error messages and skipped.
 
 ## Docker Compose
 
-To build and run the application with Docker Compose:
+To build and run the API and dashboard together with Docker Compose:
 
 ```bash
 docker compose up --build
 ```
 
-This builds the image from the included `Dockerfile`, starts the `web` service on port 8000, and persists the SQLite database using a named volume (`sqlite_data`) mounted at `/app/data`. The environment variable `DATABASE_URL=sqlite:///data/app.db` is provided to the container.
-The `SECRET_KEY` used for JWT signing is also read from the environment. Use `FRONTEND_ORIGINS` to expose a comma-separated list
-of allowed CORS origins (defaults to `http://localhost:5173`).
+This builds the FastAPI backend from the repository root and the production dashboard image defined in `dashboard/Dockerfile`.
+Once the containers are running you can reach:
+
+- Dashboard: <http://localhost:8080>
+- API: <http://localhost:8000> (interactive docs at <http://localhost:8000/docs>)
+
+The backend persists the SQLite database using the named volume `sqlite_data` mounted at `/app/data` and reads environment values from `.env`.
+By default it allows requests from both `http://localhost:8080` and `http://localhost:5173` so the static dashboard and the Vite dev server can call the API.
+The frontend image is built with `VITE_API_BASE=http://web:8000`, which points API calls from the bundled code to the backend service on the Docker network.
 
 ## Authentication
 

--- a/dashboard/Dockerfile
+++ b/dashboard/Dockerfile
@@ -1,0 +1,19 @@
+# syntax=docker/dockerfile:1
+
+FROM node:20-alpine AS build
+WORKDIR /app
+
+# Install dependencies
+COPY package*.json ./
+RUN npm ci
+
+# Build the production bundle
+COPY . .
+ARG VITE_API_BASE=http://localhost:8000
+ENV VITE_API_BASE=$VITE_API_BASE
+RUN npm run build
+
+FROM nginx:alpine AS production
+COPY --from=build /app/dist /usr/share/nginx/html
+EXPOSE 80
+CMD ["nginx", "-g", "daemon off;"]

--- a/dashboard/src/pages/Projects.tsx
+++ b/dashboard/src/pages/Projects.tsx
@@ -1,6 +1,9 @@
 import React from 'react';
 import { useAuth } from '../auth';
-import { useProjects, createProject } from '../../frontend/src/api/projects';
+import {
+  getProjects as fetchProjects,
+  createProject as createProjectRequest,
+} from '../api';
 
 interface Project {
   id: number;
@@ -9,9 +12,19 @@ interface Project {
 
 const Projects: React.FC = () => {
   const { auth } = useAuth();
-  const { projects, setProjects } = useProjects(auth?.token);
+  const [projects, setProjects] = React.useState<Project[]>([]);
   const [search, setSearch] = React.useState('');
   const [form, setForm] = React.useState({ id: '', name: '' });
+
+  React.useEffect(() => {
+    if (!auth?.token) {
+      setProjects([]);
+      return;
+    }
+    fetchProjects(auth.token)
+      .then(data => setProjects(data))
+      .catch(console.error);
+  }, [auth?.token]);
 
   const filtered = projects.filter(p => p.name.toLowerCase().includes(search.toLowerCase()));
 
@@ -19,8 +32,8 @@ const Projects: React.FC = () => {
     e.preventDefault();
     if (!form.id || !form.name || !auth) return;
     try {
-      const project = await createProject(auth.token, { id: Number(form.id), name: form.name });
-      setProjects([...projects, project]);
+      const project = await createProjectRequest(auth.token, { id: Number(form.id), name: form.name });
+      setProjects(prev => [...prev, project]);
       setForm({ id: '', name: '' });
     } catch (err) {
       console.error(err);

--- a/dashboard/src/pages/Stands.tsx
+++ b/dashboard/src/pages/Stands.tsx
@@ -1,10 +1,10 @@
 import React from 'react';
 import { useAuth } from '../auth';
 import {
-  useProjectStands,
-  createStand as createProjectStand,
-  deleteStand as deleteProjectStand,
-} from '../../frontend/src/api/projects';
+  getStands as fetchStands,
+  createStand as createStandRequest,
+  deleteStand as deleteStandRequest,
+} from '../api';
 
 interface Stand {
   id: number;
@@ -17,14 +17,30 @@ interface Stand {
 const Stands: React.FC = () => {
   const { auth } = useAuth();
   const [projectFilter, setProjectFilter] = React.useState('');
-  const { stands, setStands } = useProjectStands(
-    auth?.token,
-    projectFilter ? Number(projectFilter) : undefined,
-  );
+  const [stands, setStands] = React.useState<Stand[]>([]);
   const [search, setSearch] = React.useState('');
   const [form, setForm] = React.useState({ id: '', project_id: '', name: '', size: '', price: '' });
 
-  const filtered = stands.filter(s => s.name.toLowerCase().includes(search.toLowerCase()));
+  const projectIdFilter = projectFilter.trim();
+
+  React.useEffect(() => {
+    if (!auth?.token) {
+      setStands([]);
+      return;
+    }
+    fetchStands(auth.token)
+      .then(data => setStands(data))
+      .catch(console.error);
+  }, [auth?.token]);
+
+  const filtered = stands
+    .filter(stand => {
+      if (!projectIdFilter) return true;
+      const parsed = Number(projectIdFilter);
+      if (Number.isNaN(parsed)) return true;
+      return stand.project_id === parsed;
+    })
+    .filter(s => s.name.toLowerCase().includes(search.toLowerCase()));
 
   const submit = async (e: React.FormEvent) => {
     e.preventDefault();
@@ -37,8 +53,8 @@ const Stands: React.FC = () => {
       price: Number(form.price),
     };
     try {
-      const stand = await createProjectStand(auth.token, payload.project_id, payload);
-      setStands([...stands, stand]);
+      const stand = await createStandRequest(auth.token, payload);
+      setStands(prev => [...prev, stand]);
       setForm({ id: '', project_id: '', name: '', size: '', price: '' });
     } catch (err) {
       console.error(err);
@@ -50,8 +66,8 @@ const Stands: React.FC = () => {
     try {
       const stand = stands.find(s => s.id === id);
       if (!stand) return;
-      await deleteProjectStand(auth.token, stand.project_id, id);
-      setStands(stands.filter(s => s.id !== id));
+      await deleteStandRequest(auth.token, id);
+      setStands(prev => prev.filter(s => s.id !== id));
     } catch (err) {
       console.error(err);
     }

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,8 +8,17 @@ services:
     environment:
       DATABASE_URL: "sqlite:///data/app.db"
       SECRET_KEY: "${SECRET_KEY}"
-      FRONTEND_ORIGINS: "${FRONTEND_ORIGINS:-http://localhost:5173}"
+      FRONTEND_ORIGINS: "${FRONTEND_ORIGINS:-http://localhost:8080,http://localhost:5173}"
     volumes:
       - sqlite_data:/app/data
+  frontend:
+    build:
+      context: ./dashboard
+      args:
+        VITE_API_BASE: http://web:8000
+    ports:
+      - "8080:80"
+    depends_on:
+      - web
 volumes:
   sqlite_data:


### PR DESCRIPTION
## Summary
- add a multi-stage Dockerfile that builds the dashboard bundle and serves it from nginx
- extend docker-compose with a frontend service, wiring the API base URL and updated CORS defaults
- point dashboard pages at local API helpers and document the compose workflow for the UI and API

## Testing
- npm run build
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68c9b1e73408832ca6c6d2f201c05d9f