### PR TITLE
Add admin agent management view

### DIFF
--- a/dashboard/src/App.tsx
+++ b/dashboard/src/App.tsx
@@ -11,6 +11,7 @@ import AccountOpeningDetail from './pages/AccountOpeningDetail';
 import LoanApplications from './pages/LoanApplications';
 import LoanApprovals from './pages/LoanApprovals';
 import AdminDashboard from './pages/AdminDashboard';
+import AgentsPage from './pages/Agents';
 import ComplianceDashboard from './pages/ComplianceDashboard';
 import Deposits from './pages/Deposits';
 import DepositDetail from './pages/DepositDetail';
@@ -29,6 +30,7 @@ const App: React.FC = () => {
               <Link to="/projects">Projects</Link> |{' '}
               <Link to="/stands">Stands</Link> |{' '}
               <Link to="/mandates">Mandates</Link> |{' '}
+              <Link to="/agents">Agents</Link> |{' '}
               <Link to="/account-openings">Account Openings</Link> |{' '}
               <Link to="/loan-applications">Loan Applications</Link> |{' '}
               <Link to="/loan-approvals">Loan Approvals</Link> |{' '}
@@ -57,6 +59,14 @@ const App: React.FC = () => {
       )}
       <Routes>
         <Route path="/login" element={<Login />} />
+        <Route
+          path="/agents"
+          element={
+            <ProtectedRoute roles={["admin"]}>
+              <AgentsPage />
+            </ProtectedRoute>
+          }
+        />
         <Route
           path="/projects"
           element={

--- a/dashboard/src/pages/Agents.tsx
+++ b/dashboard/src/pages/Agents.tsx
@@ -1,0 +1,11 @@
+import React from 'react';
+import AgentManagement from '../../../frontend/src/components/AgentManagement';
+
+const AgentsPage: React.FC = () => (
+  <div>
+    <h2>Agent Management</h2>
+    <AgentManagement />
+  </div>
+);
+
+export default AgentsPage;

--- a/frontend/src/api/agents.ts
+++ b/frontend/src/api/agents.ts
@@ -1,0 +1,28 @@
+import apiFetch from './client';
+
+export type AgentRole = 'admin' | 'agent' | 'manager' | 'compliance';
+
+export interface Agent {
+  username: string;
+  role: AgentRole;
+}
+
+export interface AgentCreate {
+  username: string;
+  role: AgentRole;
+  password: string;
+}
+
+export const AGENT_ROLES: AgentRole[] = ['admin', 'manager', 'compliance', 'agent'];
+
+export async function listAgents(): Promise<Agent[]> {
+  return apiFetch('/agents');
+}
+
+export async function createAgent(agent: AgentCreate): Promise<Agent> {
+  return apiFetch('/agents', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(agent),
+  });
+}

--- a/frontend/src/components/AgentManagement.tsx
+++ b/frontend/src/components/AgentManagement.tsx
@@ -1,0 +1,178 @@
+import React, { useEffect, useMemo, useState } from 'react';
+import {
+  AGENT_ROLES,
+  Agent,
+  AgentCreate,
+  AgentRole,
+  createAgent,
+  listAgents,
+} from '../api/agents';
+
+interface AgentFormState {
+  username: string;
+  password: string;
+  role: AgentRole;
+}
+
+const defaultFormState: AgentFormState = {
+  username: '',
+  password: '',
+  role: 'agent',
+};
+
+const AgentManagement: React.FC = () => {
+  const [agents, setAgents] = useState<Agent[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [form, setForm] = useState<AgentFormState>(defaultFormState);
+  const [creating, setCreating] = useState(false);
+
+  const role = useMemo(() => localStorage.getItem('role'), []);
+
+  useEffect(() => {
+    if (role !== 'admin') {
+      setLoading(false);
+      return;
+    }
+    let cancelled = false;
+    setLoading(true);
+    setError(null);
+    listAgents()
+      .then((data) => {
+        if (!cancelled) setAgents(data);
+      })
+      .catch((err) => {
+        if (cancelled) return;
+        const message =
+          err instanceof Error ? err.message : 'Failed to load agents.';
+        setError(message);
+      })
+      .finally(() => {
+        if (!cancelled) setLoading(false);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [role]);
+
+  if (role !== 'admin') {
+    return <p>You do not have permission to view this page.</p>;
+  }
+
+  const handleChange = (
+    event: React.ChangeEvent<HTMLInputElement | HTMLSelectElement>,
+  ) => {
+    const { name, value } = event.target;
+    setForm((prev) => ({ ...prev, [name]: value }));
+  };
+
+  const handleSubmit = async (event: React.FormEvent) => {
+    event.preventDefault();
+    if (!form.username || !form.password) {
+      setError('Username and password are required.');
+      return;
+    }
+    setCreating(true);
+    setError(null);
+    try {
+      const payload: AgentCreate = {
+        username: form.username,
+        password: form.password,
+        role: form.role,
+      };
+      const created = await createAgent(payload);
+      setAgents((prev) => {
+        const filtered = prev.filter((agent) => agent.username !== created.username);
+        return [...filtered, created].sort((a, b) => a.username.localeCompare(b.username));
+      });
+      setForm(defaultFormState);
+    } catch (err) {
+      const message =
+        err instanceof Error ? err.message : 'Failed to create agent.';
+      setError(message);
+    } finally {
+      setCreating(false);
+    }
+  };
+
+  return (
+    <div>
+      <section>
+        <h3>Create Agent</h3>
+        <form onSubmit={handleSubmit}>
+          <div>
+            <label>
+              Username
+              <input
+                name="username"
+                value={form.username}
+                onChange={handleChange}
+                disabled={creating}
+                required
+              />
+            </label>
+          </div>
+          <div>
+            <label>
+              Password
+              <input
+                type="password"
+                name="password"
+                value={form.password}
+                onChange={handleChange}
+                disabled={creating}
+                required
+              />
+            </label>
+          </div>
+          <div>
+            <label>
+              Role
+              <select
+                name="role"
+                value={form.role}
+                onChange={handleChange}
+                disabled={creating}
+              >
+                {AGENT_ROLES.map((r) => (
+                  <option key={r} value={r}>
+                    {r}
+                  </option>
+                ))}
+              </select>
+            </label>
+          </div>
+          <button type="submit" disabled={creating}>
+            {creating ? 'Creating…' : 'Create Agent'}
+          </button>
+        </form>
+      </section>
+      <section>
+        <h3>Existing Agents</h3>
+        {loading && <p>Loading agents…</p>}
+        {error && <p>{error}</p>}
+        {!loading && !agents.length && !error && <p>No agents found.</p>}
+        {agents.length > 0 && (
+          <table>
+            <thead>
+              <tr>
+                <th>Username</th>
+                <th>Role</th>
+              </tr>
+            </thead>
+            <tbody>
+              {agents.map((agent) => (
+                <tr key={agent.username}>
+                  <td>{agent.username}</td>
+                  <td>{agent.role}</td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        )}
+      </section>
+    </div>
+  );
+};
+
+export default AgentManagement;


### PR DESCRIPTION
## Summary
- add shared API client helpers for creating and listing agents
- implement an agent management component with admin-only access and creation form
- expose the new agent page in the dashboard navigation guarded by admin access

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68cb69cb9994832c92fb4da8c3e86d63