### PR TITLE
Add admin property import workflow

### DIFF
--- a/dashboard/src/auth.tsx
+++ b/dashboard/src/auth.tsx
@@ -21,9 +21,24 @@ const AuthContext = React.createContext<AuthContextType>({
 
 export const AuthProvider: React.FC<{ children: React.ReactNode }> = ({ children }) => {
   const [auth, setAuth] = React.useState<Auth | null>(null);
+
+  React.useEffect(() => {
+    const token = localStorage.getItem('token');
+    const role = localStorage.getItem('role');
+    const username = localStorage.getItem('username');
+    if (token && role && username) {
+      setAuth({ token, role, username });
+    }
+  }, []);
+
   const login = (token: string, role: string, username: string) =>
     setAuth({ token, role, username });
-  const logout = () => setAuth(null);
+  const logout = () => {
+    localStorage.removeItem('token');
+    localStorage.removeItem('role');
+    localStorage.removeItem('username');
+    setAuth(null);
+  };
   return (
     <AuthContext.Provider value={{ auth, login, logout }}>
       {children}

--- a/dashboard/src/pages/Login.tsx
+++ b/dashboard/src/pages/Login.tsx
@@ -15,6 +15,9 @@ const Login: React.FC = () => {
     setError('');
     try {
       const data = await loginRequest({ username, password });
+      localStorage.setItem('token', data.token);
+      localStorage.setItem('role', data.role);
+      localStorage.setItem('username', data.username);
       login(data.token, data.role, data.username);
       if (data.role === 'agent') {
         navigate('/dashboard');

--- a/dashboard/src/pages/Projects.tsx
+++ b/dashboard/src/pages/Projects.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import PropertyImportForm from '../../../frontend/src/components/PropertyImportForm';
 import { useAuth } from '../auth';
 import {
   getProjects as fetchProjects,
@@ -43,6 +44,13 @@ const Projects: React.FC = () => {
   return (
     <div>
       <h2>Projects</h2>
+      {auth?.role === 'admin' && (
+        <section>
+          <h3>Import Properties</h3>
+          <p>Select a CSV or Excel file to upload new property records.</p>
+          <PropertyImportForm />
+        </section>
+      )}
       <form onSubmit={submit}>
         <input
           placeholder="ID"

--- a/frontend/src/api/projects.ts
+++ b/frontend/src/api/projects.ts
@@ -47,6 +47,21 @@ export async function deleteProject(id: number): Promise<Project> {
   return apiFetch(`/projects/${id}`, { method: 'DELETE' });
 }
 
+export interface ImportPropertiesResult {
+  message?: string;
+  imported?: number;
+}
+
+export async function importProperties(file: File): Promise<ImportPropertiesResult> {
+  const formData = new FormData();
+  formData.append('file', file);
+
+  return apiFetch('/import/properties', {
+    method: 'POST',
+    body: formData,
+  });
+}
+
 export function useProjects() {
   const [projects, setProjects] = useState<Project[]>([]);
   useEffect(() => {

--- a/frontend/src/components/PropertyImportForm.tsx
+++ b/frontend/src/components/PropertyImportForm.tsx
@@ -1,0 +1,79 @@
+import React, { useState } from 'react';
+import { importProperties, ImportPropertiesResult } from '../api/projects';
+
+type Status = 'idle' | 'uploading' | 'success' | 'error';
+
+export interface PropertyImportFormProps {
+  onImported?: (result: ImportPropertiesResult) => void;
+  className?: string;
+}
+
+const PropertyImportForm: React.FC<PropertyImportFormProps> = ({
+  onImported,
+  className,
+}) => {
+  const [file, setFile] = useState<File | null>(null);
+  const [status, setStatus] = useState<Status>('idle');
+  const [message, setMessage] = useState('');
+  const [error, setError] = useState('');
+
+  const resetFeedback = () => {
+    setStatus('idle');
+    setMessage('');
+    setError('');
+  };
+
+  const onFileChange = (event: React.ChangeEvent<HTMLInputElement>) => {
+    const selected = event.target.files?.[0] ?? null;
+    setFile(selected);
+    resetFeedback();
+  };
+
+  const handleSubmit = async (event: React.FormEvent) => {
+    event.preventDefault();
+    if (!file) {
+      setStatus('error');
+      setError('Please select a CSV or XLSX file to import.');
+      return;
+    }
+
+    setStatus('uploading');
+    setMessage('');
+    setError('');
+
+    try {
+      const result = await importProperties(file);
+      setStatus('success');
+      const successMessage =
+        result.message ?? 'Property data imported successfully.';
+      setMessage(successMessage);
+      onImported?.(result);
+    } catch (err) {
+      setStatus('error');
+      const errorMessage =
+        err instanceof Error ? err.message : 'Failed to import properties.';
+      setError(errorMessage);
+    }
+  };
+
+  return (
+    <form onSubmit={handleSubmit} className={className}>
+      <label>
+        Upload property data
+        <input
+          type="file"
+          accept=".csv,.xlsx,.xls"
+          onChange={onFileChange}
+          disabled={status === 'uploading'}
+        />
+      </label>
+      <button type="submit" disabled={status === 'uploading'}>
+        {status === 'uploading' ? 'Importing…' : 'Import Properties'}
+      </button>
+      {status === 'success' && message && <p>{message}</p>}
+      {status === 'error' && error && <p>{error}</p>}
+    </form>
+  );
+};
+
+export default PropertyImportForm;


### PR DESCRIPTION
## Summary
- add a multipart importProperties helper for the projects API
- create a reusable PropertyImportForm component that surfaces upload feedback
- persist auth tokens for reuse and mount the uploader on the admin Projects page

## Testing
- npm --prefix dashboard run build

------
https://chatgpt.com/codex/tasks/task_e_68cb6885808c832cbc497ad26b440ace