### PR TITLE
Add shared styling for application forms

### DIFF
--- a/dashboard/src/main.tsx
+++ b/dashboard/src/main.tsx
@@ -3,6 +3,7 @@ import ReactDOM from 'react-dom/client';
 import { BrowserRouter } from 'react-router-dom';
 import App from './App';
 import { AuthProvider } from './auth';
+import '../../frontend/src/styles/global.css';
 
 ReactDOM.createRoot(document.getElementById('root') as HTMLElement).render(
   <React.StrictMode>

--- a/frontend/src/components/ApplicationForms.tsx
+++ b/frontend/src/components/ApplicationForms.tsx
@@ -38,19 +38,34 @@ export function OfferApplicationForm({
   };
 
   return (
-    <form onSubmit={submit}>
-      <input value={id} onChange={(e) => setId(e.target.value)} placeholder="ID" />
-      <input
-        value={propertyId}
-        onChange={(e) => setPropertyId(e.target.value)}
-        placeholder="Property ID"
-      />
-      <input type="file" onChange={(e) => setFile(e.target.files?.[0] || null)} />
-      <button type="submit">Submit Offer</button>
-      {status === 'uploading' && <p>Uploading...</p>}
-      {status === 'success' && <p>Uploaded!</p>}
-      {status === 'error' && <p>{error}</p>}
-    </form>
+    <section className="form-section">
+      <form className="form-card" onSubmit={submit}>
+        <h3 className="form-title">Submit offer application</h3>
+        <div className="form-fields">
+          <input value={id} onChange={(e) => setId(e.target.value)} placeholder="ID" />
+          <input
+            value={propertyId}
+            onChange={(e) => setPropertyId(e.target.value)}
+            placeholder="Property ID"
+          />
+          <input type="file" onChange={(e) => setFile(e.target.files?.[0] || null)} />
+        </div>
+        <div className="form-actions">
+          <button type="submit" disabled={status === 'uploading'}>
+            Submit Offer
+          </button>
+        </div>
+        {status === 'uploading' && (
+          <p className="form-message form-message--info">Uploading...</p>
+        )}
+        {status === 'success' && (
+          <p className="form-message form-message--success">Uploaded!</p>
+        )}
+        {status === 'error' && (
+          <p className="form-message form-message--error">{error}</p>
+        )}
+      </form>
+    </section>
   );
 }
 
@@ -85,19 +100,34 @@ export function PropertyApplicationForm({
   };
 
   return (
-    <form onSubmit={submit}>
-      <input value={id} onChange={(e) => setId(e.target.value)} placeholder="ID" />
-      <input
-        value={propertyId}
-        onChange={(e) => setPropertyId(e.target.value)}
-        placeholder="Property ID"
-      />
-      <input type="file" onChange={(e) => setFile(e.target.files?.[0] || null)} />
-      <button type="submit">Submit Property App</button>
-      {status === 'uploading' && <p>Uploading...</p>}
-      {status === 'success' && <p>Uploaded!</p>}
-      {status === 'error' && <p>{error}</p>}
-    </form>
+    <section className="form-section">
+      <form className="form-card" onSubmit={submit}>
+        <h3 className="form-title">Submit property application</h3>
+        <div className="form-fields">
+          <input value={id} onChange={(e) => setId(e.target.value)} placeholder="ID" />
+          <input
+            value={propertyId}
+            onChange={(e) => setPropertyId(e.target.value)}
+            placeholder="Property ID"
+          />
+          <input type="file" onChange={(e) => setFile(e.target.files?.[0] || null)} />
+        </div>
+        <div className="form-actions">
+          <button type="submit" disabled={status === 'uploading'}>
+            Submit Property App
+          </button>
+        </div>
+        {status === 'uploading' && (
+          <p className="form-message form-message--info">Uploading...</p>
+        )}
+        {status === 'success' && (
+          <p className="form-message form-message--success">Uploaded!</p>
+        )}
+        {status === 'error' && (
+          <p className="form-message form-message--error">{error}</p>
+        )}
+      </form>
+    </section>
   );
 }
 
@@ -130,13 +160,28 @@ export function AccountApplicationForm({
   };
 
   return (
-    <form onSubmit={submit}>
-      <input value={id} onChange={(e) => setId(e.target.value)} placeholder="ID" />
-      <input type="file" onChange={(e) => setFile(e.target.files?.[0] || null)} />
-      <button type="submit">Submit Account App</button>
-      {status === 'uploading' && <p>Uploading...</p>}
-      {status === 'success' && <p>Uploaded!</p>}
-      {status === 'error' && <p>{error}</p>}
-    </form>
+    <section className="form-section">
+      <form className="form-card" onSubmit={submit}>
+        <h3 className="form-title">Submit account application</h3>
+        <div className="form-fields">
+          <input value={id} onChange={(e) => setId(e.target.value)} placeholder="ID" />
+          <input type="file" onChange={(e) => setFile(e.target.files?.[0] || null)} />
+        </div>
+        <div className="form-actions">
+          <button type="submit" disabled={status === 'uploading'}>
+            Submit Account App
+          </button>
+        </div>
+        {status === 'uploading' && (
+          <p className="form-message form-message--info">Uploading...</p>
+        )}
+        {status === 'success' && (
+          <p className="form-message form-message--success">Uploaded!</p>
+        )}
+        {status === 'error' && (
+          <p className="form-message form-message--error">{error}</p>
+        )}
+      </form>
+    </section>
   );
 }

--- a/frontend/src/components/LoginForm.tsx
+++ b/frontend/src/components/LoginForm.tsx
@@ -18,11 +18,27 @@ export function LoginForm({ onLogin }: { onLogin?: () => void }) {
   };
 
   return (
-    <form onSubmit={submit}>
-      <input value={username} onChange={(e) => setUsername(e.target.value)} placeholder="Username" />
-      <input type="password" value={password} onChange={(e) => setPassword(e.target.value)} placeholder="Password" />
-      <button type="submit">Login</button>
-      {error && <p>{error}</p>}
-    </form>
+    <section className="form-section">
+      <form className="form-card" onSubmit={submit}>
+        <h2 className="form-title">Sign in</h2>
+        <div className="form-fields">
+          <input
+            value={username}
+            onChange={(e) => setUsername(e.target.value)}
+            placeholder="Username"
+          />
+          <input
+            type="password"
+            value={password}
+            onChange={(e) => setPassword(e.target.value)}
+            placeholder="Password"
+          />
+        </div>
+        <div className="form-actions">
+          <button type="submit">Login</button>
+        </div>
+        {error && <p className="form-message form-message--error">{error}</p>}
+      </form>
+    </section>
   );
 }

--- a/frontend/src/styles/global.css
+++ b/frontend/src/styles/global.css
@@ -1,0 +1,171 @@
+:root {
+  font-family: 'Inter', 'Segoe UI', Helvetica, Arial, sans-serif;
+  line-height: 1.5;
+  color: #1f2933;
+  background-color: #f4f6fb;
+  font-size: 16px;
+  --spacing-xs: 0.25rem;
+  --spacing-sm: 0.5rem;
+  --spacing-md: 1rem;
+  --spacing-lg: 1.5rem;
+  --spacing-xl: 2rem;
+  --color-surface: #ffffff;
+  --color-border: #d8dee9;
+  --color-border-strong: #c0cadb;
+  --color-primary: #2563eb;
+  --color-primary-dark: #1d4ed8;
+  --color-danger: #dc2626;
+  --color-success: #059669;
+  --color-info: #1d4ed8;
+}
+
+*,
+*::before,
+*::after {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  min-height: 100vh;
+  background-color: var(--color-surface);
+  color: inherit;
+}
+
+h1,
+h2,
+h3,
+h4,
+h5,
+h6 {
+  margin: 0 0 var(--spacing-md);
+  font-weight: 600;
+  line-height: 1.25;
+}
+
+p {
+  margin: 0 0 var(--spacing-md);
+}
+
+a {
+  color: var(--color-primary);
+  text-decoration: none;
+}
+
+a:hover {
+  text-decoration: underline;
+}
+
+form {
+  margin: 0;
+}
+
+input,
+select,
+textarea {
+  width: 100%;
+  padding: var(--spacing-sm) var(--spacing-md);
+  border: 1px solid var(--color-border);
+  border-radius: 0.5rem;
+  background-color: #ffffff;
+  font: inherit;
+  transition: border-color 0.2s ease, box-shadow 0.2s ease;
+}
+
+input:focus,
+select:focus,
+textarea:focus {
+  outline: none;
+  border-color: var(--color-primary);
+  box-shadow: 0 0 0 3px rgba(37, 99, 235, 0.2);
+}
+
+input[type='file'] {
+  padding: var(--spacing-sm);
+}
+
+button {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: var(--spacing-xs);
+  padding: calc(var(--spacing-sm) + 2px) var(--spacing-lg);
+  border: none;
+  border-radius: 0.5rem;
+  background-color: var(--color-primary);
+  color: #ffffff;
+  font: inherit;
+  font-weight: 600;
+  cursor: pointer;
+  transition: background-color 0.2s ease, transform 0.1s ease;
+}
+
+button:hover {
+  background-color: var(--color-primary-dark);
+}
+
+button:active {
+  transform: translateY(1px);
+}
+
+button:disabled {
+  background-color: var(--color-border-strong);
+  color: #4b5563;
+  cursor: not-allowed;
+}
+
+.form-section {
+  max-width: 520px;
+  margin: var(--spacing-xl) auto;
+  padding: 0 var(--spacing-md);
+}
+
+.form-card {
+  background-color: var(--color-surface);
+  border: 1px solid rgba(15, 23, 42, 0.08);
+  border-radius: 0.75rem;
+  box-shadow: 0 18px 35px rgba(15, 23, 42, 0.08);
+  padding: var(--spacing-xl);
+  display: flex;
+  flex-direction: column;
+  gap: var(--spacing-md);
+}
+
+.form-title {
+  margin-bottom: var(--spacing-sm);
+  font-size: 1.25rem;
+}
+
+.form-fields {
+  display: flex;
+  flex-direction: column;
+  gap: var(--spacing-md);
+}
+
+.form-actions {
+  display: flex;
+  justify-content: flex-end;
+}
+
+.form-message {
+  margin: var(--spacing-sm) 0 0;
+  font-size: 0.9rem;
+}
+
+.form-message--error {
+  color: var(--color-danger);
+}
+
+.form-message--success {
+  color: var(--color-success);
+}
+
+.form-message--info {
+  color: var(--color-info);
+}
+
+@media (max-width: 480px) {
+  .form-card {
+    padding: var(--spacing-lg);
+  }
+}


### PR DESCRIPTION
## Summary
- add a global stylesheet that defines shared typography, spacing, and control styles for the frontend
- wrap the login and application submission forms in structured containers that use the shared styles
- import the stylesheet from the dashboard entry point so the new look is applied across the app

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68cb6b2b7000832ca3e306be1c06caff