### PR TITLE
Refine request logging middleware and add regression test

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -173,11 +173,18 @@ async def log_request(request: Request, call_next):
     session = SessionLocal()
     repos = Repositories(session)
     timestamp = datetime.utcnow().isoformat()
-    response = await call_next(request)
-    repos.audit_log.append(
-        f"{timestamp} - {username} - {request.method} {request.url.path} - {response.status_code}"
-    )
-    session.close()
+    status_code = 500
+    response: Response | None = None
+    try:
+        response = await call_next(request)
+        status_code = response.status_code
+    except Exception:
+        raise
+    finally:
+        repos.audit_log.append(
+            f"{timestamp} - {username} - {request.method} {request.url.path} - {status_code}"
+        )
+        session.close()
     return response
 
 

--- a/tests/test_middleware.py
+++ b/tests/test_middleware.py
@@ -1,0 +1,63 @@
+import sys
+from typing import Set
+
+sys.path.append('.')
+
+from fastapi.testclient import TestClient
+from sqlalchemy.orm import Session, sessionmaker
+
+from app.database import Record, drop_db, init_db
+from app.main import app
+
+
+@app.get("/middleware-error")
+def trigger_middleware_error():
+    raise RuntimeError("boom")
+
+
+def test_log_request_failure_records_audit_and_closes_session(monkeypatch):
+    from app import main
+
+    drop_db()
+    init_db()
+
+    open_sessions: Set[Session] = set()
+
+    class TrackingSession(Session):
+        def __init__(self, *args, **kwargs):
+            super().__init__(*args, **kwargs)
+            open_sessions.add(self)
+
+        def close(self) -> None:  # type: ignore[override]
+            try:
+                super().close()
+            finally:
+                open_sessions.discard(self)
+
+    original_session_local = main.SessionLocal
+    tracking_session_local = sessionmaker(class_=TrackingSession, **original_session_local.kw)
+    monkeypatch.setattr(main, "SessionLocal", tracking_session_local)
+
+    with TestClient(app, raise_server_exceptions=False) as client:
+        session = tracking_session_local()
+        try:
+            session.query(Record).filter_by(store="audit_log").delete()
+            session.commit()
+        finally:
+            session.close()
+
+        response = client.get("/middleware-error")
+        assert response.status_code == 500
+
+        session = tracking_session_local()
+        try:
+            entries = [row.data for row in session.query(Record).filter_by(store="audit_log").all()]
+        finally:
+            session.close()
+
+        failure_entries = [entry for entry in entries if "/middleware-error" in entry]
+        assert failure_entries, "Expected middleware failure to be recorded in audit log"
+        assert failure_entries[-1].endswith("500"), failure_entries[-1]
+
+    assert not open_sessions, "Middleware session should be closed after request"
+


### PR DESCRIPTION
## Summary
- ensure the request logging middleware records audit entries even when an exception bubbles out and always closes its session
- default the logged status code to 500 when call_next fails so unhandled exceptions are captured
- add a middleware regression test that uses a tracking session factory to verify failure logging and that sessions are closed

## Testing
- pytest


------
https://chatgpt.com/codex/tasks/task_e_68cae58588a0832c85c5fa9314e92a71