### PR TITLE
Add bootstrap token requirement for initial agent creation

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,3 +1,4 @@
 # Example environment variables for Stands
 DATABASE_URL=sqlite:///data/app.db
 SECRET_KEY=change-me
+INITIAL_ADMIN_TOKEN=bootstrap-token

--- a/README.md
+++ b/README.md
@@ -10,7 +10,8 @@ basic status tracking and notification storage.
 pip install -r requirements.txt
 ```
 
-Create a `.env` file based on `.env.example` and set a strong value for `SECRET_KEY`.
+Create a `.env` file based on `.env.example` and set strong values for both `SECRET_KEY` and
+`INITIAL_ADMIN_TOKEN`.
 
 ```bash
 cp .env.example .env
@@ -21,6 +22,7 @@ cp .env.example .env
 
 ```
 SECRET_KEY=your-secret-key \
+INITIAL_ADMIN_TOKEN=bootstrap-token \
 FRONTEND_ORIGINS="http://localhost:5173" \
 uvicorn app.main:app --reload
 ```
@@ -76,10 +78,12 @@ The frontend image is built with `VITE_API_BASE=http://web:8000`, which points A
 
 ## Authentication
 
-Agents are created with a password hash:
+Agents are created with a password hash. The first administrator must be created with the bootstrap
+token so that deployments start with a known secret:
 
 ```
 POST /agents {"username": "alice", "role": "admin", "password": "secret"}
+X-Bootstrap-Token: <INITIAL_ADMIN_TOKEN>
 ```
 
 Log in to receive a JWT and use it in the `Authorization` header:

--- a/app/main.py
+++ b/app/main.py
@@ -72,6 +72,7 @@ def resolve_frontend_origins() -> List[str]:
 
 
 SECRET_KEY = os.environ["SECRET_KEY"]
+INITIAL_ADMIN_TOKEN = os.environ["INITIAL_ADMIN_TOKEN"]
 
 FRONTEND_ORIGINS = resolve_frontend_origins()
 
@@ -192,14 +193,21 @@ async def log_request(request: Request, call_next):
 def create_agent(
     agent: AgentCreate,
     authorization: str = Header(None),
+    bootstrap_token: str | None = Header(None, alias="X-Bootstrap-Token"),
     repos: Repositories = Depends(get_repositories),
 ):
-    if repos.agents.list():
+    existing_agents = repos.agents.list()
+    if existing_agents:
         if not authorization:
             raise HTTPException(status_code=401, detail="Missing authentication token")
         current = get_current_agent(authorization=authorization, repos=repos)
         if current.role != AgentRole.ADMIN:
             raise HTTPException(status_code=403, detail="Admin privileges required")
+    else:
+        if not bootstrap_token:
+            raise HTTPException(status_code=401, detail="Missing bootstrap token")
+        if not hmac.compare_digest(bootstrap_token, INITIAL_ADMIN_TOKEN):
+            raise HTTPException(status_code=403, detail="Invalid bootstrap token")
     if repos.agents.get(agent.username):
         raise HTTPException(status_code=400, detail="Agent exists")
     if agent.role not in AgentRole:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,6 +8,7 @@ services:
     environment:
       DATABASE_URL: "sqlite:///data/app.db"
       SECRET_KEY: "${SECRET_KEY}"
+      INITIAL_ADMIN_TOKEN: "${INITIAL_ADMIN_TOKEN}"
       FRONTEND_ORIGINS: "${FRONTEND_ORIGINS:-http://localhost:8080,http://localhost:5173}"
     volumes:
       - sqlite_data:/app/data

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -6,6 +6,7 @@ import pytest
 from fastapi.testclient import TestClient
 
 os.environ.setdefault("SECRET_KEY", "test")
+os.environ.setdefault("INITIAL_ADMIN_TOKEN", "bootstrap-token")
 
 from app.main import app
 

--- a/tests/test_agent_roles.py
+++ b/tests/test_agent_roles.py
@@ -16,3 +16,41 @@ def test_unknown_role_rejected(client):
     assert resp.status_code == 422
     detail = resp.json()["detail"]
     assert detail and "Input should" in detail[0]["msg"]
+
+
+def test_first_agent_without_bootstrap_token_fails(client):
+    resp = client.post(
+        "/agents", json={"username": "admin", "role": "admin", "password": "secret"}
+    )
+    assert resp.status_code == 401
+    assert resp.json()["detail"] == "Missing bootstrap token"
+
+
+def test_bootstrap_token_allows_first_admin_then_admin_can_create_more(client):
+    from app.main import INITIAL_ADMIN_TOKEN
+
+    resp = client.post(
+        "/agents",
+        json={"username": "admin", "role": "admin", "password": "secret"},
+        headers={"X-Bootstrap-Token": INITIAL_ADMIN_TOKEN},
+    )
+    assert resp.status_code == 200
+    payload = resp.json()
+    assert payload["username"] == "admin"
+    assert payload["role"] == "admin"
+
+    login = client.post(
+        "/auth/login", json={"username": "admin", "password": "secret"}
+    )
+    assert login.status_code == 200
+    token = login.json()["token"]
+
+    resp = client.post(
+        "/agents",
+        json={"username": "agent2", "role": "compliance", "password": "secret"},
+        headers={"Authorization": f"Bearer {token}"},
+    )
+    assert resp.status_code == 200
+    payload = resp.json()
+    assert payload["username"] == "agent2"
+    assert payload["role"] == "compliance"


### PR DESCRIPTION
## Summary
- require an INITIAL_ADMIN_TOKEN when creating the first agent and validate via the X-Bootstrap-Token header
- document the bootstrap token environment variable and propagate it to sample configs
- cover bootstrap token behaviour with new agent role tests

## Testing
- pytest tests/test_agent_roles.py

------
https://chatgpt.com/codex/tasks/task_e_68cafaa61b3c832cb3a3c877f9440d3f