### PR TITLE
Add API helper for report downloads and update dashboards

### DIFF
--- a/dashboard/src/api.ts
+++ b/dashboard/src/api.ts
@@ -21,6 +21,16 @@ export const headers = (token: string) => ({
   Authorization: `Bearer ${token}`,
 });
 
+export async function downloadReport(token: string, report: string, format: string) {
+  const query = new URLSearchParams({ format }).toString();
+  const path = `/reports/${encodeURIComponent(report)}`;
+  const res = await fetch(apiUrl(`${path}?${query}`), {
+    headers: { Authorization: `Bearer ${token}` },
+  });
+  if (!res.ok) throw new Error('Failed to download report');
+  return res.blob();
+}
+
 export async function getDashboard(token: string) {
   const res = await fetch(apiUrl('/dashboard'), { headers: headers(token) });
   if (!res.ok) throw new Error('Failed to load dashboard');

--- a/dashboard/src/pages/AdminDashboard.tsx
+++ b/dashboard/src/pages/AdminDashboard.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { useAuth } from '../auth';
-import { getDashboard } from '../api';
+import { downloadReport, getDashboard } from '../api';
 
 const AdminDashboard: React.FC = () => {
   const { auth } = useAuth();
@@ -14,9 +14,33 @@ const AdminDashboard: React.FC = () => {
 
   if (!auth) return null;
 
-  const exportReport = (report: string, format: string) => {
-    window.location.href = `/reports/${report}?format=${format}`;
-  };
+  const exportReport = React.useCallback(
+    async (report: string, format: string) => {
+      if (!auth) return;
+      let objectUrl: string | null = null;
+      let link: HTMLAnchorElement | null = null;
+      try {
+        const blob = await downloadReport(auth.token, report, format);
+        objectUrl = URL.createObjectURL(blob);
+        const extension = format === 'excel' ? 'xlsx' : format;
+        link = document.createElement('a');
+        link.href = objectUrl;
+        link.download = `${report}.${extension}`;
+        document.body.appendChild(link);
+        link.click();
+      } catch (error) {
+        console.error('Failed to export report', error);
+      } finally {
+        if (link && document.body.contains(link)) {
+          document.body.removeChild(link);
+        }
+        if (objectUrl) {
+          URL.revokeObjectURL(objectUrl);
+        }
+      }
+    },
+    [auth],
+  );
 
   return (
     <div>

--- a/dashboard/src/pages/ComplianceDashboard.tsx
+++ b/dashboard/src/pages/ComplianceDashboard.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { useAuth } from '../auth';
-import { getDashboard, getAuditLog } from '../api';
+import { downloadReport, getAuditLog, getDashboard } from '../api';
 
 const ComplianceDashboard: React.FC = () => {
   const { auth } = useAuth();
@@ -27,9 +27,33 @@ const ComplianceDashboard: React.FC = () => {
 
   if (!auth) return null;
 
-  const exportReport = (report: string, format: string) => {
-    window.location.href = `/reports/${report}?format=${format}`;
-  };
+  const exportReport = React.useCallback(
+    async (report: string, format: string) => {
+      if (!auth) return;
+      let objectUrl: string | null = null;
+      let link: HTMLAnchorElement | null = null;
+      try {
+        const blob = await downloadReport(auth.token, report, format);
+        objectUrl = URL.createObjectURL(blob);
+        const extension = format === 'excel' ? 'xlsx' : format;
+        link = document.createElement('a');
+        link.href = objectUrl;
+        link.download = `${report}.${extension}`;
+        document.body.appendChild(link);
+        link.click();
+      } catch (error) {
+        console.error('Failed to export report', error);
+      } finally {
+        if (link && document.body.contains(link)) {
+          document.body.removeChild(link);
+        }
+        if (objectUrl) {
+          URL.revokeObjectURL(objectUrl);
+        }
+      }
+    },
+    [auth],
+  );
 
   return (
     <div>


### PR DESCRIPTION
## Summary
- add a shared `downloadReport` helper that fetches reports with authorization and returns a Blob
- update the admin and compliance dashboards to use the helper and trigger downloads via temporary object URLs
- revoke temporary URLs after use to prevent memory leaks

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68c9b621ce6c832cb32d51abd9a43061