### PR TITLE
Prevent deleting projects with stands

### DIFF
--- a/app/projects.py
+++ b/app/projects.py
@@ -33,6 +33,12 @@ class ProjectsService:
         project = self.repos.projects.get(project_id)
         if not project:
             raise HTTPException(status_code=404, detail="Project not found")
+        stands = [s for s in self.repos.stands.list() if s.project_id == project_id]
+        if stands:
+            raise HTTPException(
+                status_code=400,
+                detail="Cannot delete project with existing stands",
+            )
         self.repos.projects.delete(project_id)
         return project
 

--- a/tests/test_projects_api.py
+++ b/tests/test_projects_api.py
@@ -57,3 +57,23 @@ def test_project_and_stand_crud(client):
     # delete project
     resp = client.delete("/projects/1", headers=headers)
     assert resp.status_code == 200
+
+
+def test_delete_project_with_existing_stands_rejected(client):
+    headers = auth_headers(client, "admin")
+
+    project = {"id": 1, "name": "P"}
+    resp = client.post("/projects", json=project, headers=headers)
+    assert resp.status_code == 200
+
+    stand = {"id": 10, "project_id": 1, "name": "S", "size": 10, "price": 100}
+    resp = client.post("/projects/1/stands", json=stand, headers=headers)
+    assert resp.status_code == 200
+
+    resp = client.delete("/projects/1", headers=headers)
+    assert resp.status_code == 400
+    assert resp.json()["detail"] == "Cannot delete project with existing stands"
+
+    resp = client.get("/projects/1/stands", headers=headers)
+    assert resp.status_code == 200
+    assert len(resp.json()) == 1


### PR DESCRIPTION
## Summary
- block project deletion when associated stands still exist
- add API test covering the rejected deletion case

## Testing
- pytest tests/test_projects_api.py

------
https://chatgpt.com/codex/tasks/task_e_68ca41e22230832cbaac0b196625ff22