### PR TITLE
Modernize dashboard forms and tables

### DIFF
--- a/dashboard/src/components/AgentManagement.tsx
+++ b/dashboard/src/components/AgentManagement.tsx
@@ -21,7 +21,11 @@ const defaultFormState: AgentFormState = {
   role: 'agent',
 };
 
-const AgentManagement: React.FC = () => {
+interface AgentManagementProps {
+  className?: string;
+}
+
+const AgentManagement: React.FC<AgentManagementProps> = ({ className }) => {
   const { auth } = useAuth();
   const role = auth?.role;
   const token = auth?.token;
@@ -109,14 +113,15 @@ const AgentManagement: React.FC = () => {
   };
 
   return (
-    <div>
-      <section>
-        <h3>Create Agent</h3>
-        <form onSubmit={handleSubmit}>
-          <div>
-            <label>
+    <div className={className}>
+      <section className="form-section">
+        <form className="form-card" onSubmit={handleSubmit}>
+          <h3 className="form-title">Create Agent</h3>
+          <div className="form-fields">
+            <label htmlFor="agent-username">
               Username
               <input
+                id="agent-username"
                 name="username"
                 value={form.username}
                 onChange={handleChange}
@@ -124,11 +129,10 @@ const AgentManagement: React.FC = () => {
                 required
               />
             </label>
-          </div>
-          <div>
-            <label>
+            <label htmlFor="agent-password">
               Password
               <input
+                id="agent-password"
                 type="password"
                 name="password"
                 value={form.password}
@@ -137,11 +141,10 @@ const AgentManagement: React.FC = () => {
                 required
               />
             </label>
-          </div>
-          <div>
-            <label>
+            <label htmlFor="agent-role">
               Role
               <select
+                id="agent-role"
                 name="role"
                 value={form.role}
                 onChange={handleChange}
@@ -155,34 +158,45 @@ const AgentManagement: React.FC = () => {
               </select>
             </label>
           </div>
-          <button type="submit" disabled={creating}>
-            {creating ? 'Creating…' : 'Create Agent'}
-          </button>
+          {error && <p className="form-message form-message--error">{error}</p>}
+          <div className="form-actions">
+            <button type="submit" disabled={creating}>
+              {creating ? 'Creating…' : 'Create Agent'}
+            </button>
+          </div>
         </form>
       </section>
-      <section>
-        <h3>Existing Agents</h3>
-        {loading && <p>Loading agents…</p>}
-        {error && <p>{error}</p>}
-        {!loading && !agents.length && !error && <p>No agents found.</p>}
-        {agents.length > 0 && (
-          <table>
-            <thead>
-              <tr>
-                <th>Username</th>
-                <th>Role</th>
-              </tr>
-            </thead>
-            <tbody>
-              {agents.map((agent) => (
-                <tr key={agent.username}>
-                  <td>{agent.username}</td>
-                  <td>{agent.role}</td>
-                </tr>
-              ))}
-            </tbody>
-          </table>
-        )}
+      <section className="form-section">
+        <div className="form-card">
+          <h3 className="form-title">Existing Agents</h3>
+          {loading && <p className="form-message form-message--info">Loading agents…</p>}
+          {error && !loading && !agents.length && (
+            <p className="form-message form-message--error">{error}</p>
+          )}
+          {!loading && !agents.length && !error && (
+            <p className="form-message">No agents found.</p>
+          )}
+          {agents.length > 0 && (
+            <div className="table-wrapper">
+              <table className="data-table">
+                <thead className="data-table__header">
+                  <tr>
+                    <th scope="col">Username</th>
+                    <th scope="col">Role</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {agents.map((agent) => (
+                    <tr key={agent.username}>
+                      <td>{agent.username}</td>
+                      <td>{agent.role}</td>
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+            </div>
+          )}
+        </div>
       </section>
     </div>
   );

--- a/dashboard/src/components/PropertyImportForm.tsx
+++ b/dashboard/src/components/PropertyImportForm.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React, { useMemo, useState } from 'react';
 import { importProperties, ImportPropertiesResult } from '../api';
 import { useAuth } from '../auth';
 
@@ -7,11 +7,17 @@ type Status = 'idle' | 'uploading' | 'success' | 'error';
 export interface PropertyImportFormProps {
   onImported?: (result: ImportPropertiesResult) => void;
   className?: string;
+  fieldsClassName?: string;
+  actionsClassName?: string;
+  children?: React.ReactNode;
 }
 
 const PropertyImportForm: React.FC<PropertyImportFormProps> = ({
   onImported,
   className,
+  fieldsClassName,
+  actionsClassName,
+  children,
 }) => {
   const { auth } = useAuth();
   const [file, setFile] = useState<File | null>(null);
@@ -19,6 +25,19 @@ const PropertyImportForm: React.FC<PropertyImportFormProps> = ({
   const [message, setMessage] = useState('');
   const [error, setError] = useState('');
   const [errors, setErrors] = useState<string[]>([]);
+
+  const formClassName = useMemo(
+    () => ['form-card', className].filter(Boolean).join(' '),
+    [className],
+  );
+  const mergedFieldsClassName = useMemo(
+    () => ['form-fields', fieldsClassName].filter(Boolean).join(' '),
+    [fieldsClassName],
+  );
+  const mergedActionsClassName = useMemo(
+    () => ['form-actions', actionsClassName].filter(Boolean).join(' '),
+    [actionsClassName],
+  );
 
   const resetFeedback = () => {
     setStatus('idle');
@@ -77,28 +96,44 @@ const PropertyImportForm: React.FC<PropertyImportFormProps> = ({
   };
 
   return (
-    <form onSubmit={handleSubmit} className={className}>
-      <label>
-        Upload property data
-        <input
-          type="file"
-          accept=".csv,.xlsx,.xls"
-          onChange={onFileChange}
-          disabled={status === 'uploading'}
-        />
-      </label>
-      <button type="submit" disabled={status === 'uploading'}>
-        {status === 'uploading' ? 'Importing…' : 'Import Properties'}
-      </button>
-      {message && <p>{message}</p>}
-      {status === 'error' && error && <p>{error}</p>}
+    <form onSubmit={handleSubmit} className={formClassName}>
+      {children}
+      <div className={mergedFieldsClassName}>
+        <label htmlFor="property-import-file">
+          Upload property data
+          <input
+            id="property-import-file"
+            type="file"
+            accept=".csv,.xlsx,.xls"
+            onChange={onFileChange}
+            disabled={status === 'uploading'}
+          />
+        </label>
+      </div>
+      {message && (
+        <p
+          className={['form-message', status === 'success' ? 'form-message--success' : 'form-message--info']
+            .filter(Boolean)
+            .join(' ')}
+        >
+          {message}
+        </p>
+      )}
+      {status === 'error' && error && (
+        <p className="form-message form-message--error">{error}</p>
+      )}
       {errors.length > 0 && (
-        <ul>
+        <ul className="form-message form-message--error">
           {errors.map((item, index) => (
             <li key={index}>{item}</li>
           ))}
         </ul>
       )}
+      <div className={mergedActionsClassName}>
+        <button type="submit" disabled={status === 'uploading'}>
+          {status === 'uploading' ? 'Importing…' : 'Import Properties'}
+        </button>
+      </div>
     </form>
   );
 };

--- a/dashboard/src/pages/Dashboard.tsx
+++ b/dashboard/src/pages/Dashboard.tsx
@@ -65,14 +65,21 @@ const Dashboard: React.FC = () => {
     };
 
     return (
-      <form onSubmit={submit}>
-        <input
-          placeholder="Details"
-          value={details}
-          onChange={e => setDetails(e.target.value)}
-          required
-        />
-        <button type="submit">{label}</button>
+      <form className="upload-inline-form" onSubmit={submit}>
+        <div className="form-fields">
+          <label>
+            Details
+            <input
+              placeholder="Provide submission details"
+              value={details}
+              onChange={e => setDetails(e.target.value)}
+              required
+            />
+          </label>
+        </div>
+        <div className="form-actions">
+          <button type="submit">{label}</button>
+        </div>
         {progress > 0 && <progress value={progress} max={100} />}
       </form>
     );
@@ -83,89 +90,115 @@ const Dashboard: React.FC = () => {
   return (
     <div>
       <h2>Dashboard</h2>
-      <div>
-        <input
-          placeholder="Project ID"
-          value={project}
-          onChange={e => setProject(e.target.value)}
-        />
-        <input
-          placeholder="Max Price"
-          value={price}
-          onChange={e => setPrice(e.target.value)}
-        />
-        <select value={status} onChange={e => setStatus(e.target.value)}>
-          <option value="">All</option>
-          <option value="available">Available</option>
-          <option value="reserved">Reserved</option>
-          <option value="sold">Sold</option>
-        </select>
-      </div>
-      <table>
-        <thead>
-          <tr>
-            <th>ID</th>
-            <th>Project</th>
-            <th>Name</th>
-            <th>Price</th>
-            <th>Status</th>
-            <th>Agreement Status</th>
-            <th>Expires</th>
-            <th>Actions</th>
-          </tr>
-        </thead>
-        <tbody>
-          {filtered.map(s => (
-            <tr key={s.id}>
-              <td>{s.id}</td>
-              <td>{s.project_id}</td>
-              <td>{s.name}</td>
-              <td>{s.price}</td>
-              <td>{s.status}</td>
-              <td>{s.mandate?.agreement_status || 'N/A'}</td>
-              <td>
-                {s.mandate?.expiration_date
-                  ? new Date(s.mandate.expiration_date).toLocaleDateString()
-                  : 'N/A'}
-              </td>
-              <td>
-                <UploadForm
-                  label="Offer"
-                  onSubmit={details =>
-                    submitOffer(auth.token, {
-                      id: Date.now(),
-                      realtor: auth.username,
-                      property_id: s.id,
-                      details,
-                    })
-                  }
-                />
-                <UploadForm
-                  label="Account Opening"
-                  onSubmit={details =>
-                    submitAccountOpening(auth.token, {
-                      id: Date.now(),
-                      realtor: auth.username,
-                      details,
-                    })
-                  }
-                />
-                <UploadForm
-                  label="Property Application"
-                  onSubmit={details =>
-                    submitPropertyApplication(auth.token, {
-                      id: Date.now(),
-                      realtor: auth.username,
-                      property_id: s.id,
-                      details,
-                    })
-                  }
-                />
-              </td>
-            </tr>
-          ))}
-        </tbody>
-      </table>
+      <section className="form-section">
+        <div className="form-card">
+          <h3 className="form-title">Filter Stands</h3>
+          <div className="form-fields">
+            <label htmlFor="dashboard-project-filter">
+              Project ID
+              <input
+                id="dashboard-project-filter"
+                placeholder="Filter by project ID"
+                value={project}
+                onChange={e => setProject(e.target.value)}
+              />
+            </label>
+            <label htmlFor="dashboard-price-filter">
+              Max Price
+              <input
+                id="dashboard-price-filter"
+                placeholder="Filter by maximum price"
+                value={price}
+                onChange={e => setPrice(e.target.value)}
+              />
+            </label>
+            <label htmlFor="dashboard-status-filter">
+              Status
+              <select
+                id="dashboard-status-filter"
+                value={status}
+                onChange={e => setStatus(e.target.value)}
+              >
+                <option value="">All</option>
+                <option value="available">Available</option>
+                <option value="reserved">Reserved</option>
+                <option value="sold">Sold</option>
+              </select>
+            </label>
+          </div>
+        </div>
+      </section>
+      <section className="form-section">
+        <div className="form-card">
+          <div className="table-wrapper">
+            <table className="data-table">
+              <thead className="data-table__header">
+                <tr>
+                  <th scope="col">ID</th>
+                  <th scope="col">Project</th>
+                  <th scope="col">Name</th>
+                  <th scope="col">Price</th>
+                  <th scope="col">Status</th>
+                  <th scope="col">Agreement Status</th>
+                  <th scope="col">Expires</th>
+                  <th scope="col">Actions</th>
+                </tr>
+              </thead>
+              <tbody>
+                {filtered.map(s => (
+                  <tr key={s.id}>
+                    <td>{s.id}</td>
+                    <td>{s.project_id}</td>
+                    <td>{s.name}</td>
+                    <td>{s.price}</td>
+                    <td>{s.status}</td>
+                    <td>{s.mandate?.agreement_status || 'N/A'}</td>
+                    <td>
+                      {s.mandate?.expiration_date
+                        ? new Date(s.mandate.expiration_date).toLocaleDateString()
+                        : 'N/A'}
+                    </td>
+                    <td className="data-table__actions">
+                      <UploadForm
+                        label="Offer"
+                        onSubmit={details =>
+                          submitOffer(auth.token, {
+                            id: Date.now(),
+                            realtor: auth.username,
+                            property_id: s.id,
+                            details,
+                          })
+                        }
+                      />
+                      <UploadForm
+                        label="Account Opening"
+                        onSubmit={details =>
+                          submitAccountOpening(auth.token, {
+                            id: Date.now(),
+                            realtor: auth.username,
+                            details,
+                          })
+                        }
+                      />
+                      <UploadForm
+                        label="Property Application"
+                        onSubmit={details =>
+                          submitPropertyApplication(auth.token, {
+                            id: Date.now(),
+                            realtor: auth.username,
+                            property_id: s.id,
+                            details,
+                          })
+                        }
+                      />
+                    </td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+        </div>
+      </section>
     </div>
   );
 };

--- a/dashboard/src/pages/LoanAccounts.tsx
+++ b/dashboard/src/pages/LoanAccounts.tsx
@@ -20,20 +20,32 @@ const LoanAccounts: React.FC = () => {
   };
 
   return (
-    <div>
-      <h2>Loan Account Opening</h2>
-      <form onSubmit={handleSubmit}>
-        <input
-          type="number"
-          value={agreementId}
-          onChange={e => setAgreementId(e.target.value)}
-          placeholder="Agreement ID"
-        />
-        <button type="submit">Open Account</button>
+    <section className="form-section">
+      <form className="form-card" onSubmit={handleSubmit}>
+        <h2 className="form-title">Loan Account Opening</h2>
+        <div className="form-fields">
+          <label htmlFor="loan-agreement-id">
+            Agreement ID
+            <input
+              id="loan-agreement-id"
+              type="number"
+              value={agreementId}
+              onChange={e => setAgreementId(e.target.value)}
+              placeholder="Enter agreement ID"
+            />
+          </label>
+        </div>
+        {accountNumber && (
+          <p className="form-message form-message--success">
+            Account Number: {accountNumber}
+          </p>
+        )}
+        {error && <p className="form-message form-message--error">{error}</p>}
+        <div className="form-actions">
+          <button type="submit">Open Account</button>
+        </div>
       </form>
-      {accountNumber && <p>Account Number: {accountNumber}</p>}
-      {error && <p>{error}</p>}
-    </div>
+    </section>
   );
 };
 

--- a/dashboard/src/pages/Login.tsx
+++ b/dashboard/src/pages/Login.tsx
@@ -30,26 +30,38 @@ const Login: React.FC = () => {
   };
 
   return (
-    <div>
-      <h2>Login</h2>
-      <form onSubmit={submit}>
-        <input
-          placeholder="Username"
-          value={username}
-          onChange={e => setUsername(e.target.value)}
-          required
-        />
-        <input
-          type="password"
-          placeholder="Password"
-          value={password}
-          onChange={e => setPassword(e.target.value)}
-          required
-        />
-        <button type="submit">Login</button>
+    <section className="form-section">
+      <form className="form-card" onSubmit={submit}>
+        <h2 className="form-title">Login</h2>
+        <div className="form-fields">
+          <label htmlFor="login-username">
+            Username
+            <input
+              id="login-username"
+              placeholder="Enter your username"
+              value={username}
+              onChange={e => setUsername(e.target.value)}
+              required
+            />
+          </label>
+          <label htmlFor="login-password">
+            Password
+            <input
+              id="login-password"
+              type="password"
+              placeholder="Enter your password"
+              value={password}
+              onChange={e => setPassword(e.target.value)}
+              required
+            />
+          </label>
+        </div>
+        {error && <p className="form-message form-message--error">{error}</p>}
+        <div className="form-actions">
+          <button type="submit">Login</button>
+        </div>
       </form>
-      {error && <p>{error}</p>}
-    </div>
+    </section>
   );
 };
 

--- a/dashboard/src/pages/MultiStepForm.tsx
+++ b/dashboard/src/pages/MultiStepForm.tsx
@@ -95,67 +95,117 @@ const MultiStepForm: React.FC = () => {
   return (
     <div>
       <h2>New Submission</h2>
-      {error && <p style={{ color: 'red' }}>{error}</p>}
-      {success && <p style={{ color: 'green' }}>{success}</p>}
+      {error && <p className="form-message form-message--error">{error}</p>}
+      {success && <p className="form-message form-message--success">{success}</p>}
       {step === 1 && (
-        <form onSubmit={submitOfferStep}>
-          <h3>Offer Details</h3>
-          <input
-            placeholder="Property ID"
-            value={offer.propertyId}
-            onChange={e => setOffer({ ...offer, propertyId: e.target.value })}
-          />
-          <textarea
-            placeholder="Details"
-            value={offer.details}
-            onChange={e => setOffer({ ...offer, details: e.target.value })}
-          />
-          <input
-            type="file"
-            accept=".pdf,.csv"
-            onChange={e => setOffer({ ...offer, file: e.target.files?.[0] })}
-          />
-          <button type="submit">Next</button>
-        </form>
+        <section className="form-section">
+          <form className="form-card" onSubmit={submitOfferStep}>
+            <h3 className="form-title">Offer Details</h3>
+            <div className="form-fields">
+              <label htmlFor="offer-property-id">
+                Property ID
+                <input
+                  id="offer-property-id"
+                  placeholder="Enter property ID"
+                  value={offer.propertyId}
+                  onChange={e => setOffer({ ...offer, propertyId: e.target.value })}
+                />
+              </label>
+              <label htmlFor="offer-details">
+                Details
+                <textarea
+                  id="offer-details"
+                  placeholder="Describe the offer"
+                  value={offer.details}
+                  onChange={e => setOffer({ ...offer, details: e.target.value })}
+                />
+              </label>
+              <label htmlFor="offer-file">
+                Supporting File
+                <input
+                  id="offer-file"
+                  type="file"
+                  accept=".pdf,.csv"
+                  onChange={e => setOffer({ ...offer, file: e.target.files?.[0] })}
+                />
+              </label>
+            </div>
+            <div className="form-actions">
+              <button type="submit">Next</button>
+            </div>
+          </form>
+        </section>
       )}
       {step === 2 && (
-        <form onSubmit={submitApplicationStep}>
-          <h3>Property Application</h3>
-          <input
-            placeholder="Property ID"
-            value={application.propertyId}
-            onChange={e => setApplication({ ...application, propertyId: e.target.value })}
-          />
-          <textarea
-            placeholder="Details"
-            value={application.details}
-            onChange={e => setApplication({ ...application, details: e.target.value })}
-          />
-          <input
-            type="file"
-            accept=".pdf,.csv"
-            onChange={e => setApplication({ ...application, file: e.target.files?.[0] })}
-          />
-          <button type="submit">Next</button>
-        </form>
+        <section className="form-section">
+          <form className="form-card" onSubmit={submitApplicationStep}>
+            <h3 className="form-title">Property Application</h3>
+            <div className="form-fields">
+              <label htmlFor="application-property-id">
+                Property ID
+                <input
+                  id="application-property-id"
+                  placeholder="Enter property ID"
+                  value={application.propertyId}
+                  onChange={e => setApplication({ ...application, propertyId: e.target.value })}
+                />
+              </label>
+              <label htmlFor="application-details">
+                Details
+                <textarea
+                  id="application-details"
+                  placeholder="Describe the application"
+                  value={application.details}
+                  onChange={e => setApplication({ ...application, details: e.target.value })}
+                />
+              </label>
+              <label htmlFor="application-file">
+                Supporting File
+                <input
+                  id="application-file"
+                  type="file"
+                  accept=".pdf,.csv"
+                  onChange={e => setApplication({ ...application, file: e.target.files?.[0] })}
+                />
+              </label>
+            </div>
+            <div className="form-actions">
+              <button type="submit">Next</button>
+            </div>
+          </form>
+        </section>
       )}
       {step === 3 && (
-        <form onSubmit={submitAccountStep}>
-          <h3>Account Opening</h3>
-          <textarea
-            placeholder="Details"
-            value={account.details}
-            onChange={e => setAccount({ ...account, details: e.target.value })}
-          />
-          <input
-            type="file"
-            accept=".pdf,.csv"
-            onChange={e => setAccount({ ...account, file: e.target.files?.[0] })}
-          />
-          <button type="submit">Submit</button>
-        </form>
+        <section className="form-section">
+          <form className="form-card" onSubmit={submitAccountStep}>
+            <h3 className="form-title">Account Opening</h3>
+            <div className="form-fields">
+              <label htmlFor="account-details">
+                Details
+                <textarea
+                  id="account-details"
+                  placeholder="Provide account opening details"
+                  value={account.details}
+                  onChange={e => setAccount({ ...account, details: e.target.value })}
+                />
+              </label>
+              <label htmlFor="account-file">
+                Supporting File
+                <input
+                  id="account-file"
+                  type="file"
+                  accept=".pdf,.csv"
+                  onChange={e => setAccount({ ...account, file: e.target.files?.[0] })}
+                />
+              </label>
+            </div>
+            <div className="form-actions">
+              <button type="submit">Submit</button>
+            </div>
+          </form>
+        </section>
       )}
-      {step > 3 && <p>All steps completed.</p>}
+      {step > 3 && <p className="form-message form-message--success">All steps completed.</p>}
     </div>
   );
 };

--- a/dashboard/src/pages/Projects.tsx
+++ b/dashboard/src/pages/Projects.tsx
@@ -45,48 +45,80 @@ const Projects: React.FC = () => {
     <div>
       <h2>Projects</h2>
       {auth?.role === 'admin' && (
-        <section>
-          <h3>Import Properties</h3>
-          <p>Select a CSV or Excel file to upload new property records.</p>
-          <PropertyImportForm />
+        <section className="form-section">
+          <PropertyImportForm
+            className="form-card"
+            fieldsClassName="form-fields"
+            actionsClassName="form-actions"
+          >
+            <h3 className="form-title">Import Properties</h3>
+            <p>Select a CSV or Excel file to upload new property records.</p>
+          </PropertyImportForm>
         </section>
       )}
-      <form onSubmit={submit}>
-        <input
-          placeholder="ID"
-          value={form.id}
-          onChange={e => setForm({ ...form, id: e.target.value })}
-          required
-        />
-        <input
-          placeholder="Name"
-          value={form.name}
-          onChange={e => setForm({ ...form, name: e.target.value })}
-          required
-        />
-        <button type="submit">Add</button>
-      </form>
-      <input
-        placeholder="Search"
-        value={search}
-        onChange={e => setSearch(e.target.value)}
-      />
-      <table>
-        <thead>
-          <tr>
-            <th>ID</th>
-            <th>Name</th>
-          </tr>
-        </thead>
-        <tbody>
-          {filtered.map(p => (
-            <tr key={p.id}>
-              <td>{p.id}</td>
-              <td>{p.name}</td>
-            </tr>
-          ))}
-        </tbody>
-      </table>
+      <section className="form-section">
+        <form className="form-card" onSubmit={submit}>
+          <h3 className="form-title">Add Project</h3>
+          <div className="form-fields">
+            <label htmlFor="project-id">
+              Project ID
+              <input
+                id="project-id"
+                placeholder="e.g. 1001"
+                value={form.id}
+                onChange={e => setForm({ ...form, id: e.target.value })}
+                required
+              />
+            </label>
+            <label htmlFor="project-name">
+              Name
+              <input
+                id="project-name"
+                placeholder="Enter project name"
+                value={form.name}
+                onChange={e => setForm({ ...form, name: e.target.value })}
+                required
+              />
+            </label>
+          </div>
+          <div className="form-actions">
+            <button type="submit">Add Project</button>
+          </div>
+        </form>
+      </section>
+      <section className="form-section">
+        <div className="form-card">
+          <div className="form-fields">
+            <label htmlFor="project-search">
+              Search Projects
+              <input
+                id="project-search"
+                placeholder="Filter by name"
+                value={search}
+                onChange={e => setSearch(e.target.value)}
+              />
+            </label>
+          </div>
+          <div className="table-wrapper">
+            <table className="data-table">
+              <thead className="data-table__header">
+                <tr>
+                  <th scope="col">ID</th>
+                  <th scope="col">Name</th>
+                </tr>
+              </thead>
+              <tbody>
+                {filtered.map(p => (
+                  <tr key={p.id}>
+                    <td>{p.id}</td>
+                    <td>{p.name}</td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+        </div>
+      </section>
     </div>
   );
 };

--- a/dashboard/src/pages/Stands.tsx
+++ b/dashboard/src/pages/Stands.tsx
@@ -76,46 +76,124 @@ const Stands: React.FC = () => {
   return (
     <div>
       <h2>Stands</h2>
-      <input
-        placeholder="Project ID"
-        value={projectFilter}
-        onChange={e => setProjectFilter(e.target.value)}
-      />
-      <form onSubmit={submit}>
-        <input placeholder="ID" value={form.id} onChange={e => setForm({ ...form, id: e.target.value })} required />
-        <input placeholder="Project ID" value={form.project_id} onChange={e => setForm({ ...form, project_id: e.target.value })} required />
-        <input placeholder="Name" value={form.name} onChange={e => setForm({ ...form, name: e.target.value })} required />
-        <input placeholder="Size" value={form.size} onChange={e => setForm({ ...form, size: e.target.value })} required />
-        <input placeholder="Price" value={form.price} onChange={e => setForm({ ...form, price: e.target.value })} required />
-        <button type="submit">Add</button>
-      </form>
-      <input placeholder="Search" value={search} onChange={e => setSearch(e.target.value)} />
-      <table>
-        <thead>
-          <tr>
-            <th>ID</th>
-            <th>Name</th>
-            <th>Project</th>
-            <th>Size</th>
-            <th>Price</th>
-            <th></th>
-          </tr>
-        </thead>
-        <tbody>
-          {filtered.map(s => (
-            <tr key={s.id}>
-              <td>{s.id}</td>
-              <td>{s.name}</td>
-              <td>{s.project_id}</td>
-              <td>{s.size}</td>
-              <td>{s.price}</td>
-              <td>
-                <button onClick={() => remove(s.id)}>Delete</button>
-              </td>
-            </tr>
-          ))}
-        </tbody>
-      </table>
+      <section className="form-section">
+        <div className="form-card">
+          <div className="form-fields">
+            <label htmlFor="stands-project-filter">
+              Filter by Project ID
+              <input
+                id="stands-project-filter"
+                placeholder="Enter project ID"
+                value={projectFilter}
+                onChange={e => setProjectFilter(e.target.value)}
+              />
+            </label>
+            <label htmlFor="stands-search">
+              Search by Name
+              <input
+                id="stands-search"
+                placeholder="Search stands"
+                value={search}
+                onChange={e => setSearch(e.target.value)}
+              />
+            </label>
+          </div>
+        </div>
+      </section>
+      <section className="form-section">
+        <form className="form-card" onSubmit={submit}>
+          <h3 className="form-title">Add Stand</h3>
+          <div className="form-fields">
+            <label htmlFor="stand-id">
+              Stand ID
+              <input
+                id="stand-id"
+                placeholder="ID"
+                value={form.id}
+                onChange={e => setForm({ ...form, id: e.target.value })}
+                required
+              />
+            </label>
+            <label htmlFor="stand-project-id">
+              Project ID
+              <input
+                id="stand-project-id"
+                placeholder="Project ID"
+                value={form.project_id}
+                onChange={e => setForm({ ...form, project_id: e.target.value })}
+                required
+              />
+            </label>
+            <label htmlFor="stand-name">
+              Name
+              <input
+                id="stand-name"
+                placeholder="Name"
+                value={form.name}
+                onChange={e => setForm({ ...form, name: e.target.value })}
+                required
+              />
+            </label>
+            <label htmlFor="stand-size">
+              Size
+              <input
+                id="stand-size"
+                placeholder="Size"
+                value={form.size}
+                onChange={e => setForm({ ...form, size: e.target.value })}
+                required
+              />
+            </label>
+            <label htmlFor="stand-price">
+              Price
+              <input
+                id="stand-price"
+                placeholder="Price"
+                value={form.price}
+                onChange={e => setForm({ ...form, price: e.target.value })}
+                required
+              />
+            </label>
+          </div>
+          <div className="form-actions">
+            <button type="submit">Add Stand</button>
+          </div>
+        </form>
+      </section>
+      <section className="form-section">
+        <div className="form-card">
+          <div className="table-wrapper">
+            <table className="data-table">
+              <thead className="data-table__header">
+                <tr>
+                  <th scope="col">ID</th>
+                  <th scope="col">Name</th>
+                  <th scope="col">Project</th>
+                  <th scope="col">Size</th>
+                  <th scope="col">Price</th>
+                  <th scope="col" aria-label="Actions"></th>
+                </tr>
+              </thead>
+              <tbody>
+                {filtered.map(s => (
+                  <tr key={s.id}>
+                    <td>{s.id}</td>
+                    <td>{s.name}</td>
+                    <td>{s.project_id}</td>
+                    <td>{s.size}</td>
+                    <td>{s.price}</td>
+                    <td className="data-table__actions">
+                      <button type="button" onClick={() => remove(s.id)}>
+                        Delete
+                      </button>
+                    </td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+        </div>
+      </section>
     </div>
   );
 };

--- a/dashboard/src/styles/global.css
+++ b/dashboard/src/styles/global.css
@@ -244,6 +244,10 @@ button:disabled {
   justify-content: flex-end;
 }
 
+.form-card .form-actions {
+  margin-top: var(--spacing-sm);
+}
+
 .form-message {
   margin: var(--spacing-sm) 0 0;
   font-size: 0.9rem;
@@ -261,8 +265,78 @@ button:disabled {
   color: var(--color-info);
 }
 
+ul.form-message {
+  padding-left: var(--spacing-lg);
+}
+
+.table-wrapper {
+  overflow-x: auto;
+}
+
+.data-table {
+  width: 100%;
+  border-collapse: collapse;
+  min-width: 600px;
+  background-color: var(--color-surface);
+}
+
+.data-table th,
+.data-table td {
+  padding: var(--spacing-sm) var(--spacing-md);
+  border-bottom: 1px solid var(--color-border);
+  text-align: left;
+  vertical-align: top;
+}
+
+.data-table__header th {
+  background-color: rgba(15, 23, 42, 0.04);
+  font-weight: 600;
+  font-size: 0.85rem;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+}
+
+.data-table tbody tr:hover {
+  background-color: rgba(37, 99, 235, 0.04);
+}
+
+.data-table__actions {
+  display: flex;
+  flex-direction: column;
+  gap: var(--spacing-sm);
+}
+
+.data-table__actions .form-actions {
+  justify-content: flex-start;
+}
+
+.upload-inline-form {
+  display: flex;
+  flex-direction: column;
+  gap: var(--spacing-sm);
+}
+
+.upload-inline-form .form-actions {
+  justify-content: flex-start;
+}
+
+.upload-inline-form progress {
+  width: 100%;
+  height: 0.5rem;
+  border-radius: 999px;
+  overflow: hidden;
+}
+
 @media (max-width: 480px) {
   .form-card {
     padding: var(--spacing-lg);
+  }
+
+  .data-table {
+    min-width: unset;
+  }
+
+  .data-table__actions {
+    gap: var(--spacing-xs);
   }
 }


### PR DESCRIPTION
## Summary
- wrap login, dashboard, projects, stands, loan accounts, and multi-step flows in form-section and form-card layouts with structured form-fields and form-actions blocks
- enhance shared form components with configurable class names and updated messaging styles, and add responsive data table styling helpers
- restyle project and agent listings (and related tables) to use the new data-table presentation for improved readability

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68cb7bd87490832cb5485af8b695d649