### PR TITLE
Seed initial admin from environment

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -2,3 +2,7 @@
 DATABASE_URL=sqlite:///data/app.db
 SECRET_KEY=change-me
 INITIAL_ADMIN_TOKEN=bootstrap-token
+# Optional bootstrap admin seeding
+# INITIAL_ADMIN_USERNAME=admin
+# INITIAL_ADMIN_PASSWORD=Secret123
+# INITIAL_ADMIN_PASSWORD_HASH=replace-with-bcrypt-hash

--- a/README.md
+++ b/README.md
@@ -18,11 +18,18 @@ cp .env.example .env
 # edit .env and provide a SECRET_KEY
 ```
 
+To automatically create the first administrator during startup, set
+`INITIAL_ADMIN_USERNAME` along with either `INITIAL_ADMIN_PASSWORD` or
+`INITIAL_ADMIN_PASSWORD_HASH`. When both are provided the plaintext password wins and is
+hashed before storage.
+
 ## Running
 
 ```
 SECRET_KEY=your-secret-key \
 INITIAL_ADMIN_TOKEN=bootstrap-token \
+INITIAL_ADMIN_USERNAME=admin \
+INITIAL_ADMIN_PASSWORD=Secret123 \
 FRONTEND_ORIGINS="http://localhost:5173" \
 uvicorn app.main:app --reload
 ```
@@ -73,6 +80,15 @@ Once the containers are running you can reach:
 
 - Dashboard: <http://localhost:8080>
 - API: <http://localhost:8000> (interactive docs at <http://localhost:8000/docs>)
+
+To seed the initial administrator in Docker, export the optional variables before running
+Compose so the startup hook can create the account when the database is empty:
+
+```bash
+INITIAL_ADMIN_USERNAME=admin \
+INITIAL_ADMIN_PASSWORD=Secret123 \
+docker compose up --build
+```
 
 The backend persists the SQLite database using the named volume `sqlite_data` mounted at `/app/data` and reads environment values from `.env`.
 By default it allows requests from both `http://localhost:8080` and `http://localhost:5173` so the static dashboard and the Vite dev server can call the API.

--- a/app/main.py
+++ b/app/main.py
@@ -91,10 +91,60 @@ app.add_middleware(
 )
 
 
-@app.on_event("startup")
-def on_startup() -> None:
+def seed_initial_admin_if_configured() -> None:
+    username = os.environ.get("INITIAL_ADMIN_USERNAME")
+    if not username:
+        return
+
+    password = os.environ.get("INITIAL_ADMIN_PASSWORD")
+    password_hash = os.environ.get("INITIAL_ADMIN_PASSWORD_HASH")
+
+    if not password and not password_hash:
+        logger.warning(
+            "INITIAL_ADMIN_USERNAME is set but neither INITIAL_ADMIN_PASSWORD nor "
+            "INITIAL_ADMIN_PASSWORD_HASH was provided; skipping admin seeding"
+        )
+        return
+
+    session = SessionLocal()
+    try:
+        repos = Repositories(session)
+        if repos.agents.list():
+            logger.debug(
+                "Skipping initial admin seeding because at least one agent already exists"
+            )
+            return
+
+        hashed = password_hash
+        if password:
+            hashed = hash_password(password)
+
+        if not hashed:
+            logger.warning(
+                "Unable to determine password hash for initial admin; skipping seeding"
+            )
+            return
+
+        admin = AgentInDB(
+            username=username,
+            role=AgentRole.ADMIN,
+            password_hash=hashed,
+        )
+        repos.agents.add(admin)
+        logger.info("Seeded initial admin '%s' from environment", username)
+    finally:
+        session.close()
+
+
+def run_startup_tasks() -> None:
     logger.info("Configured frontend origins: %s", ", ".join(FRONTEND_ORIGINS))
     init_db()
+    seed_initial_admin_if_configured()
+
+
+@app.on_event("startup")
+def on_startup() -> None:
+    run_startup_tasks()
 
 
 def get_repositories(session=Depends(get_session)) -> Repositories:

--- a/tests/test_agent_roles.py
+++ b/tests/test_agent_roles.py
@@ -1,7 +1,7 @@
 import sys
 sys.path.append('.')
 
-from app.database import drop_db, init_db
+from app.database import drop_db, init_db, SessionLocal
 
 
 def setup_function():
@@ -117,3 +117,31 @@ def test_list_agents_requires_admin_and_returns_agents(client):
     )
     assert forbidden.status_code == 403
     assert forbidden.json()["detail"] == "Admin privileges required"
+
+
+def test_startup_seeds_initial_admin(monkeypatch):
+    from app.main import on_startup, verify_password
+    from app.models import AgentRole
+    from app.repositories import Repositories
+
+    monkeypatch.setenv("INITIAL_ADMIN_USERNAME", "bootstrap-admin")
+    monkeypatch.setenv("INITIAL_ADMIN_PASSWORD", "Seeding123!")
+    monkeypatch.delenv("INITIAL_ADMIN_PASSWORD_HASH", raising=False)
+
+    drop_db()
+    init_db()
+
+    on_startup()
+
+    session = SessionLocal()
+    try:
+        repos = Repositories(session)
+        agents = repos.agents.list()
+    finally:
+        session.close()
+
+    assert len(agents) == 1
+    admin = agents[0]
+    assert admin.username == "bootstrap-admin"
+    assert admin.role == AgentRole.ADMIN
+    assert verify_password("Seeding123!", admin.password_hash)


### PR DESCRIPTION
## Summary
- seed an administrator during startup when INITIAL_ADMIN_USERNAME and a password or hash are provided
- document the optional seeding variables for local and Docker Compose deployments
- add a regression test that verifies the startup hook creates the admin without hitting the agents API

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68cdbf96d660832c9616a5ca1a903148