### PR TITLE
Ensure login requests use API helper

### DIFF
--- a/dashboard/src/api.ts
+++ b/dashboard/src/api.ts
@@ -6,6 +6,16 @@ const apiUrl = (path: string) => {
   return `${normalizedBase}${normalizedPath}`;
 };
 
+export async function login(credentials: { username: string; password: string }) {
+  const res = await fetch(apiUrl('/auth/login'), {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(credentials),
+  });
+  if (!res.ok) throw new Error('Login failed');
+  return res.json();
+}
+
 export const headers = (token: string) => ({
   'Content-Type': 'application/json',
   Authorization: `Bearer ${token}`,

--- a/dashboard/src/pages/Login.tsx
+++ b/dashboard/src/pages/Login.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import { useAuth } from '../auth';
 import { useNavigate } from 'react-router-dom';
+import { login as loginRequest } from '../api';
 
 const Login: React.FC = () => {
   const { login } = useAuth();
@@ -13,13 +14,7 @@ const Login: React.FC = () => {
     e.preventDefault();
     setError('');
     try {
-      const res = await fetch('/login', {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ username, password }),
-      });
-      if (!res.ok) throw new Error('Login failed');
-      const data = await res.json();
+      const data = await loginRequest({ username, password });
       login(data.token, data.role, data.username);
       if (data.role === 'agent') {
         navigate('/dashboard');


### PR DESCRIPTION
## Summary
- add a login helper that posts credentials to the auth endpoint through `apiUrl`
- update the login page to use the helper so requests honor `VITE_API_BASE`

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68c9b5893c00832ca1705e54fd18f581