### PR TITLE
Enforce minimum password length for agents

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -214,6 +214,8 @@ def create_agent(
         raise HTTPException(status_code=400, detail="Agent exists")
     if agent.role not in AgentRole:
         raise HTTPException(status_code=400, detail="Unknown role")
+    if len(agent.password) < 8 or not agent.password.strip():
+        raise HTTPException(status_code=400, detail="Password does not meet requirements")
     password_hash = hash_password(agent.password)
     agent_db = AgentInDB(username=agent.username, role=agent.role, password_hash=password_hash)
     repos.agents.add(agent_db)

--- a/app/models.py
+++ b/app/models.py
@@ -89,7 +89,7 @@ class Agent(BaseModel):
 
 
 class AgentCreate(Agent):
-    password: str
+    password: str = Field(..., min_length=8)
 
 
 class AgentInDB(Agent):

--- a/tests/test_agent_roles.py
+++ b/tests/test_agent_roles.py
@@ -11,16 +11,36 @@ def setup_function():
 
 def test_unknown_role_rejected(client):
     resp = client.post(
-        "/agents", json={"username": "bad", "role": "ghost", "password": "x"}
+        "/agents", json={"username": "bad", "role": "ghost", "password": "ValidPass1"}
     )
     assert resp.status_code == 422
     detail = resp.json()["detail"]
     assert detail and "Input should" in detail[0]["msg"]
 
 
+def test_password_policy_enforced(client):
+    resp = client.post(
+        "/agents",
+        json={"username": "admin", "role": "admin", "password": "short"},
+        headers={"X-Bootstrap-Token": "does-not-matter"},
+    )
+    assert resp.status_code == 422
+
+    from app.main import INITIAL_ADMIN_TOKEN
+
+    resp = client.post(
+        "/agents",
+        json={"username": "admin", "role": "admin", "password": "        "},
+        headers={"X-Bootstrap-Token": INITIAL_ADMIN_TOKEN},
+    )
+    assert resp.status_code == 400
+    assert resp.json()["detail"] == "Password does not meet requirements"
+
+
 def test_first_agent_without_bootstrap_token_fails(client):
     resp = client.post(
-        "/agents", json={"username": "admin", "role": "admin", "password": "secret"}
+        "/agents",
+        json={"username": "admin", "role": "admin", "password": "Secret123"},
     )
     assert resp.status_code == 401
     assert resp.json()["detail"] == "Missing bootstrap token"
@@ -31,7 +51,7 @@ def test_bootstrap_token_allows_first_admin_then_admin_can_create_more(client):
 
     resp = client.post(
         "/agents",
-        json={"username": "admin", "role": "admin", "password": "secret"},
+        json={"username": "admin", "role": "admin", "password": "Secret123"},
         headers={"X-Bootstrap-Token": INITIAL_ADMIN_TOKEN},
     )
     assert resp.status_code == 200
@@ -40,14 +60,14 @@ def test_bootstrap_token_allows_first_admin_then_admin_can_create_more(client):
     assert payload["role"] == "admin"
 
     login = client.post(
-        "/auth/login", json={"username": "admin", "password": "secret"}
+        "/auth/login", json={"username": "admin", "password": "Secret123"}
     )
     assert login.status_code == 200
     token = login.json()["token"]
 
     resp = client.post(
         "/agents",
-        json={"username": "agent2", "role": "compliance", "password": "secret"},
+        json={"username": "agent2", "role": "compliance", "password": "Secret123"},
         headers={"Authorization": f"Bearer {token}"},
     )
     assert resp.status_code == 200
@@ -61,26 +81,26 @@ def test_list_agents_requires_admin_and_returns_agents(client):
 
     create_admin = client.post(
         "/agents",
-        json={"username": "admin", "role": "admin", "password": "secret"},
+        json={"username": "admin", "role": "admin", "password": "Secret123"},
         headers={"X-Bootstrap-Token": INITIAL_ADMIN_TOKEN},
     )
     assert create_admin.status_code == 200
 
     admin_login = client.post(
-        "/auth/login", json={"username": "admin", "password": "secret"}
+        "/auth/login", json={"username": "admin", "password": "Secret123"}
     )
     assert admin_login.status_code == 200
     admin_token = admin_login.json()["token"]
 
     create_agent = client.post(
         "/agents",
-        json={"username": "agent2", "role": "agent", "password": "secret"},
+        json={"username": "agent2", "role": "agent", "password": "Secret123"},
         headers={"Authorization": f"Bearer {admin_token}"},
     )
     assert create_agent.status_code == 200
 
     agent_login = client.post(
-        "/auth/login", json={"username": "agent2", "password": "secret"}
+        "/auth/login", json={"username": "agent2", "password": "Secret123"}
     )
     assert agent_login.status_code == 200
     agent_token = agent_login.json()["token"]

--- a/tests/test_agreements.py
+++ b/tests/test_agreements.py
@@ -10,13 +10,14 @@ def setup_data(client):
 
     def create_and_login(username, role, headers=None):
         create_headers = headers or {"X-Bootstrap-Token": "bootstrap-token"}
+        password = f"{username}Pass123"
         client.post(
             "/agents",
-            json={"username": username, "role": role, "password": username},
+            json={"username": username, "role": role, "password": password},
             headers=create_headers,
         )
         token = client.post(
-            "/auth/login", json={"username": username, "password": username}
+            "/auth/login", json={"username": username, "password": password}
         ).json()["token"]
         return {"Authorization": f"Bearer {token}"}
 

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -12,24 +12,26 @@ def setup_function():
 
 def test_auth_mandate_and_available_view(client):
     # register agents
+    admin_password = "AdminPass123"
     resp = client.post(
         "/agents",
-        json={"username": "admin", "role": "admin", "password": "a"},
+        json={"username": "admin", "role": "admin", "password": admin_password},
         headers={"X-Bootstrap-Token": "bootstrap-token"},
     )
     assert resp.status_code == 200
     admin_token = client.post(
-        "/auth/login", json={"username": "admin", "password": "a"}
+        "/auth/login", json={"username": "admin", "password": admin_password}
     ).json()["token"]
     admin_headers = {"Authorization": f"Bearer {admin_token}"}
+    agent_password = "AgentPass123"
     resp = client.post(
         "/agents",
-        json={"username": "agentA", "role": "agent", "password": "b"},
+        json={"username": "agentA", "role": "agent", "password": agent_password},
         headers=admin_headers,
     )
     assert resp.status_code == 200
     agent_token = client.post(
-        "/auth/login", json={"username": "agentA", "password": "b"}
+        "/auth/login", json={"username": "agentA", "password": agent_password}
     ).json()["token"]
 
     agent_headers = {"Authorization": f"Bearer {agent_token}"}

--- a/tests/test_application_uploads.py
+++ b/tests/test_application_uploads.py
@@ -7,22 +7,24 @@ from app.database import drop_db, init_db
 def setup_agents(client):
     drop_db()
     init_db()
+    admin_password = "AdminPass123"
     client.post(
         "/agents",
-        json={"username": "admin", "role": "admin", "password": "a"},
+        json={"username": "admin", "role": "admin", "password": admin_password},
         headers={"X-Bootstrap-Token": "bootstrap-token"},
     )
     admin_token = client.post(
-        "/auth/login", json={"username": "admin", "password": "a"}
+        "/auth/login", json={"username": "admin", "password": admin_password}
     ).json()["token"]
     headers = {"Authorization": f"Bearer {admin_token}"}
+    realtor_password = "RealtorPass123"
     client.post(
         "/agents",
-        json={"username": "realtor", "role": "agent", "password": "b"},
+        json={"username": "realtor", "role": "agent", "password": realtor_password},
         headers=headers,
     )
     realtor_token = client.post(
-        "/auth/login", json={"username": "realtor", "password": "b"}
+        "/auth/login", json={"username": "realtor", "password": realtor_password}
     ).json()["token"]
     return {"admin": admin_token, "realtor": realtor_token}
 

--- a/tests/test_dashboard.py
+++ b/tests/test_dashboard.py
@@ -16,26 +16,27 @@ def register_agents(client):
         "compliance": "compliance",
         "agentA": "agent",
     }
+    passwords = {user: f"{user}Pass123" for user in creds}
     tokens = {}
     # create first admin
     client.post(
         "/agents",
-        json={"username": "admin", "role": "admin", "password": "admin"},
+        json={"username": "admin", "role": "admin", "password": passwords["admin"]},
         headers={"X-Bootstrap-Token": "bootstrap-token"},
     )
     admin_token = client.post(
-        "/auth/login", json={"username": "admin", "password": "admin"}
+        "/auth/login", json={"username": "admin", "password": passwords["admin"]}
     ).json()["token"]
     tokens["admin"] = admin_token
     admin_headers = {"Authorization": f"Bearer {admin_token}"}
     for user, role in list(creds.items())[1:]:
         client.post(
             "/agents",
-            json={"username": user, "role": role, "password": user},
+            json={"username": user, "role": role, "password": passwords[user]},
             headers=admin_headers,
         )
         token = client.post(
-            "/auth/login", json={"username": user, "password": user}
+            "/auth/login", json={"username": user, "password": passwords[user]}
         ).json()["token"]
         tokens[user] = token
     return tokens

--- a/tests/test_deposits_api.py
+++ b/tests/test_deposits_api.py
@@ -8,22 +8,24 @@ def setup_function(_):
     init_db()
 
 def register_users(client):
+    admin_password = "AdminPass123"
     client.post(
         "/agents",
-        json={"username": "admin", "role": "admin", "password": "admin"},
+        json={"username": "admin", "role": "admin", "password": admin_password},
         headers={"X-Bootstrap-Token": "bootstrap-token"},
     )
     admin_token = client.post(
-        "/auth/login", json={"username": "admin", "password": "admin"}
+        "/auth/login", json={"username": "admin", "password": admin_password}
     ).json()["token"]
     headers = {"Authorization": f"Bearer {admin_token}"}
+    agent_password = "AgentPass123"
     client.post(
         "/agents",
-        json={"username": "agent", "role": "agent", "password": "agent"},
+        json={"username": "agent", "role": "agent", "password": agent_password},
         headers=headers,
     )
     agent_token = client.post(
-        "/auth/login", json={"username": "agent", "password": "agent"}
+        "/auth/login", json={"username": "agent", "password": agent_password}
     ).json()["token"]
     return {"admin": admin_token, "agent": agent_token}
 

--- a/tests/test_import.py
+++ b/tests/test_import.py
@@ -11,13 +11,14 @@ from app.database import drop_db, init_db
 def admin_headers(client):
     drop_db()
     init_db()
+    admin_password = "AdminPass123"
     client.post(
         "/agents",
-        json={"username": "admin", "role": "admin", "password": "a"},
+        json={"username": "admin", "role": "admin", "password": admin_password},
         headers={"X-Bootstrap-Token": "bootstrap-token"},
     )
     token = client.post(
-        "/auth/login", json={"username": "admin", "password": "a"}
+        "/auth/login", json={"username": "admin", "password": admin_password}
     ).json()["token"]
     return {"Authorization": f"Bearer {token}"}
 

--- a/tests/test_loans_api.py
+++ b/tests/test_loans_api.py
@@ -9,22 +9,24 @@ from app.models import LoanStatus
 def setup_agents(client):
     drop_db()
     init_db()
+    admin_password = "AdminPass123"
     client.post(
         "/agents",
-        json={"username": "admin", "role": "admin", "password": "a"},
+        json={"username": "admin", "role": "admin", "password": admin_password},
         headers={"X-Bootstrap-Token": "bootstrap-token"},
     )
     admin_token = client.post(
-        "/auth/login", json={"username": "admin", "password": "a"}
+        "/auth/login", json={"username": "admin", "password": admin_password}
     ).json()["token"]
     headers = {"Authorization": f"Bearer {admin_token}"}
+    user_password = "UserPass123"
     client.post(
         "/agents",
-        json={"username": "user", "role": "agent", "password": "b"},
+        json={"username": "user", "role": "agent", "password": user_password},
         headers=headers,
     )
     user_token = client.post(
-        "/auth/login", json={"username": "user", "password": "b"}
+        "/auth/login", json={"username": "user", "password": user_password}
     ).json()["token"]
     return {"admin": admin_token, "user": user_token}
 

--- a/tests/test_projects_api.py
+++ b/tests/test_projects_api.py
@@ -10,13 +10,14 @@ def setup_function():
 
 
 def auth_headers(client, username: str):
+    password = f"{username}Pass123"
     client.post(
         "/agents",
-        json={"username": username, "role": "admin", "password": username},
+        json={"username": username, "role": "admin", "password": password},
         headers={"X-Bootstrap-Token": "bootstrap-token"},
     )
     token = client.post(
-        "/auth/login", json={"username": username, "password": username}
+        "/auth/login", json={"username": username, "password": password}
     ).json()["token"]
     return {"Authorization": f"Bearer {token}"}
 

--- a/tests/test_reporting.py
+++ b/tests/test_reporting.py
@@ -11,19 +11,25 @@ def setup_function():
 
 
 def setup_data(client):
+    admin_password = "AdminPass123"
     client.post(
         "/agents",
-        json={"username": "admin", "role": "admin", "password": "a"},
+        json={"username": "admin", "role": "admin", "password": admin_password},
         headers={"X-Bootstrap-Token": "bootstrap-token"},
     )
-    admin_token = client.post("/auth/login", json={"username": "admin", "password": "a"}).json()["token"]
+    admin_token = client.post(
+        "/auth/login", json={"username": "admin", "password": admin_password}
+    ).json()["token"]
     admin_headers = {"Authorization": f"Bearer {admin_token}"}
+    agent_password = "AgentPass123"
     client.post(
         "/agents",
-        json={"username": "agent", "role": "agent", "password": "b"},
+        json={"username": "agent", "role": "agent", "password": agent_password},
         headers=admin_headers,
     )
-    agent_token = client.post("/auth/login", json={"username": "agent", "password": "b"}).json()["token"]
+    agent_token = client.post(
+        "/auth/login", json={"username": "agent", "password": agent_password}
+    ).json()["token"]
     agent_headers = {"Authorization": f"Bearer {agent_token}"}
     project_id = client.post(
         "/projects", json={"name": "Proj"}, headers=admin_headers

--- a/tests/test_submissions.py
+++ b/tests/test_submissions.py
@@ -9,22 +9,24 @@ from app.database import drop_db, init_db
 def setup_agents(client):
     drop_db()
     init_db()
+    admin_password = "AdminPass123"
     client.post(
         "/agents",
-        json={"username": "admin", "role": "admin", "password": "a"},
+        json={"username": "admin", "role": "admin", "password": admin_password},
         headers={"X-Bootstrap-Token": "bootstrap-token"},
     )
     admin_token = client.post(
-        "/auth/login", json={"username": "admin", "password": "a"}
+        "/auth/login", json={"username": "admin", "password": admin_password}
     ).json()["token"]
     headers = {"Authorization": f"Bearer {admin_token}"}
+    realtor_password = "RealtorPass123"
     client.post(
         "/agents",
-        json={"username": "realtor", "role": "agent", "password": "b"},
+        json={"username": "realtor", "role": "agent", "password": realtor_password},
         headers=headers,
     )
     realtor_token = client.post(
-        "/auth/login", json={"username": "realtor", "password": "b"}
+        "/auth/login", json={"username": "realtor", "password": realtor_password}
     ).json()["token"]
     return {"admin": admin_token, "realtor": realtor_token}
 
@@ -316,12 +318,12 @@ def test_loan_application_realtor_mismatch_rejected(client):
     # Another agent attempts to submit a loan application using this account
     resp = client.post(
         "/agents",
-        json={"username": "other", "role": "agent", "password": "c"},
+        json={"username": "other", "role": "agent", "password": "OtherPass123"},
         headers=admin_headers,
     )
     assert resp.status_code == 200
     other_token = client.post(
-        "/auth/login", json={"username": "other", "password": "c"}
+        "/auth/login", json={"username": "other", "password": "OtherPass123"}
     ).json()["token"]
     other_headers = {"Authorization": f"Bearer {other_token}"}
 


### PR DESCRIPTION
## Summary
- require agent creation requests to supply passwords at least eight characters long
- reject whitespace-only passwords before hashing
- update agent-related tests to cover password validation and use compliant credentials across fixtures

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68cb94187a78832c893f7c54db8699bd