### PR TITLE
Update dashboard creation forms to rely on server-generated IDs

### DIFF
--- a/dashboard/src/api.ts
+++ b/dashboard/src/api.ts
@@ -54,7 +54,10 @@ export async function getProjects(token: string) {
   return res.json();
 }
 
-export async function createProject(token: string, project: { id: number; name: string }) {
+export async function createProject(
+  token: string,
+  project: { name: string; description?: string },
+) {
   const res = await fetch(apiUrl('/projects'), {
     method: 'POST',
     headers: headers(token),
@@ -120,7 +123,10 @@ export async function getStands(token: string) {
   return res.json();
 }
 
-export async function createStand(token: string, stand: { id: number; project_id: number; name: string; size: number; price: number }) {
+export async function createStand(
+  token: string,
+  stand: { project_id: number; name: string; size: number; price: number },
+) {
   const res = await fetch(apiUrl('/stands'), {
     method: 'POST',
     headers: headers(token),

--- a/dashboard/src/pages/Projects.tsx
+++ b/dashboard/src/pages/Projects.tsx
@@ -9,13 +9,14 @@ import {
 interface Project {
   id: number;
   name: string;
+  description?: string;
 }
 
 const Projects: React.FC = () => {
   const { auth } = useAuth();
   const [projects, setProjects] = React.useState<Project[]>([]);
   const [search, setSearch] = React.useState('');
-  const [form, setForm] = React.useState({ id: '', name: '' });
+  const [form, setForm] = React.useState({ name: '', description: '' });
 
   React.useEffect(() => {
     if (!auth?.token) {
@@ -31,11 +32,16 @@ const Projects: React.FC = () => {
 
   const submit = async (e: React.FormEvent) => {
     e.preventDefault();
-    if (!form.id || !form.name || !auth) return;
+    const name = form.name.trim();
+    const description = form.description.trim();
+    if (!name || !auth) return;
     try {
-      const project = await createProjectRequest(auth.token, { id: Number(form.id), name: form.name });
+      const project = await createProjectRequest(auth.token, {
+        name,
+        ...(description ? { description } : {}),
+      });
       setProjects(prev => [...prev, project]);
-      setForm({ id: '', name: '' });
+      setForm({ name: '', description: '' });
     } catch (err) {
       console.error(err);
     }
@@ -60,16 +66,6 @@ const Projects: React.FC = () => {
         <form className="form-card" onSubmit={submit}>
           <h3 className="form-title">Add Project</h3>
           <div className="form-fields">
-            <label htmlFor="project-id">
-              Project ID
-              <input
-                id="project-id"
-                placeholder="e.g. 1001"
-                value={form.id}
-                onChange={e => setForm({ ...form, id: e.target.value })}
-                required
-              />
-            </label>
             <label htmlFor="project-name">
               Name
               <input
@@ -78,6 +74,15 @@ const Projects: React.FC = () => {
                 value={form.name}
                 onChange={e => setForm({ ...form, name: e.target.value })}
                 required
+              />
+            </label>
+            <label htmlFor="project-description">
+              Description (optional)
+              <input
+                id="project-description"
+                placeholder="Enter project description"
+                value={form.description}
+                onChange={e => setForm({ ...form, description: e.target.value })}
               />
             </label>
           </div>

--- a/dashboard/src/pages/Stands.tsx
+++ b/dashboard/src/pages/Stands.tsx
@@ -19,7 +19,7 @@ const Stands: React.FC = () => {
   const [projectFilter, setProjectFilter] = React.useState('');
   const [stands, setStands] = React.useState<Stand[]>([]);
   const [search, setSearch] = React.useState('');
-  const [form, setForm] = React.useState({ id: '', project_id: '', name: '', size: '', price: '' });
+  const [form, setForm] = React.useState({ project_id: '', name: '', size: '', price: '' });
 
   const projectIdFilter = projectFilter.trim();
 
@@ -46,7 +46,6 @@ const Stands: React.FC = () => {
     e.preventDefault();
     if (!auth) return;
     const payload = {
-      id: Number(form.id),
       project_id: Number(form.project_id),
       name: form.name,
       size: Number(form.size),
@@ -55,7 +54,7 @@ const Stands: React.FC = () => {
     try {
       const stand = await createStandRequest(auth.token, payload);
       setStands(prev => [...prev, stand]);
-      setForm({ id: '', project_id: '', name: '', size: '', price: '' });
+      setForm({ project_id: '', name: '', size: '', price: '' });
     } catch (err) {
       console.error(err);
     }
@@ -104,16 +103,6 @@ const Stands: React.FC = () => {
         <form className="form-card" onSubmit={submit}>
           <h3 className="form-title">Add Stand</h3>
           <div className="form-fields">
-            <label htmlFor="stand-id">
-              Stand ID
-              <input
-                id="stand-id"
-                placeholder="ID"
-                value={form.id}
-                onChange={e => setForm({ ...form, id: e.target.value })}
-                required
-              />
-            </label>
             <label htmlFor="stand-project-id">
               Project ID
               <input


### PR DESCRIPTION
## Summary
- adjust dashboard API helpers to send only the fields required by the backend when creating projects and stands
- update the projects page to collect just the project name and optional description before calling the new helper
- update the stands page to omit manual stand IDs and rely on the backend response for identifiers

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68cb909fad74832c9339d78ad77dda3e