### PR TITLE
Add dashboard Docker ignore for build context

### DIFF
--- a/dashboard/.dockerignore
+++ b/dashboard/.dockerignore
@@ -1,0 +1,14 @@
+node_modules
+npm-debug.log*
+yarn-debug.log*
+yarn-error.log*
+pnpm-debug.log*
+dist
+build
+.tmp
+.cache
+.eslintcache
+.vscode
+.DS_Store
+coverage
+**/*.local


### PR DESCRIPTION
## Summary
- add a dashboard-specific .dockerignore to exclude node modules, build artifacts, and local caches from the Docker build context

## Testing
- `docker compose build frontend` *(fails: docker not available in execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68cdbe21dc04832cb4094330cb6d2050