### PR TITLE
Implement auto-assigned IDs for projects and stands

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -26,7 +26,9 @@ from .reporting import (
 )
 from .models import (
     Project,
+    ProjectCreate,
     Stand,
+    StandCreate,
     PropertyStatus,
     Mandate,
     MandateRecord,
@@ -248,7 +250,7 @@ def login(data: LoginRequest, repos: Repositories = Depends(get_repositories)):
 
 @app.post("/projects", response_model=Project)
 def create_project(
-    project: Project,
+    project: ProjectCreate,
     _: Agent = Depends(require_admin),
     service: ProjectsService = Depends(get_projects_service),
 ):
@@ -294,7 +296,7 @@ def list_project_stands(
 @app.post("/projects/{project_id}/stands", response_model=Stand)
 def create_project_stand(
     project_id: int,
-    stand: Stand,
+    stand: StandCreate,
     _: Agent = Depends(require_admin),
     service: ProjectsService = Depends(get_projects_service),
 ):
@@ -324,7 +326,7 @@ def delete_project_stand(
 
 @app.post("/stands", response_model=Stand)
 def create_stand(
-    stand: Stand,
+    stand: StandCreate,
     _: Agent = Depends(require_admin),
     service: ProjectsService = Depends(get_projects_service),
 ):

--- a/app/models.py
+++ b/app/models.py
@@ -18,10 +18,17 @@ class PropertyStatus(str, Enum):
     ARCHIVED = "archived"
 
 
-class Project(BaseModel):
-    id: int
+class ProjectBase(BaseModel):
     name: str
     description: Optional[str] = None
+
+
+class Project(ProjectBase):
+    id: int
+
+
+class ProjectCreate(ProjectBase):
+    pass
 
 
 class MandateStatus(str, Enum):
@@ -52,14 +59,21 @@ class MandateHistoryEntry(BaseModel):
     status: MandateStatus
 
 
-class Stand(BaseModel):
-    id: int
+class StandBase(BaseModel):
     project_id: int
     name: str
     size: float = Field(..., gt=0)
     price: float = Field(..., gt=0)
     status: PropertyStatus = PropertyStatus.AVAILABLE
+
+
+class Stand(StandBase):
+    id: int
     mandate: Optional[Mandate] = None
+
+
+class StandCreate(StandBase):
+    pass
 
 
 class AgentRole(str, Enum):

--- a/app/projects.py
+++ b/app/projects.py
@@ -1,6 +1,6 @@
 from typing import List
 from fastapi import HTTPException
-from .models import Project, Stand, PropertyStatus
+from .models import Project, ProjectCreate, Stand, StandCreate, PropertyStatus
 from .repositories import Repositories
 
 
@@ -14,11 +14,25 @@ class ProjectsService:
     def list_projects(self) -> List[Project]:
         return self.repos.projects.list()
 
-    def create_project(self, project: Project) -> Project:
-        if self.repos.projects.get(project.id):
-            raise HTTPException(status_code=400, detail="Project ID exists")
-        self.repos.projects.add(project)
-        return project
+    def _allocate_project_id(self) -> int:
+        next_id = self.repos.counters.get("next_project_id")
+        if next_id is None:
+            next_id = max((p.id for p in self.repos.projects.list()), default=0) + 1
+        self.repos.counters.set("next_project_id", next_id + 1)
+        return next_id
+
+    def _allocate_stand_id(self) -> int:
+        next_id = self.repos.counters.get("next_stand_id")
+        if next_id is None:
+            next_id = max((s.id for s in self.repos.stands.list()), default=0) + 1
+        self.repos.counters.set("next_stand_id", next_id + 1)
+        return next_id
+
+    def create_project(self, project: ProjectCreate) -> Project:
+        project_id = self._allocate_project_id()
+        project_record = Project(id=project_id, **project.model_dump())
+        self.repos.projects.add(project_record)
+        return project_record
 
     def update_project(self, project_id: int, project: Project) -> Project:
         existing = self.repos.projects.get(project_id)
@@ -48,15 +62,15 @@ class ProjectsService:
             raise HTTPException(status_code=404, detail="Project not found")
         return [s for s in self.repos.stands.list() if s.project_id == project_id]
 
-    def create_stand(self, project_id: int, stand: Stand) -> Stand:
+    def create_stand(self, project_id: int, stand: StandCreate) -> Stand:
         if not self.repos.projects.get(project_id):
             raise HTTPException(status_code=404, detail="Project not found")
-        if self.repos.stands.get(stand.id):
-            raise HTTPException(status_code=400, detail="Stand ID exists")
         if stand.project_id != project_id:
             raise HTTPException(status_code=400, detail="Project mismatch")
-        self.repos.stands.add(stand)
-        return stand
+        stand_id = self._allocate_stand_id()
+        stand_record = Stand(id=stand_id, **stand.model_dump())
+        self.repos.stands.add(stand_record)
+        return stand_record
 
     def update_stand(self, project_id: int, stand_id: int, stand: Stand) -> Stand:
         if not self.repos.projects.get(project_id):

--- a/app/repositories.py
+++ b/app/repositories.py
@@ -115,3 +115,4 @@ class Repositories:
         self.agreements = Repository(session, 'agreements', Agreement)
         self.customer_loan_accounts = SimpleRepository(session, 'customer_loan_accounts')
         self.audit_log = ListRepository(session, 'audit_log')
+        self.counters = SimpleRepository(session, 'counters')

--- a/frontend/src/api/projects.ts
+++ b/frontend/src/api/projects.ts
@@ -7,6 +7,8 @@ export interface Project {
   description?: string;
 }
 
+export type ProjectCreate = Omit<Project, 'id'>;
+
 export interface Stand {
   id: number;
   project_id: number;
@@ -16,11 +18,13 @@ export interface Stand {
   status?: string;
 }
 
+export type StandCreate = Omit<Stand, 'id'>;
+
 export async function listProjects(): Promise<Project[]> {
   return apiFetch('/projects');
 }
 
-export async function createProject(project: Project): Promise<Project> {
+export async function createProject(project: ProjectCreate): Promise<Project> {
   return apiFetch('/projects', {
     method: 'POST',
     headers: { 'Content-Type': 'application/json' },
@@ -57,7 +61,7 @@ export async function listStands(projectId: number): Promise<Stand[]> {
 
 export async function createStand(
   projectId: number,
-  stand: Stand,
+  stand: StandCreate,
 ): Promise<Stand> {
   return apiFetch(`/projects/${projectId}/stands`, {
     method: 'POST',

--- a/tests/test_agreements.py
+++ b/tests/test_agreements.py
@@ -9,10 +9,11 @@ def setup_data(client):
     reset_state()
 
     def create_and_login(username, role, headers=None):
+        create_headers = headers or {"X-Bootstrap-Token": "bootstrap-token"}
         client.post(
             "/agents",
             json={"username": username, "role": role, "password": username},
-            headers=headers,
+            headers=create_headers,
         )
         token = client.post(
             "/auth/login", json={"username": username, "password": username}
@@ -23,12 +24,14 @@ def setup_data(client):
     realtor_headers = create_and_login("realtor", "agent", admin_headers)
     intruder_headers = create_and_login("intruder", "agent", admin_headers)
 
-    client.post("/projects", json={"id": 1, "name": "Proj"}, headers=admin_headers)
-    client.post(
+    project_id = client.post(
+        "/projects", json={"name": "Proj"}, headers=admin_headers
+    ).json()["id"]
+    stand_id = client.post(
         "/stands",
-        json={"id": 1, "project_id": 1, "name": "Stand1", "size": 100, "price": 1000},
+        json={"project_id": project_id, "name": "Stand1", "size": 100, "price": 1000},
         headers=admin_headers,
-    )
+    ).json()["id"]
 
     client.post(
         "/account-openings",
@@ -50,7 +53,13 @@ def setup_data(client):
         json={"id": 1, "realtor": "realtor", "account_id": 1, "documents": ["doc"]},
         headers=realtor_headers,
     )
-    return admin_headers, realtor_headers, intruder_headers
+    return {
+        "admin_headers": admin_headers,
+        "realtor_headers": realtor_headers,
+        "intruder_headers": intruder_headers,
+        "project_id": project_id,
+        "stand_id": stand_id,
+    }
 
 
 def reset_state():
@@ -59,42 +68,46 @@ def reset_state():
 
 
 def test_agreement_flow(client):
-    admin_headers, realtor_headers, intruder_headers = setup_data(client)
+    ctx = setup_data(client)
 
     resp = client.post(
         "/agreements",
-        json={"id": 1, "loan_application_id": 1, "property_id": 1},
-        headers=admin_headers,
+        json={
+            "id": 1,
+            "loan_application_id": 1,
+            "property_id": ctx["stand_id"],
+        },
+        headers=ctx["admin_headers"],
     )
     assert resp.status_code == 200
     data = resp.json()
     assert "Stand1" in data["document"]
     assert data["status"] == "draft"
 
-    resp = client.get("/agreements/1", headers=intruder_headers)
+    resp = client.get("/agreements/1", headers=ctx["intruder_headers"])
     assert resp.status_code == 403
 
-    resp = client.get("/agreements/1", headers=realtor_headers)
+    resp = client.get("/agreements/1", headers=ctx["realtor_headers"])
     assert resp.status_code == 200
 
-    resp = client.get("/agreements/1", headers=admin_headers)
+    resp = client.get("/agreements/1", headers=ctx["admin_headers"])
     assert resp.status_code == 200
 
-    resp = client.get("/agreements/1/document", headers=admin_headers)
+    resp = client.get("/agreements/1/document", headers=ctx["admin_headers"])
     assert resp.status_code == 200
     assert "Stand1" in resp.text
 
     resp = client.post(
         "/agreements/1/sign",
         json={"document_url": "url_intruder"},
-        headers=intruder_headers,
+        headers=ctx["intruder_headers"],
     )
     assert resp.status_code == 403
 
     resp = client.post(
         "/agreements/1/sign",
         json={"document_url": "url_customer"},
-        headers=realtor_headers,
+        headers=ctx["realtor_headers"],
     )
     assert resp.status_code == 200
     data = resp.json()
@@ -104,27 +117,27 @@ def test_agreement_flow(client):
     resp = client.post(
         "/agreements/1/sign",
         json={"document_url": "url_bank"},
-        headers=admin_headers,
+        headers=ctx["admin_headers"],
     )
     assert resp.status_code == 200
     data = resp.json()
     assert data["bank_document_url"] == "url_bank"
     assert data["status"] == "signed"
 
-    notes_resp = client.get("/notifications", headers=admin_headers)
+    notes_resp = client.get("/notifications", headers=ctx["admin_headers"])
     assert any("Loan Accounts Opening Team" in n for n in notes_resp.json())
 
     resp = client.post(
         "/agreements/1/upload",
         json={"document": "Intrusion"},
-        headers=intruder_headers,
+        headers=ctx["intruder_headers"],
     )
     assert resp.status_code == 403
 
     resp = client.post(
         "/agreements/1/upload",
         json={"document": "Updated by Realtor"},
-        headers=realtor_headers,
+        headers=ctx["realtor_headers"],
     )
     assert resp.status_code == 200
     data = resp.json()
@@ -134,7 +147,7 @@ def test_agreement_flow(client):
     resp = client.post(
         "/agreements/1/upload",
         json={"document": "Updated by Admin"},
-        headers=admin_headers,
+        headers=ctx["admin_headers"],
     )
     assert resp.status_code == 200
     data = resp.json()
@@ -145,28 +158,30 @@ def test_agreement_flow(client):
     resp = client.post(
         "/loan-accounts",
         json={"agreement_id": 1},
-        headers=admin_headers,
+        headers=ctx["admin_headers"],
     )
     assert resp.status_code == 200
     account_number = resp.json()["account_number"]
-    stand_resp = client.get("/stands/1", headers=admin_headers)
+    stand_resp = client.get(f"/stands/{ctx['stand_id']}", headers=ctx["admin_headers"])
     assert stand_resp.json()["status"] == PropertyStatus.SOLD.value
-    loan_resp = client.get("/loan-applications/1", headers=realtor_headers)
+    loan_resp = client.get("/loan-applications/1", headers=ctx["realtor_headers"])
     assert loan_resp.json()["loan_account_number"] == account_number
-    acct_resp = client.get("/loan-accounts/realtor", headers=admin_headers)
+    acct_resp = client.get(
+        "/loan-accounts/realtor", headers=ctx["admin_headers"]
+    )
     assert acct_resp.json() == [account_number]
 
     resp = client.put(
-        "/stands/1",
+        f"/stands/{ctx['stand_id']}",
         json={
-            "id": 1,
-            "project_id": 1,
+            "id": ctx["stand_id"],
+            "project_id": ctx["project_id"],
             "name": "New",
             "status": "available",
             "size": 100,
             "price": 1000,
         },
-        headers=admin_headers,
+        headers=ctx["admin_headers"],
     )
     assert resp.status_code == 400
     reset_state()

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -13,7 +13,9 @@ def setup_function():
 def test_auth_mandate_and_available_view(client):
     # register agents
     resp = client.post(
-        "/agents", json={"username": "admin", "role": "admin", "password": "a"}
+        "/agents",
+        json={"username": "admin", "role": "admin", "password": "a"},
+        headers={"X-Bootstrap-Token": "bootstrap-token"},
     )
     assert resp.status_code == 200
     admin_token = client.post(
@@ -33,43 +35,54 @@ def test_auth_mandate_and_available_view(client):
     agent_headers = {"Authorization": f"Bearer {agent_token}"}
 
     # Create project as admin
-    project = {"id": 1, "name": "Project A"}
+    project = {"name": "Project A"}
     resp = client.post("/projects", json=project, headers=admin_headers)
     assert resp.status_code == 200
+    project_id = resp.json()["id"]
 
     # Create stand as admin
-    stand = {"id": 1, "project_id": 1, "name": "Stand 1", "size": 100, "price": 1000}
+    stand = {"project_id": project_id, "name": "Stand 1", "size": 100, "price": 1000}
     resp = client.post("/stands", json=stand, headers=admin_headers)
     assert resp.status_code == 200
+    stand_id = resp.json()["id"]
 
     # Agent cannot create stand
     resp = client.post(
         "/stands",
-        json={"id": 2, "project_id": 1, "name": "Stand 2", "size": 100, "price": 1000},
+        json={
+            "project_id": project_id,
+            "name": "Stand 2",
+            "size": 100,
+            "price": 1000,
+        },
         headers=agent_headers,
     )
     assert resp.status_code == 403
 
     # Update stand as admin
     stand_update = {
-        "id": 1,
-        "project_id": 1,
+        "id": stand_id,
+        "project_id": project_id,
         "name": "Stand 1 Updated",
         "status": "available",
         "size": 100,
         "price": 1000,
     }
-    resp = client.put("/stands/1", json=stand_update, headers=admin_headers)
+    resp = client.put(f"/stands/{stand_id}", json=stand_update, headers=admin_headers)
     assert resp.status_code == 200
     assert resp.json()["name"] == "Stand 1 Updated"
 
     # Assign mandate with document
-    resp = client.post("/stands/1/mandate", json={"agent": "agentA", "document": "doc.pdf"}, headers=admin_headers)
+    resp = client.post(
+        f"/stands/{stand_id}/mandate",
+        json={"agent": "agentA", "document": "doc.pdf"},
+        headers=admin_headers,
+    )
     assert resp.status_code == 200
     assert resp.json()["mandate"]["status"] == "pending"
 
     # Agent accepts mandate
-    resp = client.put("/stands/1/mandate/accept", headers=agent_headers)
+    resp = client.put(f"/stands/{stand_id}/mandate/accept", headers=agent_headers)
     assert resp.status_code == 200
     assert resp.json()["mandate"]["status"] == "accepted"
 
@@ -84,7 +97,7 @@ def test_auth_mandate_and_available_view(client):
     assert len(resp.json()) == 1
 
     # Archive stand
-    resp = client.delete("/stands/1", headers=admin_headers)
+    resp = client.delete(f"/stands/{stand_id}", headers=admin_headers)
     assert resp.status_code == 200
     assert resp.json()["status"] == PropertyStatus.ARCHIVED.value
 

--- a/tests/test_application_uploads.py
+++ b/tests/test_application_uploads.py
@@ -8,7 +8,9 @@ def setup_agents(client):
     drop_db()
     init_db()
     client.post(
-        "/agents", json={"username": "admin", "role": "admin", "password": "a"}
+        "/agents",
+        json={"username": "admin", "role": "admin", "password": "a"},
+        headers={"X-Bootstrap-Token": "bootstrap-token"},
     )
     admin_token = client.post(
         "/auth/login", json={"username": "admin", "password": "a"}

--- a/tests/test_dashboard.py
+++ b/tests/test_dashboard.py
@@ -19,7 +19,9 @@ def register_agents(client):
     tokens = {}
     # create first admin
     client.post(
-        "/agents", json={"username": "admin", "role": "admin", "password": "admin"}
+        "/agents",
+        json={"username": "admin", "role": "admin", "password": "admin"},
+        headers={"X-Bootstrap-Token": "bootstrap-token"},
     )
     admin_token = client.post(
         "/auth/login", json={"username": "admin", "password": "admin"}
@@ -40,16 +42,21 @@ def register_agents(client):
 
 
 def setup_data(client, admin_headers, agent_headers):
-    project = {"id": 100, "name": "Proj"}
-    client.post("/projects", json=project, headers=admin_headers)
-    stand = {"id": 100, "project_id": 100, "name": "Stand1", "size": 100, "price": 1000}
-    client.post("/stands", json=stand, headers=admin_headers)
+    project = {"name": "Proj"}
+    project_id = client.post("/projects", json=project, headers=admin_headers).json()["id"]
+    stand = {
+        "project_id": project_id,
+        "name": "Stand1",
+        "size": 100,
+        "price": 1000,
+    }
+    stand_id = client.post("/stands", json=stand, headers=admin_headers).json()["id"]
     client.post(
-        "/stands/100/mandate",
+        f"/stands/{stand_id}/mandate",
         json={"agent": "agentA", "document": "m.pdf"},
         headers=admin_headers,
     )
-    client.put("/stands/100/mandate/accept", headers=agent_headers)
+    client.put(f"/stands/{stand_id}/mandate/accept", headers=agent_headers)
     client.post(
         "/account-openings",
         json={"id": 100, "realtor": "agentA"},

--- a/tests/test_deposits_api.py
+++ b/tests/test_deposits_api.py
@@ -8,7 +8,11 @@ def setup_function(_):
     init_db()
 
 def register_users(client):
-    client.post("/agents", json={"username": "admin", "role": "admin", "password": "admin"})
+    client.post(
+        "/agents",
+        json={"username": "admin", "role": "admin", "password": "admin"},
+        headers={"X-Bootstrap-Token": "bootstrap-token"},
+    )
     admin_token = client.post(
         "/auth/login", json={"username": "admin", "password": "admin"}
     ).json()["token"]

--- a/tests/test_import.py
+++ b/tests/test_import.py
@@ -12,7 +12,9 @@ def admin_headers(client):
     drop_db()
     init_db()
     client.post(
-        "/agents", json={"username": "admin", "role": "admin", "password": "a"}
+        "/agents",
+        json={"username": "admin", "role": "admin", "password": "a"},
+        headers={"X-Bootstrap-Token": "bootstrap-token"},
     )
     token = client.post(
         "/auth/login", json={"username": "admin", "password": "a"}

--- a/tests/test_loans_api.py
+++ b/tests/test_loans_api.py
@@ -10,7 +10,9 @@ def setup_agents(client):
     drop_db()
     init_db()
     client.post(
-        "/agents", json={"username": "admin", "role": "admin", "password": "a"}
+        "/agents",
+        json={"username": "admin", "role": "admin", "password": "a"},
+        headers={"X-Bootstrap-Token": "bootstrap-token"},
     )
     admin_token = client.post(
         "/auth/login", json={"username": "admin", "password": "a"}

--- a/tests/test_projects_api.py
+++ b/tests/test_projects_api.py
@@ -13,6 +13,7 @@ def auth_headers(client, username: str):
     client.post(
         "/agents",
         json={"username": username, "role": "admin", "password": username},
+        headers={"X-Bootstrap-Token": "bootstrap-token"},
     )
     token = client.post(
         "/auth/login", json={"username": username, "password": username}
@@ -24,56 +25,74 @@ def test_project_and_stand_crud(client):
     headers = auth_headers(client, "admin")
 
     # create project
-    project = {"id": 1, "name": "P"}
+    project = {"name": "P"}
     resp = client.post("/projects", json=project, headers=headers)
     assert resp.status_code == 200
+    project_id = resp.json()["id"]
+    assert isinstance(project_id, int)
 
     # update project
-    project_update = {"id": 1, "name": "P2"}
-    resp = client.put("/projects/1", json=project_update, headers=headers)
+    project_update = {"id": project_id, "name": "P2"}
+    resp = client.put(f"/projects/{project_id}", json=project_update, headers=headers)
     assert resp.status_code == 200
     assert resp.json()["name"] == "P2"
 
     # create stand under project
-    stand = {"id": 10, "project_id": 1, "name": "S", "size": 10, "price": 100}
-    resp = client.post("/projects/1/stands", json=stand, headers=headers)
+    stand = {"project_id": project_id, "name": "S", "size": 10, "price": 100}
+    resp = client.post(f"/projects/{project_id}/stands", json=stand, headers=headers)
     assert resp.status_code == 200
+    stand_id = resp.json()["id"]
+    assert isinstance(stand_id, int)
 
     # list stands
-    resp = client.get("/projects/1/stands", headers=headers)
+    resp = client.get(f"/projects/{project_id}/stands", headers=headers)
     assert resp.status_code == 200
     assert len(resp.json()) == 1
 
     # update stand
-    stand_update = {"id": 10, "project_id": 1, "name": "S2", "size": 10, "price": 100}
-    resp = client.put("/projects/1/stands/10", json=stand_update, headers=headers)
+    stand_update = {
+        "id": stand_id,
+        "project_id": project_id,
+        "name": "S2",
+        "size": 10,
+        "price": 100,
+    }
+    resp = client.put(
+        f"/projects/{project_id}/stands/{stand_id}",
+        json=stand_update,
+        headers=headers,
+    )
     assert resp.status_code == 200
     assert resp.json()["name"] == "S2"
 
     # delete stand
-    resp = client.delete("/projects/1/stands/10", headers=headers)
+    resp = client.delete(
+        f"/projects/{project_id}/stands/{stand_id}", headers=headers
+    )
     assert resp.status_code == 200
 
     # delete project
-    resp = client.delete("/projects/1", headers=headers)
+    resp = client.delete(f"/projects/{project_id}", headers=headers)
     assert resp.status_code == 200
 
 
 def test_delete_project_with_existing_stands_rejected(client):
     headers = auth_headers(client, "admin")
 
-    project = {"id": 1, "name": "P"}
+    project = {"name": "P"}
     resp = client.post("/projects", json=project, headers=headers)
     assert resp.status_code == 200
+    project_id = resp.json()["id"]
 
-    stand = {"id": 10, "project_id": 1, "name": "S", "size": 10, "price": 100}
-    resp = client.post("/projects/1/stands", json=stand, headers=headers)
+    stand = {"project_id": project_id, "name": "S", "size": 10, "price": 100}
+    resp = client.post(f"/projects/{project_id}/stands", json=stand, headers=headers)
     assert resp.status_code == 200
+    stand_id = resp.json()["id"]
 
-    resp = client.delete("/projects/1", headers=headers)
+    resp = client.delete(f"/projects/{project_id}", headers=headers)
     assert resp.status_code == 400
     assert resp.json()["detail"] == "Cannot delete project with existing stands"
 
-    resp = client.get("/projects/1/stands", headers=headers)
+    resp = client.get(f"/projects/{project_id}/stands", headers=headers)
     assert resp.status_code == 200
     assert len(resp.json()) == 1

--- a/tests/test_reporting.py
+++ b/tests/test_reporting.py
@@ -11,7 +11,11 @@ def setup_function():
 
 
 def setup_data(client):
-    client.post("/agents", json={"username": "admin", "role": "admin", "password": "a"})
+    client.post(
+        "/agents",
+        json={"username": "admin", "role": "admin", "password": "a"},
+        headers={"X-Bootstrap-Token": "bootstrap-token"},
+    )
     admin_token = client.post("/auth/login", json={"username": "admin", "password": "a"}).json()["token"]
     admin_headers = {"Authorization": f"Bearer {admin_token}"}
     client.post(
@@ -21,19 +25,31 @@ def setup_data(client):
     )
     agent_token = client.post("/auth/login", json={"username": "agent", "password": "b"}).json()["token"]
     agent_headers = {"Authorization": f"Bearer {agent_token}"}
-    client.post("/projects", json={"id": 1, "name": "Proj"}, headers=admin_headers)
-    client.post(
+    project_id = client.post(
+        "/projects", json={"name": "Proj"}, headers=admin_headers
+    ).json()["id"]
+    stand_one = client.post(
         "/stands",
-        json={"id": 1, "project_id": 1, "name": "S1", "size": 100, "price": 1000},
+        json={"project_id": project_id, "name": "S1", "size": 100, "price": 1000},
+        headers=admin_headers,
+    ).json()
+    stand_two = client.post(
+        "/stands",
+        json={
+            "project_id": project_id,
+            "name": "S2",
+            "size": 100,
+            "price": 2000,
+            "status": "sold",
+        },
+        headers=admin_headers,
+    ).json()
+    client.post(
+        f"/stands/{stand_one['id']}/mandate",
+        json={"agent": "agent"},
         headers=admin_headers,
     )
-    client.post(
-        "/stands",
-        json={"id": 2, "project_id": 1, "name": "S2", "size": 100, "price": 2000, "status": "sold"},
-        headers=admin_headers,
-    )
-    client.post("/stands/1/mandate", json={"agent": "agent"}, headers=admin_headers)
-    client.put("/stands/1/mandate/accept", headers=agent_headers)
+    client.put(f"/stands/{stand_one['id']}/mandate/accept", headers=agent_headers)
     client.post(
         "/account-openings",
         json={"id": 1, "realtor": "agent"},
@@ -59,12 +75,17 @@ def setup_data(client):
         json={"decision": "approved"},
         headers=admin_headers,
     )
-    return admin_headers
+    return {
+        "admin_headers": admin_headers,
+        "agent_headers": agent_headers,
+        "project_id": project_id,
+        "stand_ids": [stand_one["id"], stand_two["id"]],
+    }
 
 
 def test_report_headers_and_rows(client):
-    admin_headers = setup_data(client)
-    resp = client.get("/reports/properties", headers=admin_headers)
+    ctx = setup_data(client)
+    resp = client.get("/reports/properties", headers=ctx["admin_headers"])
     assert resp.status_code == 200
     lines = resp.text.strip().splitlines()
     assert (
@@ -73,13 +94,15 @@ def test_report_headers_and_rows(client):
     )
     data = list(csv.DictReader(lines))
     assert len(data) == 2
-    row = next(r for r in data if r["stand_id"] == "1")
+    row = next(r for r in data if r["stand_id"] == str(ctx["stand_ids"][0]))
     assert row["mandate_status"] == "accepted"
 
 
 def test_report_filtering(client):
-    admin_headers = setup_data(client)
-    resp = client.get("/reports/properties?status=sold", headers=admin_headers)
+    ctx = setup_data(client)
+    resp = client.get(
+        "/reports/properties?status=sold", headers=ctx["admin_headers"]
+    )
     assert resp.status_code == 200
     data = list(csv.DictReader(resp.text.splitlines()))
     assert len(data) == 1
@@ -87,13 +110,15 @@ def test_report_filtering(client):
 
 
 def test_mandate_and_loan_reports(client):
-    admin_headers = setup_data(client)
-    resp = client.get("/reports/mandates", headers=admin_headers)
+    ctx = setup_data(client)
+    resp = client.get("/reports/mandates", headers=ctx["admin_headers"])
     assert resp.status_code == 200
     data = list(csv.DictReader(resp.text.splitlines()))
     assert data[0]["status"] == "accepted"
 
-    resp = client.get("/reports/loans?status=completed", headers=admin_headers)
+    resp = client.get(
+        "/reports/loans?status=completed", headers=ctx["admin_headers"]
+    )
     assert resp.status_code == 200
     data = list(csv.DictReader(resp.text.splitlines()))
     assert data[0]["decision"] == "approved"

--- a/tests/test_submissions.py
+++ b/tests/test_submissions.py
@@ -10,7 +10,9 @@ def setup_agents(client):
     drop_db()
     init_db()
     client.post(
-        "/agents", json={"username": "admin", "role": "admin", "password": "a"}
+        "/agents",
+        json={"username": "admin", "role": "admin", "password": "a"},
+        headers={"X-Bootstrap-Token": "bootstrap-token"},
     )
     admin_token = client.post(
         "/auth/login", json={"username": "admin", "password": "a"}
@@ -375,12 +377,14 @@ def test_loan_application_queue_listing_and_agreement_generation(client):
     admin_headers = {"Authorization": f"Bearer {tokens['admin']}"}
     realtor_headers = {"Authorization": f"Bearer {tokens['realtor']}"}
 
-    client.post("/projects", json={"id": 1, "name": "P"}, headers=admin_headers)
-    client.post(
+    project_id = client.post(
+        "/projects", json={"name": "P"}, headers=admin_headers
+    ).json()["id"]
+    stand_id = client.post(
         "/stands",
-        json={"id": 1, "project_id": 1, "name": "S", "size": 100, "price": 1000},
+        json={"project_id": project_id, "name": "S", "size": 100, "price": 1000},
         headers=admin_headers,
-    )
+    ).json()["id"]
 
     client.post(
         "/account-openings",
@@ -403,7 +407,7 @@ def test_loan_application_queue_listing_and_agreement_generation(client):
         "realtor": "realtor",
         "account_id": 1,
         "documents": ["doc"],
-        "property_id": 1,
+        "property_id": stand_id,
     }
     client.post("/loan-applications", json=loan_app, headers=realtor_headers)
 


### PR DESCRIPTION
## Summary
- add dedicated ProjectCreate and StandCreate models so new resources omit an id
- allocate ids in the service layer before persisting projects and stands and adjust API/frontend usage
- refresh project- and stand-related tests to expect generated ids and supply the bootstrap token when seeding admins

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68cb60fde0ec832c861a07437aecb6dc