### PR TITLE
Add admin-only agents listing endpoint and regression tests

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -220,6 +220,14 @@ def create_agent(
     return Agent(username=agent.username, role=agent.role)
 
 
+@app.get("/agents", response_model=List[Agent])
+def list_agents(
+    _: Agent = Depends(require_admin),
+    repos: Repositories = Depends(get_repositories),
+):
+    return [Agent(username=agent.username, role=agent.role) for agent in repos.agents.list()]
+
+
 class LoginRequest(BaseModel):
     username: str
     password: str

--- a/tests/test_agent_roles.py
+++ b/tests/test_agent_roles.py
@@ -54,3 +54,46 @@ def test_bootstrap_token_allows_first_admin_then_admin_can_create_more(client):
     payload = resp.json()
     assert payload["username"] == "agent2"
     assert payload["role"] == "compliance"
+
+
+def test_list_agents_requires_admin_and_returns_agents(client):
+    from app.main import INITIAL_ADMIN_TOKEN
+
+    create_admin = client.post(
+        "/agents",
+        json={"username": "admin", "role": "admin", "password": "secret"},
+        headers={"X-Bootstrap-Token": INITIAL_ADMIN_TOKEN},
+    )
+    assert create_admin.status_code == 200
+
+    admin_login = client.post(
+        "/auth/login", json={"username": "admin", "password": "secret"}
+    )
+    assert admin_login.status_code == 200
+    admin_token = admin_login.json()["token"]
+
+    create_agent = client.post(
+        "/agents",
+        json={"username": "agent2", "role": "agent", "password": "secret"},
+        headers={"Authorization": f"Bearer {admin_token}"},
+    )
+    assert create_agent.status_code == 200
+
+    agent_login = client.post(
+        "/auth/login", json={"username": "agent2", "password": "secret"}
+    )
+    assert agent_login.status_code == 200
+    agent_token = agent_login.json()["token"]
+
+    list_resp = client.get(
+        "/agents", headers={"Authorization": f"Bearer {admin_token}"}
+    )
+    assert list_resp.status_code == 200
+    usernames = {agent["username"] for agent in list_resp.json()}
+    assert {"admin", "agent2"}.issubset(usernames)
+
+    forbidden = client.get(
+        "/agents", headers={"Authorization": f"Bearer {agent_token}"}
+    )
+    assert forbidden.status_code == 403
+    assert forbidden.json()["detail"] == "Admin privileges required"


### PR DESCRIPTION
## Summary
- add an admin-protected GET /agents endpoint returning stripped agent records
- exercise the new endpoint with regression coverage for admin and non-admin access

## Testing
- pytest tests/test_agent_roles.py

------
https://chatgpt.com/codex/tasks/task_e_68cb6fe0a584832cbc4911cb616223f1