### PR TITLE
Add mailer integration for submissions

### DIFF
--- a/app/mailer.py
+++ b/app/mailer.py
@@ -1,0 +1,214 @@
+"""Email delivery helpers used by the application."""
+
+from __future__ import annotations
+
+import base64
+import logging
+import os
+import smtplib
+import ssl
+from dataclasses import dataclass
+from email.message import EmailMessage as _EmailMessage
+from typing import Iterable, Optional, Protocol, Sequence
+
+logger = logging.getLogger(__name__)
+
+
+class EmailSendError(Exception):
+    """Raised when an email could not be sent."""
+
+
+@dataclass
+class Attachment:
+    filename: str
+    content_type: str
+    content: bytes
+
+
+@dataclass
+class MailRequest:
+    to: Sequence[str]
+    subject: str
+    body: str
+    attachments: Sequence[Attachment] = ()
+
+
+class Mailer(Protocol):
+    def send(self, request: MailRequest) -> None:  # pragma: no cover - protocol
+        """Send the provided email request."""
+
+
+def _split_content_type(content_type: str) -> tuple[str, str]:
+    maintype, subtype = content_type.split("/", 1) if "/" in content_type else (
+        content_type,
+        "octet-stream",
+    )
+    maintype = maintype or "application"
+    subtype = subtype or "octet-stream"
+    return maintype, subtype
+
+
+class SMTPMailer:
+    """Mailer implementation backed by SMTP."""
+
+    def __init__(
+        self,
+        host: str,
+        port: int,
+        *,
+        username: Optional[str] = None,
+        password: Optional[str] = None,
+        from_address: Optional[str] = None,
+        use_tls: bool = True,
+        use_ssl: bool = False,
+    ) -> None:
+        self.host = host
+        self.port = port
+        self.username = username
+        self.password = password
+        self.from_address = from_address or username
+        self.use_tls = use_tls
+        self.use_ssl = use_ssl
+
+    def _connect(self) -> smtplib.SMTP:
+        if self.use_ssl:
+            context = ssl.create_default_context()
+            return smtplib.SMTP_SSL(self.host, self.port, context=context)
+        return smtplib.SMTP(self.host, self.port)
+
+    def send(self, request: MailRequest) -> None:
+        if not self.from_address:
+            raise EmailSendError("SMTP mailer requires a from address")
+
+        message = _EmailMessage()
+        message["From"] = self.from_address
+        message["To"] = ", ".join(request.to)
+        message["Subject"] = request.subject
+        message.set_content(request.body)
+
+        for attachment in request.attachments:
+            maintype, subtype = _split_content_type(attachment.content_type)
+            message.add_attachment(
+                attachment.content,
+                maintype=maintype,
+                subtype=subtype,
+                filename=attachment.filename,
+            )
+
+        try:
+            with self._connect() as server:
+                server.ehlo()
+                if self.use_tls and not self.use_ssl:
+                    context = ssl.create_default_context()
+                    server.starttls(context=context)
+                    server.ehlo()
+                if self.username and self.password:
+                    server.login(self.username, self.password)
+                server.send_message(message)
+        except smtplib.SMTPException as exc:  # pragma: no cover - smtplib specifics
+            raise EmailSendError(str(exc)) from exc
+
+
+class LoggingMailer:
+    """Fallback mailer that simply logs outgoing messages."""
+
+    def __init__(self, logger_: logging.Logger) -> None:
+        self._logger = logger_
+
+    def send(self, request: MailRequest) -> None:
+        self._logger.info(
+            "LoggingMailer delivering email to %s with subject '%s' (%d attachments)",
+            ", ".join(request.to),
+            request.subject,
+            len(request.attachments),
+        )
+
+
+def _parse_bool(value: Optional[str], default: bool) -> bool:
+    if value is None:
+        return default
+    return value.strip().lower() in {"1", "true", "yes", "on"}
+
+
+def _create_smtp_mailer() -> SMTPMailer:
+    host = os.environ.get("SMTP_HOST")
+    if not host:
+        raise EmailSendError("SMTP_HOST environment variable is required for SMTP mailer")
+
+    port = int(os.environ.get("SMTP_PORT", "587"))
+    username = os.environ.get("SMTP_USERNAME")
+    password = os.environ.get("SMTP_PASSWORD")
+    from_address = os.environ.get("MAIL_FROM_ADDRESS") or os.environ.get("SMTP_FROM")
+    use_tls = _parse_bool(os.environ.get("SMTP_USE_TLS"), True)
+    use_ssl = _parse_bool(os.environ.get("SMTP_USE_SSL"), False)
+
+    return SMTPMailer(
+        host,
+        port,
+        username=username,
+        password=password,
+        from_address=from_address,
+        use_tls=use_tls,
+        use_ssl=use_ssl,
+    )
+
+
+def create_mailer_from_env() -> Mailer:
+    provider = os.environ.get("MAIL_PROVIDER", "smtp").strip().lower()
+    if provider == "smtp":
+        try:
+            return _create_smtp_mailer()
+        except EmailSendError as exc:
+            logger.warning("Falling back to LoggingMailer due to configuration error: %s", exc)
+            return LoggingMailer(logger)
+    if provider == "console":
+        return LoggingMailer(logger)
+
+    logger.warning("Unknown MAIL_PROVIDER '%s'; using LoggingMailer", provider)
+    return LoggingMailer(logger)
+
+
+_mailer: Optional[Mailer] = None
+
+
+def get_mailer() -> Mailer:
+    global _mailer
+    if _mailer is None:
+        _mailer = create_mailer_from_env()
+    return _mailer
+
+
+def set_mailer_for_testing(mailer: Optional[Mailer]) -> None:
+    """Override the configured mailer. Only intended for tests."""
+
+    global _mailer
+    _mailer = mailer
+
+
+def build_attachment(uploaded: "UploadedFile") -> Attachment:
+    """Convert an UploadedFile pydantic model to an Attachment."""
+
+    from .models import UploadedFile  # Local import to avoid circular dependency
+
+    if not isinstance(uploaded, UploadedFile):  # pragma: no cover - defensive
+        raise TypeError("build_attachment expects an UploadedFile instance")
+
+    try:
+        content = base64.b64decode(uploaded.content)
+    except (TypeError, ValueError) as exc:
+        raise EmailSendError("Invalid base64 content in uploaded file") from exc
+
+    content_type = uploaded.content_type or "application/octet-stream"
+    filename = uploaded.filename or "attachment"
+    return Attachment(filename=filename, content_type=content_type, content=content)
+
+
+def build_attachments(files: Iterable["UploadedFile"]) -> list[Attachment]:
+    from .models import UploadedFile  # Local import to avoid circular dependency
+
+    attachments: list[Attachment] = []
+    for uploaded in files:
+        if isinstance(uploaded, UploadedFile) and uploaded.content:
+            attachments.append(build_attachment(uploaded))
+    return attachments
+

--- a/app/main.py
+++ b/app/main.py
@@ -17,6 +17,12 @@ from passlib.context import CryptContext
 from pydantic import BaseModel, ValidationError
 from openpyxl import load_workbook, Workbook
 from .database import init_db, get_session, SessionLocal
+from .mailer import (
+    MailRequest,
+    build_attachments,
+    get_mailer,
+    EmailSendError,
+)
 from .repositories import Repositories
 from .projects import ProjectsService
 from .reporting import (
@@ -82,6 +88,18 @@ SECRET_KEY = os.environ["SECRET_KEY"]
 INITIAL_ADMIN_TOKEN = os.environ["INITIAL_ADMIN_TOKEN"]
 
 FRONTEND_ORIGINS = resolve_frontend_origins()
+
+
+def _parse_recipients(value: Optional[str]) -> List[str]:
+    if not value:
+        return []
+    return [part.strip() for part in value.split(",") if part.strip()]
+
+
+DEPOSIT_ACCOUNTS_RECIPIENTS = _parse_recipients(
+    os.environ.get("DEPOSIT_ACCOUNTS_EMAIL")
+)
+MAIL_MAX_RETRIES = max(1, int(os.environ.get("MAIL_MAX_RETRIES", "3")))
 
 pwd_context = CryptContext(schemes=["bcrypt"], deprecated="auto")
 
@@ -171,6 +189,76 @@ def verify_password(password: str, hashed: str) -> bool:
         return pwd_context.verify(password, hashed)
     legacy = hashlib.sha256(password.encode()).hexdigest()
     return hmac.compare_digest(legacy, hashed)
+
+
+def _send_submission_email(
+    subject: str,
+    metadata: Dict[str, Optional[str | int]],
+    primary_document: Optional[UploadedFile],
+    required_documents: Dict[int, UploadedFile] | None,
+    repos: Repositories,
+) -> None:
+    if not DEPOSIT_ACCOUNTS_RECIPIENTS:
+        logger.debug(
+            "Skipping email dispatch for '%s' because no recipients were configured",
+            subject,
+        )
+        return
+
+    attachments = []
+    if primary_document and getattr(primary_document, "content", None):
+        try:
+            attachments.extend(build_attachments([primary_document]))
+        except EmailSendError as exc:
+            logger.warning("Unable to attach primary document for '%s': %s", subject, exc)
+    if required_documents:
+        try:
+            attachments.extend(build_attachments(required_documents.values()))
+        except EmailSendError as exc:
+            logger.warning(
+                "Unable to attach required documents for '%s': %s",
+                subject,
+                exc,
+            )
+
+    lines = [subject, ""]
+    for key, value in metadata.items():
+        normalized = value if value not in (None, "") else "N/A"
+        lines.append(f"{key}: {normalized}")
+
+    request = MailRequest(
+        to=DEPOSIT_ACCOUNTS_RECIPIENTS,
+        subject=subject,
+        body="\n".join(lines),
+        attachments=attachments,
+    )
+
+    mailer = get_mailer()
+    last_error: Exception | None = None
+    for attempt in range(1, MAIL_MAX_RETRIES + 1):
+        try:
+            mailer.send(request)
+            return
+        except EmailSendError as exc:
+            last_error = exc
+            logger.exception(
+                "Email dispatch failed for '%s' on attempt %d/%d",
+                subject,
+                attempt,
+                MAIL_MAX_RETRIES,
+            )
+        except Exception as exc:  # pragma: no cover - defensive
+            last_error = exc
+            logger.exception(
+                "Unexpected error while sending '%s' on attempt %d/%d",
+                subject,
+                attempt,
+                MAIL_MAX_RETRIES,
+            )
+    if last_error:
+        message = f"Email delivery failed for {subject}: {last_error}"
+        repos.notifications.append(message)
+
 
 def create_access_token(data: dict, expires_delta: timedelta | None = None) -> str:
     to_encode = data.copy()
@@ -953,6 +1041,19 @@ def upload_offer_application(
     )
     repos.offers.add(offer)
     repos.notifications.append(f"Offer {id} submitted by {realtor}")
+    _send_submission_email(
+        subject=f"Offer submission #{id}",
+        metadata={
+            "Submission Type": "Offer",
+            "Offer ID": id,
+            "Realtor": realtor,
+            "Property ID": property_id,
+            "Details": details,
+        },
+        primary_document=offer.document,
+        required_documents=offer.required_documents,
+        repos=repos,
+    )
     return offer
 
 
@@ -1000,6 +1101,19 @@ def upload_property_application(
     repos.notifications.append(
         f"Property application {id} submitted by {realtor}"
     )
+    _send_submission_email(
+        subject=f"Property application #{id}",
+        metadata={
+            "Submission Type": "Property Application",
+            "Application ID": id,
+            "Realtor": realtor,
+            "Property ID": property_id,
+            "Details": details,
+        },
+        primary_document=application.document,
+        required_documents=application.required_documents,
+        repos=repos,
+    )
     return application
 
 
@@ -1045,6 +1159,18 @@ def upload_account_opening(
     repos.notifications.append(
         f"Account opening {id} submitted by {realtor}"
     )
+    _send_submission_email(
+        subject=f"Account opening #{id}",
+        metadata={
+            "Submission Type": "Account Opening",
+            "Request ID": id,
+            "Realtor": realtor,
+            "Details": details,
+        },
+        primary_document=request.document,
+        required_documents=request.required_documents,
+        repos=repos,
+    )
     return request
 
 
@@ -1067,6 +1193,19 @@ def submit_offer(
     repos.offers.add(sanitized_offer)
     repos.notifications.append(
         f"Offer {sanitized_offer.id} submitted by {sanitized_offer.realtor}"
+    )
+    _send_submission_email(
+        subject=f"Offer submission #{sanitized_offer.id}",
+        metadata={
+            "Submission Type": "Offer",
+            "Offer ID": sanitized_offer.id,
+            "Realtor": sanitized_offer.realtor,
+            "Property ID": sanitized_offer.property_id,
+            "Details": sanitized_offer.details,
+        },
+        primary_document=sanitized_offer.document,
+        required_documents=sanitized_offer.required_documents,
+        repos=repos,
     )
     return sanitized_offer
 
@@ -1120,6 +1259,19 @@ def submit_property_application(
     repos.applications.add(sanitized_application)
     repos.notifications.append(
         f"Property application {sanitized_application.id} submitted by {sanitized_application.realtor}"
+    )
+    _send_submission_email(
+        subject=f"Property application #{sanitized_application.id}",
+        metadata={
+            "Submission Type": "Property Application",
+            "Application ID": sanitized_application.id,
+            "Realtor": sanitized_application.realtor,
+            "Property ID": sanitized_application.property_id,
+            "Details": sanitized_application.details,
+        },
+        primary_document=sanitized_application.document,
+        required_documents=sanitized_application.required_documents,
+        repos=repos,
     )
     return sanitized_application
 
@@ -1176,6 +1328,18 @@ def submit_account_opening(
     repos.account_openings.add(sanitized_request)
     repos.notifications.append(
         f"Account opening {sanitized_request.id} submitted by {sanitized_request.realtor}"
+    )
+    _send_submission_email(
+        subject=f"Account opening #{sanitized_request.id}",
+        metadata={
+            "Submission Type": "Account Opening",
+            "Request ID": sanitized_request.id,
+            "Realtor": sanitized_request.realtor,
+            "Details": sanitized_request.details,
+        },
+        primary_document=sanitized_request.document,
+        required_documents=sanitized_request.required_documents,
+        repos=repos,
     )
     return sanitized_request
 
@@ -1366,6 +1530,19 @@ def submit_loan_application(
     repos.loan_applications.add(sanitized_application)
     repos.notifications.append(
         f"Loan application {sanitized_application.id} submitted by {sanitized_application.realtor}"
+    )
+    _send_submission_email(
+        subject=f"Loan application #{sanitized_application.id}",
+        metadata={
+            "Submission Type": "Loan Application",
+            "Application ID": sanitized_application.id,
+            "Realtor": sanitized_application.realtor,
+            "Account ID": sanitized_application.account_id,
+            "Property ID": sanitized_application.property_id,
+        },
+        primary_document=None,
+        required_documents=sanitized_application.required_documents,
+        repos=repos,
     )
     return sanitized_application
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -7,6 +7,9 @@ from fastapi.testclient import TestClient
 
 os.environ.setdefault("SECRET_KEY", "test")
 os.environ.setdefault("INITIAL_ADMIN_TOKEN", "bootstrap-token")
+os.environ.setdefault("DEPOSIT_ACCOUNTS_EMAIL", "deposits@example.com")
+os.environ.setdefault("MAIL_PROVIDER", "console")
+os.environ.setdefault("MAIL_FROM_ADDRESS", "noreply@example.com")
 
 from app.main import app
 

--- a/tests/test_submission_email.py
+++ b/tests/test_submission_email.py
@@ -1,0 +1,150 @@
+import base64
+import json
+
+import pytest
+
+from app.database import drop_db, init_db
+from app.mailer import EmailSendError, set_mailer_for_testing
+
+
+class StubMailer:
+    def __init__(self) -> None:
+        self.sent_requests = []
+
+    def send(self, request) -> None:
+        self.sent_requests.append(request)
+
+
+@pytest.fixture()
+def mailer_stub():
+    stub = StubMailer()
+    set_mailer_for_testing(stub)
+    try:
+        yield stub
+    finally:
+        set_mailer_for_testing(None)
+
+
+def setup_agents(client):
+    drop_db()
+    init_db()
+    admin_password = "AdminPass123"
+    client.post(
+        "/agents",
+        json={"username": "admin", "role": "admin", "password": admin_password},
+        headers={"X-Bootstrap-Token": "bootstrap-token"},
+    )
+    admin_token = client.post(
+        "/auth/login", json={"username": "admin", "password": admin_password}
+    ).json()["token"]
+    realtor_password = "RealtorPass123"
+    client.post(
+        "/agents",
+        json={"username": "realtor", "role": "agent", "password": realtor_password},
+        headers={"Authorization": f"Bearer {admin_token}"},
+    )
+    realtor_token = client.post(
+        "/auth/login", json={"username": "realtor", "password": realtor_password}
+    ).json()["token"]
+    return {
+        "admin": {"Authorization": f"Bearer {admin_token}"},
+        "realtor": {"Authorization": f"Bearer {realtor_token}"},
+    }
+
+
+def test_offer_submission_dispatches_email(client, mailer_stub):
+    headers = setup_agents(client)
+    encoded_document = base64.b64encode(b"offer document").decode()
+    encoded_requirement = base64.b64encode(b"supporting document").decode()
+    payload = {
+        "id": 601,
+        "realtor": "realtor",
+        "property_id": 42,
+        "details": "New offer",
+        "document": {
+            "filename": "offer.pdf",
+            "content_type": "application/pdf",
+            "content": encoded_document,
+        },
+        "required_documents": {
+            1: {
+                "filename": "proof.pdf",
+                "content_type": "application/pdf",
+                "content": encoded_requirement,
+            }
+        },
+    }
+
+    resp = client.post("/offers", json=payload, headers=headers["realtor"])
+    assert resp.status_code == 200
+
+    assert len(mailer_stub.sent_requests) == 1
+    request = mailer_stub.sent_requests[0]
+    assert request.subject == "Offer submission #601"
+    assert "Submission Type: Offer" in request.body
+    assert len(request.attachments) == 2
+    filenames = {attachment.filename for attachment in request.attachments}
+    assert filenames == {"offer.pdf", "proof.pdf"}
+
+
+def test_account_opening_upload_dispatches_email(client, mailer_stub):
+    headers = setup_agents(client)
+    encoded_requirement = base64.b64encode(b"id doc").decode()
+    data = {
+        "id": "777",
+        "realtor": "realtor",
+        "details": "Open account",
+        "requirement_documents": json.dumps(
+            {
+                1: {
+                    "filename": "id.pdf",
+                    "content_type": "application/pdf",
+                    "content": encoded_requirement,
+                }
+            }
+        ),
+    }
+    files = {
+        "file": ("statement.pdf", b"statement", "application/pdf"),
+    }
+
+    resp = client.post(
+        "/applications/account",
+        data=data,
+        files=files,
+        headers=headers["realtor"],
+    )
+    assert resp.status_code == 200
+
+    assert len(mailer_stub.sent_requests) == 1
+    request = mailer_stub.sent_requests[0]
+    assert request.subject == "Account opening #777"
+    assert "Submission Type: Account Opening" in request.body
+    assert len(request.attachments) == 2
+    filenames = {attachment.filename for attachment in request.attachments}
+    assert filenames == {"statement.pdf", "id.pdf"}
+
+
+def test_email_failure_is_reported_to_notifications(client):
+    headers = setup_agents(client)
+
+    class FailingMailer:
+        def send(self, request) -> None:  # pragma: no cover - simple stub
+            raise EmailSendError("smtp failure")
+
+    set_mailer_for_testing(FailingMailer())
+    try:
+        payload = {
+            "id": 888,
+            "realtor": "realtor",
+            "property_id": 11,
+        }
+        resp = client.post("/offers", json=payload, headers=headers["realtor"])
+        assert resp.status_code == 200
+
+        notes_resp = client.get("/notifications", headers=headers["admin"])
+        assert notes_resp.status_code == 200
+        notes = notes_resp.json()
+        assert any("Email delivery failed for Offer submission #888" in note for note in notes)
+    finally:
+        set_mailer_for_testing(None)


### PR DESCRIPTION
## Summary
- add a configurable mailer utility with SMTP and logging providers
- send submission emails for offers, property/property account applications, and loan applications including attachments
- surface email delivery failures via retries and notifications
- cover submission email dispatch with integration tests

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68cecc3db2d0832c9a518dc1c99ba971