### PR TITLE
Port property import and agent management components to dashboard

### DIFF
--- a/dashboard/src/api.ts
+++ b/dashboard/src/api.ts
@@ -64,6 +64,56 @@ export async function createProject(token: string, project: { id: number; name: 
   return res.json();
 }
 
+export interface ImportPropertiesResult {
+  message?: string;
+  imported?: number;
+  errors?: string[];
+}
+
+export async function importProperties(token: string, file: File) {
+  const formData = new FormData();
+  formData.append('file', file);
+
+  const res = await fetch(apiUrl('/import/properties'), {
+    method: 'POST',
+    headers: { Authorization: `Bearer ${token}` },
+    body: formData,
+  });
+  if (!res.ok) throw new Error('Failed to import properties');
+  return res.json() as Promise<ImportPropertiesResult>;
+}
+
+export type AgentRole = 'admin' | 'agent' | 'manager' | 'compliance';
+
+export interface Agent {
+  username: string;
+  role: AgentRole;
+}
+
+export interface AgentCreate {
+  username: string;
+  role: AgentRole;
+  password: string;
+}
+
+export const AGENT_ROLES: AgentRole[] = ['admin', 'manager', 'compliance', 'agent'];
+
+export async function listAgents(token: string) {
+  const res = await fetch(apiUrl('/agents'), { headers: headers(token) });
+  if (!res.ok) throw new Error('Failed to load agents');
+  return res.json() as Promise<Agent[]>;
+}
+
+export async function createAgent(token: string, agent: AgentCreate) {
+  const res = await fetch(apiUrl('/agents'), {
+    method: 'POST',
+    headers: headers(token),
+    body: JSON.stringify(agent),
+  });
+  if (!res.ok) throw new Error('Failed to create agent');
+  return res.json() as Promise<Agent>;
+}
+
 export async function getStands(token: string) {
   const res = await fetch(apiUrl('/stands/available'), { headers: headers(token) });
   if (!res.ok) throw new Error('Failed to load stands');

--- a/dashboard/src/components/AgentManagement.tsx
+++ b/dashboard/src/components/AgentManagement.tsx
@@ -1,0 +1,192 @@
+import React, { useEffect, useState } from 'react';
+import {
+  AGENT_ROLES,
+  Agent,
+  AgentCreate,
+  AgentRole,
+  createAgent,
+  listAgents,
+} from '../api';
+import { useAuth } from '../auth';
+
+interface AgentFormState {
+  username: string;
+  password: string;
+  role: AgentRole;
+}
+
+const defaultFormState: AgentFormState = {
+  username: '',
+  password: '',
+  role: 'agent',
+};
+
+const AgentManagement: React.FC = () => {
+  const { auth } = useAuth();
+  const role = auth?.role;
+  const token = auth?.token;
+  const [agents, setAgents] = useState<Agent[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [form, setForm] = useState<AgentFormState>(defaultFormState);
+  const [creating, setCreating] = useState(false);
+
+  useEffect(() => {
+    if (role !== 'admin') {
+      setLoading(false);
+      return;
+    }
+    if (!token) {
+      setError('You must be logged in to view agents.');
+      setLoading(false);
+      return;
+    }
+    let cancelled = false;
+    setLoading(true);
+    setError(null);
+    listAgents(token)
+      .then((data) => {
+        if (!cancelled) setAgents(data);
+      })
+      .catch((err) => {
+        if (cancelled) return;
+        const message =
+          err instanceof Error ? err.message : 'Failed to load agents.';
+        setError(message);
+      })
+      .finally(() => {
+        if (!cancelled) setLoading(false);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [role, token]);
+
+  if (role !== 'admin') {
+    return <p>You do not have permission to view this page.</p>;
+  }
+
+  const handleChange = (
+    event: React.ChangeEvent<HTMLInputElement | HTMLSelectElement>,
+  ) => {
+    const { name, value } = event.target;
+    setForm((prev) => ({ ...prev, [name]: value }));
+  };
+
+  const handleSubmit = async (event: React.FormEvent) => {
+    event.preventDefault();
+    if (!form.username || !form.password) {
+      setError('Username and password are required.');
+      return;
+    }
+    if (!auth?.token) {
+      setError('You must be logged in to create an agent.');
+      return;
+    }
+    setCreating(true);
+    setError(null);
+    try {
+      const payload: AgentCreate = {
+        username: form.username,
+        password: form.password,
+        role: form.role,
+      };
+      const created = await createAgent(auth.token, payload);
+      setAgents((prev) => {
+        const filtered = prev.filter((agent) => agent.username !== created.username);
+        return [...filtered, created].sort((a, b) =>
+          a.username.localeCompare(b.username),
+        );
+      });
+      setForm(defaultFormState);
+    } catch (err) {
+      const message =
+        err instanceof Error ? err.message : 'Failed to create agent.';
+      setError(message);
+    } finally {
+      setCreating(false);
+    }
+  };
+
+  return (
+    <div>
+      <section>
+        <h3>Create Agent</h3>
+        <form onSubmit={handleSubmit}>
+          <div>
+            <label>
+              Username
+              <input
+                name="username"
+                value={form.username}
+                onChange={handleChange}
+                disabled={creating}
+                required
+              />
+            </label>
+          </div>
+          <div>
+            <label>
+              Password
+              <input
+                type="password"
+                name="password"
+                value={form.password}
+                onChange={handleChange}
+                disabled={creating}
+                required
+              />
+            </label>
+          </div>
+          <div>
+            <label>
+              Role
+              <select
+                name="role"
+                value={form.role}
+                onChange={handleChange}
+                disabled={creating}
+              >
+                {AGENT_ROLES.map((r) => (
+                  <option key={r} value={r}>
+                    {r}
+                  </option>
+                ))}
+              </select>
+            </label>
+          </div>
+          <button type="submit" disabled={creating}>
+            {creating ? 'Creating…' : 'Create Agent'}
+          </button>
+        </form>
+      </section>
+      <section>
+        <h3>Existing Agents</h3>
+        {loading && <p>Loading agents…</p>}
+        {error && <p>{error}</p>}
+        {!loading && !agents.length && !error && <p>No agents found.</p>}
+        {agents.length > 0 && (
+          <table>
+            <thead>
+              <tr>
+                <th>Username</th>
+                <th>Role</th>
+              </tr>
+            </thead>
+            <tbody>
+              {agents.map((agent) => (
+                <tr key={agent.username}>
+                  <td>{agent.username}</td>
+                  <td>{agent.role}</td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        )}
+      </section>
+    </div>
+  );
+};
+
+export default AgentManagement;
+

--- a/dashboard/src/components/PropertyImportForm.tsx
+++ b/dashboard/src/components/PropertyImportForm.tsx
@@ -1,0 +1,107 @@
+import React, { useState } from 'react';
+import { importProperties, ImportPropertiesResult } from '../api';
+import { useAuth } from '../auth';
+
+type Status = 'idle' | 'uploading' | 'success' | 'error';
+
+export interface PropertyImportFormProps {
+  onImported?: (result: ImportPropertiesResult) => void;
+  className?: string;
+}
+
+const PropertyImportForm: React.FC<PropertyImportFormProps> = ({
+  onImported,
+  className,
+}) => {
+  const { auth } = useAuth();
+  const [file, setFile] = useState<File | null>(null);
+  const [status, setStatus] = useState<Status>('idle');
+  const [message, setMessage] = useState('');
+  const [error, setError] = useState('');
+  const [errors, setErrors] = useState<string[]>([]);
+
+  const resetFeedback = () => {
+    setStatus('idle');
+    setMessage('');
+    setError('');
+    setErrors([]);
+  };
+
+  const onFileChange = (event: React.ChangeEvent<HTMLInputElement>) => {
+    const selected = event.target.files?.[0] ?? null;
+    setFile(selected);
+    resetFeedback();
+  };
+
+  const handleSubmit = async (event: React.FormEvent) => {
+    event.preventDefault();
+    if (!file) {
+      setStatus('error');
+      setError('Please select a CSV or XLSX file to import.');
+      return;
+    }
+    if (!auth?.token) {
+      setStatus('error');
+      setError('You must be logged in to import properties.');
+      return;
+    }
+
+    setStatus('uploading');
+    setMessage('');
+    setError('');
+    setErrors([]);
+
+    try {
+      const result = await importProperties(auth.token, file);
+      const successMessage =
+        result.message ?? 'Property data imported successfully.';
+      const importErrors = result.errors ?? [];
+      setErrors(importErrors);
+
+      if (importErrors.length > 0) {
+        setStatus('error');
+        setMessage(successMessage);
+        setError('Some rows failed to import.');
+      } else {
+        setStatus('success');
+        setMessage(successMessage);
+      }
+      onImported?.(result);
+    } catch (err) {
+      setStatus('error');
+      const errorMessage =
+        err instanceof Error ? err.message : 'Failed to import properties.';
+      setError(errorMessage);
+      setErrors([]);
+    }
+  };
+
+  return (
+    <form onSubmit={handleSubmit} className={className}>
+      <label>
+        Upload property data
+        <input
+          type="file"
+          accept=".csv,.xlsx,.xls"
+          onChange={onFileChange}
+          disabled={status === 'uploading'}
+        />
+      </label>
+      <button type="submit" disabled={status === 'uploading'}>
+        {status === 'uploading' ? 'Importing…' : 'Import Properties'}
+      </button>
+      {message && <p>{message}</p>}
+      {status === 'error' && error && <p>{error}</p>}
+      {errors.length > 0 && (
+        <ul>
+          {errors.map((item, index) => (
+            <li key={index}>{item}</li>
+          ))}
+        </ul>
+      )}
+    </form>
+  );
+};
+
+export default PropertyImportForm;
+

--- a/dashboard/src/main.tsx
+++ b/dashboard/src/main.tsx
@@ -3,7 +3,7 @@ import ReactDOM from 'react-dom/client';
 import { BrowserRouter } from 'react-router-dom';
 import App from './App';
 import { AuthProvider } from './auth';
-import '../../frontend/src/styles/global.css';
+import './styles/global.css';
 
 ReactDOM.createRoot(document.getElementById('root') as HTMLElement).render(
   <React.StrictMode>

--- a/dashboard/src/pages/Agents.tsx
+++ b/dashboard/src/pages/Agents.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import AgentManagement from '../../../frontend/src/components/AgentManagement';
+import AgentManagement from '../components/AgentManagement';
 
 const AgentsPage: React.FC = () => (
   <div>

--- a/dashboard/src/pages/Projects.tsx
+++ b/dashboard/src/pages/Projects.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import PropertyImportForm from '../../../frontend/src/components/PropertyImportForm';
+import PropertyImportForm from '../components/PropertyImportForm';
 import { useAuth } from '../auth';
 import {
   getProjects as fetchProjects,

--- a/dashboard/src/styles/global.css
+++ b/dashboard/src/styles/global.css
@@ -1,0 +1,171 @@
+:root {
+  font-family: 'Inter', 'Segoe UI', Helvetica, Arial, sans-serif;
+  line-height: 1.5;
+  color: #1f2933;
+  background-color: #f4f6fb;
+  font-size: 16px;
+  --spacing-xs: 0.25rem;
+  --spacing-sm: 0.5rem;
+  --spacing-md: 1rem;
+  --spacing-lg: 1.5rem;
+  --spacing-xl: 2rem;
+  --color-surface: #ffffff;
+  --color-border: #d8dee9;
+  --color-border-strong: #c0cadb;
+  --color-primary: #2563eb;
+  --color-primary-dark: #1d4ed8;
+  --color-danger: #dc2626;
+  --color-success: #059669;
+  --color-info: #1d4ed8;
+}
+
+*,
+*::before,
+*::after {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  min-height: 100vh;
+  background-color: var(--color-surface);
+  color: inherit;
+}
+
+h1,
+h2,
+h3,
+h4,
+h5,
+h6 {
+  margin: 0 0 var(--spacing-md);
+  font-weight: 600;
+  line-height: 1.25;
+}
+
+p {
+  margin: 0 0 var(--spacing-md);
+}
+
+a {
+  color: var(--color-primary);
+  text-decoration: none;
+}
+
+a:hover {
+  text-decoration: underline;
+}
+
+form {
+  margin: 0;
+}
+
+input,
+select,
+textarea {
+  width: 100%;
+  padding: var(--spacing-sm) var(--spacing-md);
+  border: 1px solid var(--color-border);
+  border-radius: 0.5rem;
+  background-color: #ffffff;
+  font: inherit;
+  transition: border-color 0.2s ease, box-shadow 0.2s ease;
+}
+
+input:focus,
+select:focus,
+textarea:focus {
+  outline: none;
+  border-color: var(--color-primary);
+  box-shadow: 0 0 0 3px rgba(37, 99, 235, 0.2);
+}
+
+input[type='file'] {
+  padding: var(--spacing-sm);
+}
+
+button {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: var(--spacing-xs);
+  padding: calc(var(--spacing-sm) + 2px) var(--spacing-lg);
+  border: none;
+  border-radius: 0.5rem;
+  background-color: var(--color-primary);
+  color: #ffffff;
+  font: inherit;
+  font-weight: 600;
+  cursor: pointer;
+  transition: background-color 0.2s ease, transform 0.1s ease;
+}
+
+button:hover {
+  background-color: var(--color-primary-dark);
+}
+
+button:active {
+  transform: translateY(1px);
+}
+
+button:disabled {
+  background-color: var(--color-border-strong);
+  color: #4b5563;
+  cursor: not-allowed;
+}
+
+.form-section {
+  max-width: 520px;
+  margin: var(--spacing-xl) auto;
+  padding: 0 var(--spacing-md);
+}
+
+.form-card {
+  background-color: var(--color-surface);
+  border: 1px solid rgba(15, 23, 42, 0.08);
+  border-radius: 0.75rem;
+  box-shadow: 0 18px 35px rgba(15, 23, 42, 0.08);
+  padding: var(--spacing-xl);
+  display: flex;
+  flex-direction: column;
+  gap: var(--spacing-md);
+}
+
+.form-title {
+  margin-bottom: var(--spacing-sm);
+  font-size: 1.25rem;
+}
+
+.form-fields {
+  display: flex;
+  flex-direction: column;
+  gap: var(--spacing-md);
+}
+
+.form-actions {
+  display: flex;
+  justify-content: flex-end;
+}
+
+.form-message {
+  margin: var(--spacing-sm) 0 0;
+  font-size: 0.9rem;
+}
+
+.form-message--error {
+  color: var(--color-danger);
+}
+
+.form-message--success {
+  color: var(--color-success);
+}
+
+.form-message--info {
+  color: var(--color-info);
+}
+
+@media (max-width: 480px) {
+  .form-card {
+    padding: var(--spacing-lg);
+  }
+}


### PR DESCRIPTION
## Summary
- copy the shared global stylesheet into the dashboard bundle and point main.tsx at it
- expose property import and agent management API helpers alongside new dashboard components
- update dashboard pages to consume the local components and drop frontend/ references

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68cb77e03b80832cb80bcecb0438e2f2