### PR TITLE
Add external account ingestion service and manager dashboards

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,24 @@ Rows missing required fields are reported with clear error messages and skipped.
 
 **Manual verification:** Uploading a file that contains at least one invalid row now displays the backend-provided error text in the dashboard import form.
 
+## Synchronising External Bank Accounts
+
+Deposit and loan account records can be synchronised from an external core-banking system using the ingestion
+service in `app/accounts.py`. Provide adapters that expose `fetch_deposit_accounts()` and
+`fetch_loan_accounts()` methods (they can return dictionaries or the `ImportedDepositAccount`/
+`ImportedLoanAccount` Pydantic models) and pass them to the CLI runner:
+
+```bash
+python -m app.accounts --deposit-adapter myproject.adapters:DepositAdapterFactory \
+  --loan-adapter myproject.adapters:LoanAdapterFactory --source-system "Core Banking"
+```
+
+The script loads the dotted paths, instantiates the adapters (callables are invoked) and persists the returned
+records via the existing repositories. Schedule the command with cron or a containerised task runner to keep the
+read-only management dashboards up to date. When the adapters omit the source metadata, the CLI uses the
+`--source-system` value as the default audit label so every imported record retains traceability back to its
+originating system.
+
 ## Docker Compose
 
 To build and run the API and dashboard together with Docker Compose:

--- a/app/accounts.py
+++ b/app/accounts.py
@@ -1,0 +1,220 @@
+"""Services for ingesting external account data."""
+
+from __future__ import annotations
+
+import argparse
+import importlib
+import os
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from typing import Any, Iterable, Mapping, Optional, Protocol
+
+from pydantic import BaseModel, ValidationError
+
+from .database import SessionLocal
+from .models import (
+    ImportedDepositAccount,
+    ImportedLoanAccount,
+    SourceAuditInfo,
+)
+from .repositories import Repositories
+
+
+class DepositAccountAdapter(Protocol):
+    """Adapter that yields deposit account records from an external system."""
+
+    def fetch_deposit_accounts(self) -> Iterable[Mapping[str, Any] | ImportedDepositAccount]:
+        ...
+
+
+class LoanAccountAdapter(Protocol):
+    """Adapter that yields loan account records from an external system."""
+
+    def fetch_loan_accounts(self) -> Iterable[Mapping[str, Any] | ImportedLoanAccount]:
+        ...
+
+
+@dataclass
+class IngestionResult:
+    deposits: list[ImportedDepositAccount]
+    loans: list[ImportedLoanAccount]
+
+
+class AccountIngestionService:
+    """Persist imported deposit and loan account records using repositories."""
+
+    def __init__(
+        self,
+        repos: Repositories,
+        *,
+        deposit_adapter: Optional[DepositAccountAdapter] = None,
+        loan_adapter: Optional[LoanAccountAdapter] = None,
+        default_source_system: str = "external",
+    ) -> None:
+        self._repos = repos
+        self._deposit_adapter = deposit_adapter
+        self._loan_adapter = loan_adapter
+        self._default_source_system = default_source_system
+
+    def ingest(self) -> IngestionResult:
+        """Run both deposit and loan ingestions."""
+
+        deposits = self.ingest_deposits()
+        loans = self.ingest_loans()
+        return IngestionResult(deposits=deposits, loans=loans)
+
+    def ingest_deposits(self) -> list[ImportedDepositAccount]:
+        if not self._deposit_adapter:
+            return []
+        records = self._deposit_adapter.fetch_deposit_accounts()
+        return self._store_records(records, self._repos.imported_deposit_accounts, ImportedDepositAccount)
+
+    def ingest_loans(self) -> list[ImportedLoanAccount]:
+        if not self._loan_adapter:
+            return []
+        records = self._loan_adapter.fetch_loan_accounts()
+        return self._store_records(records, self._repos.imported_loan_accounts, ImportedLoanAccount)
+
+    def _store_records(
+        self,
+        records: Iterable[Mapping[str, Any] | BaseModel],
+        repository,
+        model: type[ImportedDepositAccount] | type[ImportedLoanAccount],
+    ) -> list[ImportedDepositAccount] | list[ImportedLoanAccount]:
+        stored: list[ImportedDepositAccount] | list[ImportedLoanAccount] = []
+        for raw in records:
+            prepared = self._prepare_record(raw, model)
+            repository.add(prepared)
+            stored.append(prepared)
+        return stored
+
+    def _prepare_record(
+        self,
+        record: Mapping[str, Any] | BaseModel,
+        model: type[ImportedDepositAccount] | type[ImportedLoanAccount],
+    ) -> ImportedDepositAccount | ImportedLoanAccount:
+        if isinstance(record, BaseModel):
+            data = record.model_dump()
+        else:
+            data = dict(record)
+
+        audit_payload = self._pop_audit_payload(data)
+        audit = self._build_audit(audit_payload, data)
+
+        metadata = data.get("metadata")
+        if metadata is None:
+            data["metadata"] = {}
+        elif not isinstance(metadata, dict):
+            raise TypeError("metadata must be a mapping if provided")
+
+        payload = {**data, "audit": audit}
+
+        try:
+            parsed = model.model_validate(payload)
+        except ValidationError as exc:  # pragma: no cover - validation errors surface in tests
+            raise ValueError(f"Invalid {model.__name__} payload: {exc}") from exc
+        return parsed
+
+    def _pop_audit_payload(self, data: dict[str, Any]) -> dict[str, Any] | SourceAuditInfo | None:
+        audit = data.pop("audit", None)
+        if audit is not None:
+            return audit
+
+        payload: dict[str, Any] = {
+            "system": data.pop("source_system", self._default_source_system),
+            "reference": data.pop("source_reference", str(data.get("id"))),
+            "ingested_at": data.pop("ingested_at", None),
+            "metadata": data.pop("source_metadata", {}) or {},
+        }
+        return payload
+
+    def _build_audit(
+        self, audit_payload: dict[str, Any] | SourceAuditInfo | None, context: Mapping[str, Any]
+    ) -> dict[str, Any]:
+        if audit_payload is None:
+            audit_payload = {}
+        if isinstance(audit_payload, SourceAuditInfo):
+            audit_dict = audit_payload.model_dump()
+        else:
+            audit_dict = dict(audit_payload)
+
+        audit_dict.setdefault("system", self._default_source_system)
+        audit_dict.setdefault("reference", str(context.get("id")))
+        audit_dict["ingested_at"] = self._normalize_datetime(audit_dict.get("ingested_at"))
+        metadata = audit_dict.get("metadata")
+        if metadata is None:
+            audit_dict["metadata"] = {}
+        elif not isinstance(metadata, dict):
+            raise TypeError("audit.metadata must be a mapping")
+        return audit_dict
+
+    @staticmethod
+    def _normalize_datetime(value: Any) -> datetime:
+        if isinstance(value, datetime):
+            dt = value
+        elif isinstance(value, str) and value:
+            cleaned = value.replace("Z", "+00:00")
+            dt = datetime.fromisoformat(cleaned)
+        else:
+            dt = datetime.now(timezone.utc)
+        if dt.tzinfo is None:
+            dt = dt.replace(tzinfo=timezone.utc)
+        return dt
+
+
+def _load_adapter(spec: str | None) -> Any:
+    if not spec:
+        return None
+    module_path, factory_name = (spec.split(":", 1) if ":" in spec else spec.rsplit(".", 1))
+    module = importlib.import_module(module_path)
+    factory = getattr(module, factory_name)
+    return factory() if callable(factory) else factory
+
+
+def run_sync(
+    deposit_adapter_spec: str | None,
+    loan_adapter_spec: str | None,
+    *,
+    default_source_system: str,
+) -> IngestionResult:
+    session = SessionLocal()
+    try:
+        repos = Repositories(session)
+        deposit_adapter = _load_adapter(deposit_adapter_spec)
+        loan_adapter = _load_adapter(loan_adapter_spec)
+        service = AccountIngestionService(
+            repos,
+            deposit_adapter=deposit_adapter,
+            loan_adapter=loan_adapter,
+            default_source_system=default_source_system,
+        )
+        return service.ingest()
+    finally:
+        session.close()
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Synchronise external deposit and loan accounts")
+    parser.add_argument("--deposit-adapter", help="Dotted path to deposit adapter factory or instance")
+    parser.add_argument("--loan-adapter", help="Dotted path to loan adapter factory or instance")
+    parser.add_argument(
+        "--source-system",
+        default=os.environ.get("EXTERNAL_SOURCE_SYSTEM", "external"),
+        help="Default source system label to use when adapters do not provide one",
+    )
+    args = parser.parse_args()
+    result = run_sync(
+        args.deposit_adapter,
+        args.loan_adapter,
+        default_source_system=args.source_system,
+    )
+    print(
+        "Ingested",
+        f"{len(result.deposits)} deposit account(s)",
+        "and",
+        f"{len(result.loans)} loan account(s)",
+    )
+
+
+if __name__ == "__main__":  # pragma: no cover - manual execution
+    main()

--- a/app/main.py
+++ b/app/main.py
@@ -61,6 +61,8 @@ from .models import (
     UploadedFile,
     DocumentRequirement,
     DocumentWorkflow,
+    ImportedDepositAccount,
+    ImportedLoanAccount,
 )
 
 logger = logging.getLogger(__name__)
@@ -206,6 +208,12 @@ def get_current_agent(
 def require_admin(agent: Agent = Depends(get_current_agent)) -> Agent:
     if agent.role != AgentRole.ADMIN:
         raise HTTPException(status_code=403, detail="Admin privileges required")
+    return agent
+
+
+def require_management(agent: Agent = Depends(get_current_agent)) -> Agent:
+    if agent.role not in (AgentRole.ADMIN, AgentRole.MANAGER):
+        raise HTTPException(status_code=403, detail="Management privileges required")
     return agent
 
 
@@ -1175,7 +1183,7 @@ def submit_account_opening(
 @app.get("/account-openings", response_model=List[AccountOpening])
 def list_account_openings(
     status: Optional[SubmissionStatus] = None,
-    _: Agent = Depends(require_admin),
+    _: Agent = Depends(require_management),
     repos: Repositories = Depends(get_repositories),
 ):
     openings = repos.account_openings.list()
@@ -1252,7 +1260,7 @@ def record_deposit(
 
 @app.get("/accounts/deposits/pending", response_model=List[AccountOpening])
 def list_pending_deposits(
-    _: Agent = Depends(require_admin),
+    _: Agent = Depends(require_management),
     repos: Repositories = Depends(get_repositories),
 ):
     openings = repos.account_openings.list()
@@ -1261,6 +1269,26 @@ def list_pending_deposits(
         for o in openings
         if o.status in (SubmissionStatus.SUBMITTED, SubmissionStatus.IN_PROGRESS)
     ]
+
+
+@app.get("/accounts/deposits/imported", response_model=List[ImportedDepositAccount])
+def list_imported_deposits(
+    _: Agent = Depends(require_management),
+    repos: Repositories = Depends(get_repositories),
+):
+    return repos.imported_deposit_accounts.list()
+
+
+@app.get("/accounts/deposits/imported/{record_id}", response_model=ImportedDepositAccount)
+def get_imported_deposit(
+    record_id: str,
+    _: Agent = Depends(require_management),
+    repos: Repositories = Depends(get_repositories),
+):
+    record = repos.imported_deposit_accounts.get(record_id)
+    if not record:
+        raise HTTPException(status_code=404, detail="Imported deposit account not found")
+    return record
 
 
 @app.post("/accounts/deposits/{req_id}/open", response_model=AccountOpening)
@@ -1469,6 +1497,26 @@ class LoanAccountRequest(BaseModel):
     agreement_id: int
 
 
+@app.get("/loan-accounts/imported", response_model=List[ImportedLoanAccount])
+def list_imported_loan_accounts(
+    _: Agent = Depends(require_management),
+    repos: Repositories = Depends(get_repositories),
+):
+    return repos.imported_loan_accounts.list()
+
+
+@app.get("/loan-accounts/imported/{record_id}", response_model=ImportedLoanAccount)
+def get_imported_loan_account(
+    record_id: str,
+    _: Agent = Depends(require_management),
+    repos: Repositories = Depends(get_repositories),
+):
+    record = repos.imported_loan_accounts.get(record_id)
+    if not record:
+        raise HTTPException(status_code=404, detail="Imported loan account not found")
+    return record
+
+
 @app.post("/loan-accounts", response_model=dict)
 def create_loan_account(
     payload: LoanAccountRequest,
@@ -1511,7 +1559,7 @@ def list_loan_accounts(
     agent: Agent = Depends(get_current_agent),
     repos: Repositories = Depends(get_repositories),
 ):
-    if agent.role != AgentRole.ADMIN and agent.username != realtor:
+    if agent.role not in (AgentRole.ADMIN, AgentRole.MANAGER) and agent.username != realtor:
         raise HTTPException(status_code=403, detail="Not authorized")
     return repos.customer_loan_accounts.get(realtor, [])
 

--- a/app/models.py
+++ b/app/models.py
@@ -1,5 +1,5 @@
 from enum import Enum
-from typing import Dict, List, Optional
+from typing import Any, Dict, List, Optional
 from datetime import datetime
 
 from pydantic import BaseModel, Field
@@ -239,3 +239,33 @@ class Agreement(BaseModel):
 
 class AgreementExecution(BaseModel):
     loan_account_number: str
+
+
+class SourceAuditInfo(BaseModel):
+    """Metadata describing where an imported record originated."""
+
+    system: str
+    reference: str
+    ingested_at: datetime
+    metadata: Dict[str, Any] = Field(default_factory=dict)
+
+
+class ImportedAccountBase(BaseModel):
+    id: str
+    account_number: str
+    customer_name: str
+    product_name: Optional[str] = None
+    status: Optional[str] = None
+    audit: SourceAuditInfo
+    metadata: Dict[str, Any] = Field(default_factory=dict)
+
+
+class ImportedDepositAccount(ImportedAccountBase):
+    balance: float
+    currency: str
+
+
+class ImportedLoanAccount(ImportedAccountBase):
+    principal_amount: float
+    outstanding_balance: float
+    interest_rate: Optional[float] = None

--- a/app/repositories.py
+++ b/app/repositories.py
@@ -22,7 +22,7 @@ class Repository(Generic[T]):
 
     def add(self, obj: T) -> None:
         key = str(self._key(obj))
-        row = Record(store=self.store, key=key, data=obj.model_dump())
+        row = Record(store=self.store, key=key, data=obj.model_dump(mode="json"))
         self.session.merge(row)
         self.session.commit()
 
@@ -97,6 +97,8 @@ from .models import (
     Agreement,
     Loan,
     DocumentRequirement,
+    ImportedDepositAccount,
+    ImportedLoanAccount,
 )
 
 
@@ -119,4 +121,10 @@ class Repositories:
         self.counters = SimpleRepository(session, 'counters')
         self.document_requirements = Repository(
             session, 'document_requirements', DocumentRequirement
+        )
+        self.imported_deposit_accounts = Repository(
+            session, 'imported_deposit_accounts', ImportedDepositAccount
+        )
+        self.imported_loan_accounts = Repository(
+            session, 'imported_loan_accounts', ImportedLoanAccount
         )

--- a/dashboard/src/App.tsx
+++ b/dashboard/src/App.tsx
@@ -17,6 +17,8 @@ import Deposits from './pages/Deposits';
 import DepositDetail from './pages/DepositDetail';
 import LoanAccounts from './pages/LoanAccounts';
 import DocumentRequirementsPage from './pages/DocumentRequirements';
+import ImportedDeposits from './pages/ImportedDeposits';
+import ImportedLoanAccounts from './pages/ImportedLoanAccounts';
 import { ProtectedRoute, useAuth } from './auth';
 
 const App: React.FC = () => {
@@ -35,9 +37,16 @@ const App: React.FC = () => {
           { to: '/loan-approvals', label: 'Loan Approvals' },
           { to: '/deposits', label: 'Deposits' },
           { to: '/loan-accounts-open', label: 'Loan Accounts' },
+          { to: '/imported-deposits', label: 'Imported Deposits' },
+          { to: '/imported-loan-accounts', label: 'Imported Loan Accounts' },
         ]
       : auth.role === 'manager'
-        ? [{ to: '/admin-dashboard', label: 'Dashboard' }]
+        ? [
+            { to: '/admin-dashboard', label: 'Dashboard' },
+            { to: '/account-openings', label: 'Account Openings' },
+            { to: '/imported-deposits', label: 'Imported Deposits' },
+            { to: '/imported-loan-accounts', label: 'Imported Loan Accounts' },
+          ]
         : auth.role === 'compliance'
           ? [{ to: '/compliance-dashboard', label: 'Dashboard' }]
           : auth.role === 'agent'
@@ -114,7 +123,7 @@ const App: React.FC = () => {
             <Route
               path="/account-openings"
               element={
-                <ProtectedRoute roles={["admin"]}>
+                <ProtectedRoute roles={["admin", "manager"]}>
                   <AccountOpenings />
                 </ProtectedRoute>
               }
@@ -148,6 +157,22 @@ const App: React.FC = () => {
               element={
                 <ProtectedRoute roles={["admin"]}>
                   <DepositDetail />
+                </ProtectedRoute>
+              }
+            />
+            <Route
+              path="/imported-deposits"
+              element={
+                <ProtectedRoute roles={["admin", "manager"]}>
+                  <ImportedDeposits />
+                </ProtectedRoute>
+              }
+            />
+            <Route
+              path="/imported-loan-accounts"
+              element={
+                <ProtectedRoute roles={["admin", "manager"]}>
+                  <ImportedLoanAccounts />
                 </ProtectedRoute>
               }
             />

--- a/dashboard/src/api.ts
+++ b/dashboard/src/api.ts
@@ -425,6 +425,58 @@ export async function recordAccountDeposit(token: string, id: number, amount: nu
   return res.json();
 }
 
+export interface SourceAuditInfo {
+  system: string;
+  reference: string;
+  ingested_at: string;
+  metadata: Record<string, unknown>;
+}
+
+export interface ImportedAccountBase {
+  id: string;
+  account_number: string;
+  customer_name: string;
+  product_name?: string | null;
+  status?: string | null;
+  audit: SourceAuditInfo;
+  metadata: Record<string, unknown>;
+}
+
+export interface ImportedDepositAccount extends ImportedAccountBase {
+  balance: number;
+  currency: string;
+}
+
+export interface ImportedLoanAccount extends ImportedAccountBase {
+  principal_amount: number;
+  outstanding_balance: number;
+  interest_rate?: number | null;
+}
+
+export async function listImportedDeposits(token: string) {
+  const res = await fetch(apiUrl('/accounts/deposits/imported'), { headers: headers(token) });
+  if (!res.ok) throw new Error('Failed to load imported deposits');
+  return res.json() as Promise<ImportedDepositAccount[]>;
+}
+
+export async function getImportedDeposit(token: string, id: string) {
+  const res = await fetch(apiUrl(`/accounts/deposits/imported/${id}`), { headers: headers(token) });
+  if (!res.ok) throw new Error('Failed to load imported deposit');
+  return res.json() as Promise<ImportedDepositAccount>;
+}
+
+export async function listImportedLoanAccounts(token: string) {
+  const res = await fetch(apiUrl('/loan-accounts/imported'), { headers: headers(token) });
+  if (!res.ok) throw new Error('Failed to load imported loan accounts');
+  return res.json() as Promise<ImportedLoanAccount[]>;
+}
+
+export async function getImportedLoanAccount(token: string, id: string) {
+  const res = await fetch(apiUrl(`/loan-accounts/imported/${id}`), { headers: headers(token) });
+  if (!res.ok) throw new Error('Failed to load imported loan account');
+  return res.json() as Promise<ImportedLoanAccount>;
+}
+
 export async function getLoanApplications(token: string, status?: string) {
   const url = status ? `/loan-applications?status=${status}` : '/loan-applications';
   const res = await fetch(apiUrl(url), { headers: headers(token) });

--- a/dashboard/src/pages/ImportedDeposits.tsx
+++ b/dashboard/src/pages/ImportedDeposits.tsx
@@ -1,0 +1,100 @@
+import React from 'react';
+import { useAuth } from '../auth';
+import { ImportedDepositAccount, listImportedDeposits } from '../api';
+
+const formatDateTime = (value: string) => new Date(value).toLocaleString();
+
+const renderMetadata = (metadata: Record<string, unknown>) => {
+  const entries = Object.entries(metadata || {});
+  if (entries.length === 0) {
+    return <em>No additional metadata</em>;
+  }
+  return (
+    <dl>
+      {entries.map(([key, val]) => (
+        <React.Fragment key={key}>
+          <dt>{key}</dt>
+          <dd>{typeof val === 'object' ? JSON.stringify(val, null, 2) : String(val)}</dd>
+        </React.Fragment>
+      ))}
+    </dl>
+  );
+};
+
+const ImportedDeposits: React.FC = () => {
+  const { auth } = useAuth();
+  const [records, setRecords] = React.useState<ImportedDepositAccount[]>([]);
+  const [error, setError] = React.useState('');
+
+  React.useEffect(() => {
+    if (!auth) return;
+    listImportedDeposits(auth.token)
+      .then(setRecords)
+      .catch(() => setError('Unable to load imported deposit accounts.'));
+  }, [auth]);
+
+  return (
+    <div>
+      <h2>Imported Deposit Accounts</h2>
+      <p className="page-description">
+        These records reflect deposit accounts synced from external banking systems. Managers can review the
+        source system metadata without modifying the accounts.
+      </p>
+      {error && (
+        <p role="alert" className="error">
+          {error}
+        </p>
+      )}
+      {records.length === 0 && !error ? (
+        <p>No imported deposit accounts are available.</p>
+      ) : (
+        <div className="imported-records">
+          {records.map((record) => (
+            <details key={record.id} className="imported-record">
+              <summary>
+                <strong>{record.account_number}</strong> – {record.customer_name} ({record.currency}
+                {record.balance.toLocaleString(undefined, { maximumFractionDigits: 2 })})
+              </summary>
+              <div className="imported-record__body">
+                <section>
+                  <h3>Account Details</h3>
+                  <dl>
+                    <dt>Product</dt>
+                    <dd>{record.product_name ?? '—'}</dd>
+                    <dt>Status</dt>
+                    <dd>{record.status ?? 'Unknown'}</dd>
+                    <dt>Balance</dt>
+                    <dd>
+                      {record.currency} {record.balance.toLocaleString(undefined, { maximumFractionDigits: 2 })}
+                    </dd>
+                  </dl>
+                </section>
+                <section>
+                  <h3>Source Audit</h3>
+                  <dl>
+                    <dt>System</dt>
+                    <dd>{record.audit.system}</dd>
+                    <dt>Reference</dt>
+                    <dd>{record.audit.reference}</dd>
+                    <dt>Imported At</dt>
+                    <dd>{formatDateTime(record.audit.ingested_at)}</dd>
+                  </dl>
+                  <div>
+                    <h4>Source Metadata</h4>
+                    {renderMetadata(record.audit.metadata)}
+                  </div>
+                </section>
+                <section>
+                  <h3>Internal Metadata</h3>
+                  {renderMetadata(record.metadata)}
+                </section>
+              </div>
+            </details>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+};
+
+export default ImportedDeposits;

--- a/dashboard/src/pages/ImportedLoanAccounts.tsx
+++ b/dashboard/src/pages/ImportedLoanAccounts.tsx
@@ -1,0 +1,102 @@
+import React from 'react';
+import { useAuth } from '../auth';
+import { ImportedLoanAccount, listImportedLoanAccounts } from '../api';
+
+const formatDateTime = (value: string) => new Date(value).toLocaleString();
+
+const renderMetadata = (metadata: Record<string, unknown>) => {
+  const entries = Object.entries(metadata || {});
+  if (entries.length === 0) {
+    return <em>No additional metadata</em>;
+  }
+  return (
+    <dl>
+      {entries.map(([key, val]) => (
+        <React.Fragment key={key}>
+          <dt>{key}</dt>
+          <dd>{typeof val === 'object' ? JSON.stringify(val, null, 2) : String(val)}</dd>
+        </React.Fragment>
+      ))}
+    </dl>
+  );
+};
+
+const ImportedLoanAccounts: React.FC = () => {
+  const { auth } = useAuth();
+  const [records, setRecords] = React.useState<ImportedLoanAccount[]>([]);
+  const [error, setError] = React.useState('');
+
+  React.useEffect(() => {
+    if (!auth) return;
+    listImportedLoanAccounts(auth.token)
+      .then(setRecords)
+      .catch(() => setError('Unable to load imported loan accounts.'));
+  }, [auth]);
+
+  return (
+    <div>
+      <h2>Imported Loan Accounts</h2>
+      <p className="page-description">
+        Loan accounts ingested from external systems are read-only here. Review the funding amounts and audit
+        trail before contacting the banking team.
+      </p>
+      {error && (
+        <p role="alert" className="error">
+          {error}
+        </p>
+      )}
+      {records.length === 0 && !error ? (
+        <p>No imported loan accounts are available.</p>
+      ) : (
+        <div className="imported-records">
+          {records.map((record) => (
+            <details key={record.id} className="imported-record">
+              <summary>
+                <strong>{record.account_number}</strong> – {record.customer_name} (Outstanding:
+                {record.outstanding_balance.toLocaleString(undefined, { maximumFractionDigits: 2 })})
+              </summary>
+              <div className="imported-record__body">
+                <section>
+                  <h3>Account Details</h3>
+                  <dl>
+                    <dt>Product</dt>
+                    <dd>{record.product_name ?? '—'}</dd>
+                    <dt>Status</dt>
+                    <dd>{record.status ?? 'Unknown'}</dd>
+                    <dt>Principal Amount</dt>
+                    <dd>{record.principal_amount.toLocaleString(undefined, { maximumFractionDigits: 2 })}</dd>
+                    <dt>Outstanding Balance</dt>
+                    <dd>{record.outstanding_balance.toLocaleString(undefined, { maximumFractionDigits: 2 })}</dd>
+                    <dt>Interest Rate</dt>
+                    <dd>{record.interest_rate != null ? `${record.interest_rate}%` : 'Not provided'}</dd>
+                  </dl>
+                </section>
+                <section>
+                  <h3>Source Audit</h3>
+                  <dl>
+                    <dt>System</dt>
+                    <dd>{record.audit.system}</dd>
+                    <dt>Reference</dt>
+                    <dd>{record.audit.reference}</dd>
+                    <dt>Imported At</dt>
+                    <dd>{formatDateTime(record.audit.ingested_at)}</dd>
+                  </dl>
+                  <div>
+                    <h4>Source Metadata</h4>
+                    {renderMetadata(record.audit.metadata)}
+                  </div>
+                </section>
+                <section>
+                  <h3>Internal Metadata</h3>
+                  {renderMetadata(record.metadata)}
+                </section>
+              </div>
+            </details>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+};
+
+export default ImportedLoanAccounts;

--- a/tests/test_accounts_service.py
+++ b/tests/test_accounts_service.py
@@ -1,0 +1,111 @@
+import sys
+sys.path.append('.')
+
+from datetime import datetime, timezone
+
+from app.accounts import AccountIngestionService
+from app.database import SessionLocal, drop_db, init_db
+from app.repositories import Repositories
+
+
+def setup_function(_):
+    drop_db()
+    init_db()
+
+
+class DummyDepositAdapter:
+    def __init__(self, records):
+        self._records = records
+
+    def fetch_deposit_accounts(self):
+        return self._records
+
+
+class DummyLoanAdapter:
+    def __init__(self, records):
+        self._records = records
+
+    def fetch_loan_accounts(self):
+        return self._records
+
+
+def test_ingest_deposit_accounts_populates_repository():
+    session = SessionLocal()
+    try:
+        repos = Repositories(session)
+        adapter = DummyDepositAdapter(
+            [
+                {
+                    "id": "dep-1",
+                    "account_number": "D001",
+                    "customer_name": "Alice",
+                    "product_name": "Savings",
+                    "status": "active",
+                    "balance": 2500.5,
+                    "currency": "ZAR",
+                    "source_reference": "CORE-001",
+                    "source_metadata": {"branch": "HQ"},
+                    "metadata": {"segment": "retail"},
+                }
+            ]
+        )
+        service = AccountIngestionService(
+            repos,
+            deposit_adapter=adapter,
+            default_source_system="core-banking",
+        )
+        ingested = service.ingest_deposits()
+        assert len(ingested) == 1
+        stored = repos.imported_deposit_accounts.get("dep-1")
+        assert stored is not None
+        assert stored.audit.system == "core-banking"
+        assert stored.audit.reference == "CORE-001"
+        assert stored.audit.ingested_at.tzinfo is not None
+        assert stored.audit.metadata == {"branch": "HQ"}
+        assert stored.metadata == {"segment": "retail"}
+    finally:
+        session.close()
+
+
+def test_ingest_loans_uses_provided_audit_metadata():
+    explicit_ingested = datetime(2024, 5, 10, 12, 0, tzinfo=timezone.utc)
+    session = SessionLocal()
+    try:
+        repos = Repositories(session)
+        loan_adapter = DummyLoanAdapter(
+            [
+                {
+                    "id": "loan-9",
+                    "account_number": "L009",
+                    "customer_name": "Bob",
+                    "product_name": "Home Loan",
+                    "status": "funded",
+                    "principal_amount": 500000.0,
+                    "outstanding_balance": 420000.0,
+                    "interest_rate": 7.5,
+                    "audit": {
+                        "system": "loan-ledger",
+                        "reference": "LL-42",
+                        "ingested_at": explicit_ingested.isoformat(),
+                        "metadata": {"batch": "nightly"},
+                    },
+                    "metadata": {"portfolio": "residential"},
+                }
+            ]
+        )
+        service = AccountIngestionService(
+            repos,
+            loan_adapter=loan_adapter,
+            default_source_system="core-banking",
+        )
+        result = service.ingest()
+        assert len(result.loans) == 1
+        stored = repos.imported_loan_accounts.get("loan-9")
+        assert stored is not None
+        assert stored.audit.system == "loan-ledger"
+        assert stored.audit.reference == "LL-42"
+        assert stored.audit.ingested_at == explicit_ingested
+        assert stored.audit.metadata == {"batch": "nightly"}
+        assert stored.metadata == {"portfolio": "residential"}
+    finally:
+        session.close()


### PR DESCRIPTION
## Summary
- add an accounts ingestion service with adapter protocols, CLI entry point, and repository support for imported deposit/loan records
- relax read privileges and expose new endpoints so managers can view imported account data alongside admins
- extend the React dashboard with manager navigation and pages for imported deposit and loan accounts, surfacing audit metadata
- document the sync process and cover ingestion behaviour with unit tests

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68cec7081bf8832c812d8a10d4c9b69f