### PR TITLE
Handle non-sqlite database URLs

### DIFF
--- a/app/database.py
+++ b/app/database.py
@@ -9,8 +9,9 @@ DATABASE_URL = os.getenv("DATABASE_URL", "sqlite:///data/app.db")
 if DATABASE_URL.startswith("sqlite:///"):
     db_path = Path(DATABASE_URL.replace("sqlite:///", ""))
     db_path.parent.mkdir(parents=True, exist_ok=True)
-
-engine = create_engine(DATABASE_URL, connect_args={"check_same_thread": False})
+    engine = create_engine(DATABASE_URL, connect_args={"check_same_thread": False})
+else:
+    engine = create_engine(DATABASE_URL)
 SessionLocal = sessionmaker(bind=engine, autoflush=False, autocommit=False)
 Base = declarative_base()
 

--- a/tests/test_database.py
+++ b/tests/test_database.py
@@ -1,0 +1,28 @@
+import importlib
+import sys
+
+
+def test_non_sqlite_database_url_omits_sqlite_args(monkeypatch):
+    """Ensure non-SQLite URLs do not receive SQLite-specific connect args."""
+
+    monkeypatch.setenv("DATABASE_URL", "postgresql://user:pass@localhost/db")
+
+    # Ensure a clean import for the module under test.
+    sys.modules.pop("app.database", None)
+
+    recorded_kwargs = {}
+
+    def fake_create_engine(url, **kwargs):  # pragma: no cover - trivial
+        recorded_kwargs.update(kwargs)
+        if "connect_args" in kwargs:
+            raise TypeError("connect_args should not be provided for non-SQLite URLs")
+        return object()
+
+    monkeypatch.setattr("sqlalchemy.create_engine", fake_create_engine)
+
+    importlib.import_module("app.database")
+
+    assert "connect_args" not in recorded_kwargs
+
+    # Allow subsequent imports to load the real module.
+    sys.modules.pop("app.database", None)


### PR DESCRIPTION
## Summary
- only apply SQLite-specific engine options when the database URL uses the sqlite scheme
- add a regression test ensuring non-SQLite URLs do not receive SQLite-only connect args

## Testing
- pytest tests/test_database.py

------
https://chatgpt.com/codex/tasks/task_e_68ca4126c608832c96aacef1ae5373a5