### PR TITLE
Add manager approval workflow for account openings

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,16 @@ Simple FastAPI service that allows a Property Sales Manager to manage real estat
 It also supports submission workflows for offers, property applications, and account opening requests with
 basic status tracking and notification storage.
 
+## Account Opening Workflow
+
+Realtors capture account opening requests from the dashboard or by submitting the multipart form at
+`POST /applications/account`. The initial submission only stores the request and marks it as `submitted`.
+Managers review new requests, upload any missing documents, and approve them via the
+`POST /account-openings/{id}/approve` (or `/applications/account/{id}/approve` for file uploads) endpoints.
+Approval sets the status to `manager_approved`, records a notification, and triggers the email dispatch to the
+deposit mailbox. Once a request is approved, management can provision the target account and track incoming
+deposits using the existing `/account-openings/{id}/open` and `/account-openings/{id}/deposit` endpoints.
+
 ## Setup
 
 ```

--- a/app/main.py
+++ b/app/main.py
@@ -1215,22 +1215,11 @@ async def upload_account_opening(
         details=details,
         document=document,
         required_documents=parsed_documents,
+        status=SubmissionStatus.SUBMITTED,
     )
     repos.account_openings.add(request)
     repos.notifications.append(
         f"Account opening {id} submitted by {realtor}"
-    )
-    _send_submission_email(
-        subject=f"Account opening #{id}",
-        metadata={
-            "Submission Type": "Account Opening",
-            "Request ID": id,
-            "Realtor": realtor,
-            "Details": details,
-        },
-        primary_document=request.document,
-        required_documents=request.required_documents,
-        repos=repos,
     )
     return request
 
@@ -1390,19 +1379,47 @@ def submit_account_opening(
     repos.notifications.append(
         f"Account opening {sanitized_request.id} submitted by {sanitized_request.realtor}"
     )
+    return sanitized_request
+
+
+@app.post("/account-openings/{req_id}/approve", response_model=AccountOpening)
+def approve_account_opening(
+    req_id: int,
+    agent: Agent = Depends(require_management),
+    repos: Repositories = Depends(get_repositories),
+):
+    request = repos.account_openings.get(req_id)
+    if not request:
+        raise HTTPException(status_code=404, detail="Request not found")
+    if request.status != SubmissionStatus.SUBMITTED:
+        raise HTTPException(status_code=400, detail="Only submitted requests can be approved")
+    request.status = SubmissionStatus.MANAGER_APPROVED
+    repos.account_openings.add(request)
+    repos.notifications.append(
+        f"Account opening {req_id} approved by {agent.username}"
+    )
     _send_submission_email(
-        subject=f"Account opening #{sanitized_request.id}",
+        subject=f"Account opening #{request.id}",
         metadata={
             "Submission Type": "Account Opening",
-            "Request ID": sanitized_request.id,
-            "Realtor": sanitized_request.realtor,
-            "Details": sanitized_request.details,
+            "Request ID": request.id,
+            "Realtor": request.realtor,
+            "Details": request.details,
         },
-        primary_document=sanitized_request.document,
-        required_documents=sanitized_request.required_documents,
+        primary_document=request.document,
+        required_documents=request.required_documents,
         repos=repos,
     )
-    return sanitized_request
+    return request
+
+
+@app.post("/applications/account/{req_id}/approve", response_model=AccountOpening)
+def approve_uploaded_account_opening(
+    req_id: int,
+    agent: Agent = Depends(require_management),
+    repos: Repositories = Depends(get_repositories),
+):
+    return approve_account_opening(req_id=req_id, agent=agent, repos=repos)
 
 
 @app.get("/account-openings", response_model=List[AccountOpening])
@@ -1426,7 +1443,8 @@ def get_account_opening(
     request = repos.account_openings.get(req_id)
     if not request:
         raise HTTPException(status_code=404, detail="Request not found")
-    _ensure_owner(request.realtor, agent)
+    if agent.role not in (AgentRole.ADMIN, AgentRole.MANAGER) and request.realtor != agent.username:
+        raise HTTPException(status_code=403, detail="Not authorized")
     return request
 
 
@@ -1434,7 +1452,7 @@ def get_account_opening(
 def update_account_opening_status(
     req_id: int,
     update: StatusUpdate,
-    _: Agent = Depends(require_admin),
+    _: Agent = Depends(require_management),
     repos: Repositories = Depends(get_repositories),
 ):
     request = repos.account_openings.get(req_id)
@@ -1449,12 +1467,21 @@ def update_account_opening_status(
 def open_account(
     req_id: int,
     details: AccountSetup,
-    _: Agent = Depends(require_admin),
+    _: Agent = Depends(require_management),
     repos: Repositories = Depends(get_repositories),
 ):
     request = repos.account_openings.get(req_id)
     if not request:
         raise HTTPException(status_code=404, detail="Request not found")
+    if request.status not in (
+        SubmissionStatus.MANAGER_APPROVED,
+        SubmissionStatus.IN_PROGRESS,
+        SubmissionStatus.COMPLETED,
+    ):
+        raise HTTPException(
+            status_code=400,
+            detail="Account opening must be manager approved before setup",
+        )
     if details.deposit_threshold <= 0:
         raise HTTPException(status_code=400, detail="Deposit threshold must be positive")
     request.account_number = details.account_number
@@ -1468,7 +1495,7 @@ def open_account(
 def record_deposit(
     req_id: int,
     deposit: Deposit,
-    _: Agent = Depends(require_admin),
+    _: Agent = Depends(require_management),
     repos: Repositories = Depends(get_repositories),
 ):
     request = repos.account_openings.get(req_id)
@@ -1492,7 +1519,12 @@ def list_pending_deposits(
     return [
         o
         for o in openings
-        if o.status in (SubmissionStatus.SUBMITTED, SubmissionStatus.IN_PROGRESS)
+        if o.status
+        in (
+            SubmissionStatus.SUBMITTED,
+            SubmissionStatus.MANAGER_APPROVED,
+            SubmissionStatus.IN_PROGRESS,
+        )
     ]
 
 
@@ -1520,12 +1552,21 @@ def get_imported_deposit(
 def open_deposit_account(
     req_id: int,
     details: AccountSetup,
-    _: Agent = Depends(require_admin),
+    _: Agent = Depends(require_management),
     repos: Repositories = Depends(get_repositories),
 ):
     request = repos.account_openings.get(req_id)
     if not request:
         raise HTTPException(status_code=404, detail="Request not found")
+    if request.status not in (
+        SubmissionStatus.MANAGER_APPROVED,
+        SubmissionStatus.IN_PROGRESS,
+        SubmissionStatus.COMPLETED,
+    ):
+        raise HTTPException(
+            status_code=400,
+            detail="Account opening must be manager approved before setup",
+        )
     if details.deposit_threshold <= 0:
         raise HTTPException(status_code=400, detail="Deposit threshold must be positive")
     request.account_number = details.account_number
@@ -1539,7 +1580,7 @@ def open_deposit_account(
 def record_account_deposit(
     req_id: int,
     deposit: Deposit,
-    _: Agent = Depends(require_admin),
+    _: Agent = Depends(require_management),
     repos: Repositories = Depends(get_repositories),
 ):
     request = repos.account_openings.get(req_id)

--- a/app/models.py
+++ b/app/models.py
@@ -98,6 +98,7 @@ class AgentInDB(Agent):
 
 class SubmissionStatus(str, Enum):
     SUBMITTED = "submitted"
+    MANAGER_APPROVED = "manager_approved"
     IN_PROGRESS = "in_progress"
     COMPLETED = "completed"
     REJECTED = "rejected"

--- a/dashboard/src/App.tsx
+++ b/dashboard/src/App.tsx
@@ -156,7 +156,7 @@ const App: React.FC = () => {
             <Route
               path="/deposits/:id"
               element={
-                <ProtectedRoute roles={["admin"]}>
+                <ProtectedRoute roles={["admin", "manager"]}>
                   <DepositDetail />
                 </ProtectedRoute>
               }
@@ -188,7 +188,7 @@ const App: React.FC = () => {
             <Route
               path="/account-openings/:id"
               element={
-                <ProtectedRoute roles={["admin"]}>
+                <ProtectedRoute roles={["admin", "manager"]}>
                   <AccountOpeningDetail />
                 </ProtectedRoute>
               }

--- a/dashboard/src/api.ts
+++ b/dashboard/src/api.ts
@@ -349,6 +349,15 @@ export async function submitAccountOpening(
   return res.json();
 }
 
+export async function approveAccountOpening(token: string, id: number) {
+  const res = await fetch(apiUrl(`/account-openings/${id}/approve`), {
+    method: 'POST',
+    headers: headers(token),
+  });
+  if (!res.ok) throw new Error('Failed to approve account opening');
+  return res.json();
+}
+
 export async function submitPropertyApplication(
   token: string,
   app: {

--- a/dashboard/src/pages/AccountOpeningDetail.tsx
+++ b/dashboard/src/pages/AccountOpeningDetail.tsx
@@ -5,6 +5,7 @@ import {
   getAccountOpening,
   openAccount,
   recordDeposit,
+  approveAccountOpening,
 } from '../api';
 
 interface AccountOpening {
@@ -25,6 +26,8 @@ const AccountOpeningDetail: React.FC = () => {
   const [deposit, setDeposit] = React.useState('');
   const [error, setError] = React.useState('');
 
+  const canManage = auth?.role === 'admin' || auth?.role === 'manager';
+
   const load = () => {
     if (auth && id) {
       getAccountOpening(auth.token, Number(id))
@@ -36,6 +39,17 @@ const AccountOpeningDetail: React.FC = () => {
   React.useEffect(load, [auth, id]);
 
   const totalDeposits = opening?.deposits.reduce((s, d) => s + d, 0) || 0;
+
+  const handleApprove = async () => {
+    if (!auth || !id) return;
+    try {
+      const req = await approveAccountOpening(auth.token, Number(id));
+      setOpening(req);
+      setError('');
+    } catch {
+      setError('Failed to approve request');
+    }
+  };
 
   const handleOpen = async () => {
     if (!auth || !id) return;
@@ -65,13 +79,32 @@ const AccountOpeningDetail: React.FC = () => {
 
   if (!opening) return <div>{error || 'Loading...'}</div>;
 
+  const canOpenAccount =
+    opening.status === 'manager_approved' ||
+    opening.status === 'in_progress' ||
+    opening.status === 'completed';
+
   return (
     <div>
       <h2>Account Opening {opening.id}</h2>
       <p>Realtor: {opening.realtor}</p>
       <p>Status: {opening.status}</p>
 
-      {!opening.account_number && (
+      {canManage && opening.status === 'submitted' && (
+        <div>
+          <h3>Manager Approval</h3>
+          <p>Approve this request to notify the deposit team.</p>
+          <button type="button" onClick={handleApprove}>
+            Approve for Processing
+          </button>
+        </div>
+      )}
+
+      {!canManage && opening.status === 'submitted' && (
+        <p>This request is awaiting manager approval.</p>
+      )}
+
+      {canManage && !opening.account_number && (
         <div>
           <h3>Open Account</h3>
           <input
@@ -87,7 +120,7 @@ const AccountOpeningDetail: React.FC = () => {
           />
           <button
             onClick={handleOpen}
-            disabled={!accountNumber || !threshold}
+            disabled={!accountNumber || !threshold || !canOpenAccount}
           >
             Save
           </button>
@@ -101,7 +134,7 @@ const AccountOpeningDetail: React.FC = () => {
           <p>
             Received {totalDeposits} / {opening.deposit_threshold}
           </p>
-          {opening.status !== 'completed' && (
+          {canManage && opening.status !== 'completed' && (
             <div>
               <input
                 placeholder="Deposit Amount"

--- a/dashboard/src/pages/DepositDetail.tsx
+++ b/dashboard/src/pages/DepositDetail.tsx
@@ -5,6 +5,7 @@ import {
   getAccountOpening,
   openDepositAccount,
   recordAccountDeposit,
+  approveAccountOpening,
 } from '../api';
 
 interface AccountOpening {
@@ -25,6 +26,8 @@ const DepositDetail: React.FC = () => {
   const [deposit, setDeposit] = React.useState('');
   const [error, setError] = React.useState('');
 
+  const canManage = auth?.role === 'admin' || auth?.role === 'manager';
+
   const load = () => {
     if (auth && id) {
       getAccountOpening(auth.token, Number(id))
@@ -36,6 +39,17 @@ const DepositDetail: React.FC = () => {
   React.useEffect(load, [auth, id]);
 
   const totalDeposits = opening?.deposits.reduce((s, d) => s + d, 0) || 0;
+
+  const handleApprove = async () => {
+    if (!auth || !id) return;
+    try {
+      const req = await approveAccountOpening(auth.token, Number(id));
+      setOpening(req);
+      setError('');
+    } catch {
+      setError('Failed to approve request');
+    }
+  };
 
   const handleOpen = async () => {
     if (!auth || !id) return;
@@ -65,13 +79,32 @@ const DepositDetail: React.FC = () => {
 
   if (!opening) return <div>{error || 'Loading...'}</div>;
 
+  const canOpenAccount =
+    opening.status === 'manager_approved' ||
+    opening.status === 'in_progress' ||
+    opening.status === 'completed';
+
   return (
     <div>
       <h2>Deposit Request {opening.id}</h2>
       <p>Realtor: {opening.realtor}</p>
       <p>Status: {opening.status}</p>
 
-      {!opening.account_number && (
+      {canManage && opening.status === 'submitted' && (
+        <div>
+          <h3>Manager Approval</h3>
+          <p>Approve this request to begin account setup.</p>
+          <button type="button" onClick={handleApprove}>
+            Approve for Processing
+          </button>
+        </div>
+      )}
+
+      {!canManage && opening.status === 'submitted' && (
+        <p>This deposit request is awaiting manager approval.</p>
+      )}
+
+      {canManage && !opening.account_number && (
         <div>
           <h3>Open Account</h3>
           <input
@@ -85,7 +118,10 @@ const DepositDetail: React.FC = () => {
             value={threshold}
             onChange={e => setThreshold(e.target.value)}
           />
-          <button onClick={handleOpen} disabled={!accountNumber || !threshold}>
+          <button
+            onClick={handleOpen}
+            disabled={!accountNumber || !threshold || !canOpenAccount}
+          >
             Save
           </button>
         </div>
@@ -98,7 +134,7 @@ const DepositDetail: React.FC = () => {
           <p>
             Received {totalDeposits} / {opening.deposit_threshold}
           </p>
-          {opening.status !== 'completed' && (
+          {canManage && opening.status !== 'completed' && (
             <div>
               <input
                 placeholder="Deposit Amount"

--- a/tests/test_agreements.py
+++ b/tests/test_agreements.py
@@ -39,6 +39,10 @@ def setup_data(client):
         json={"id": 1, "realtor": "realtor"},
         headers=realtor_headers,
     )
+    client.post(
+        "/account-openings/1/approve",
+        headers=admin_headers,
+    )
     client.put(
         "/account-openings/1/open",
         json={"account_number": "ACC1", "deposit_threshold": 100},

--- a/tests/test_dashboard.py
+++ b/tests/test_dashboard.py
@@ -63,6 +63,10 @@ def setup_data(client, admin_headers, agent_headers):
         json={"id": 100, "realtor": "agentA"},
         headers=agent_headers,
     )
+    client.post(
+        "/account-openings/100/approve",
+        headers=admin_headers,
+    )
     client.put(
         "/account-openings/100/open",
         json={"account_number": "A1", "deposit_threshold": 100},

--- a/tests/test_deposits_api.py
+++ b/tests/test_deposits_api.py
@@ -50,6 +50,19 @@ def test_deposit_workflow(client):
         json={"account_number": "A1", "deposit_threshold": 100},
         headers=admin_headers,
     )
+    assert resp.status_code == 400
+    assert resp.json()["detail"] == "Account opening must be manager approved before setup"
+
+    client.post(
+        "/account-openings/1/approve",
+        headers=admin_headers,
+    )
+
+    resp = client.post(
+        "/accounts/deposits/1/open",
+        json={"account_number": "A1", "deposit_threshold": 100},
+        headers=admin_headers,
+    )
     assert resp.status_code == 200
     assert resp.json()["status"] == "in_progress"
 

--- a/tests/test_reporting.py
+++ b/tests/test_reporting.py
@@ -61,6 +61,10 @@ def setup_data(client):
         json={"id": 1, "realtor": "agent"},
         headers=agent_headers,
     )
+    client.post(
+        "/account-openings/1/approve",
+        headers=admin_headers,
+    )
     client.put(
         "/account-openings/1/open",
         json={"account_number": "A1", "deposit_threshold": 100},

--- a/tests/test_submission_email.py
+++ b/tests/test_submission_email.py
@@ -115,6 +115,14 @@ def test_account_opening_upload_dispatches_email(client, mailer_stub):
     )
     assert resp.status_code == 200
 
+    assert len(mailer_stub.sent_requests) == 0
+
+    resp = client.post(
+        "/applications/account/777/approve",
+        headers=headers["admin"],
+    )
+    assert resp.status_code == 200
+
     assert len(mailer_stub.sent_requests) == 1
     request = mailer_stub.sent_requests[0]
     assert request.subject == "Account opening #777"

--- a/tests/test_submissions.py
+++ b/tests/test_submissions.py
@@ -137,6 +137,13 @@ def test_submission_payload_privileged_fields_are_sanitized(client):
     assert stored["deposit_threshold"] is None
     assert stored["deposits"] == []
 
+    resp = client.post(
+        "/account-openings/303/approve",
+        headers=admin_headers,
+    )
+    assert resp.status_code == 200
+    assert resp.json()["status"] == SubmissionStatus.MANAGER_APPROVED.value
+
     resp = client.put(
         "/account-openings/303/open",
         json={"account_number": "SAFE", "deposit_threshold": 100},
@@ -208,6 +215,21 @@ def test_account_opening_deposit_tracking(client):
         json={"account_number": "ACC123", "deposit_threshold": 100},
         headers=admin_headers,
     )
+    assert resp.status_code == 400
+    assert resp.json()["detail"] == "Account opening must be manager approved before setup"
+
+    resp = client.post(
+        "/account-openings/2/approve",
+        headers=admin_headers,
+    )
+    assert resp.status_code == 200
+    assert resp.json()["status"] == SubmissionStatus.MANAGER_APPROVED.value
+
+    resp = client.put(
+        "/account-openings/2/open",
+        json={"account_number": "ACC123", "deposit_threshold": 100},
+        headers=admin_headers,
+    )
     assert resp.status_code == 200
     assert resp.json()["account_number"] == "ACC123"
     assert resp.json()["status"] == SubmissionStatus.IN_PROGRESS.value
@@ -247,6 +269,13 @@ def test_loan_application_flow(client):
     account = {"id": 3, "realtor": "realtor"}
     resp = client.post("/account-openings", json=account, headers=realtor_headers)
     assert resp.status_code == 200
+
+    resp = client.post(
+        "/account-openings/3/approve",
+        headers=admin_headers,
+    )
+    assert resp.status_code == 200
+    assert resp.json()["status"] == SubmissionStatus.MANAGER_APPROVED.value
 
     resp = client.put(
         "/account-openings/3/open",
@@ -353,6 +382,12 @@ def test_loan_application_realtor_mismatch_rejected(client):
     resp = client.post("/account-openings", json=account, headers=realtor_headers)
     assert resp.status_code == 200
 
+    resp = client.post(
+        "/account-openings/7/approve",
+        headers=admin_headers,
+    )
+    assert resp.status_code == 200
+
     resp = client.put(
         "/account-openings/7/open",
         json={"account_number": "AC7", "deposit_threshold": 100},
@@ -404,6 +439,10 @@ def test_account_opening_queue_listing(client):
         json={"id": 20, "realtor": "realtor"},
         headers=realtor_headers,
     )
+    client.post(
+        "/account-openings/10/approve",
+        headers=admin_headers,
+    )
     client.put(
         "/account-openings/10/open",
         json={"account_number": "ACC10", "deposit_threshold": 100},
@@ -444,6 +483,10 @@ def test_loan_application_queue_listing_and_agreement_generation(client):
         "/account-openings",
         json={"id": 1, "realtor": "realtor"},
         headers=realtor_headers,
+    )
+    client.post(
+        "/account-openings/1/approve",
+        headers=admin_headers,
     )
     client.put(
         "/account-openings/1/open",


### PR DESCRIPTION
## Summary
- add a manager approval status and endpoints so account-opening emails are sent only after approval
- relax backend permissions for account-opening management and require approval before opening accounts or deposits
- expose the approval flow in the dashboard and document the revised workflow

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68cef3e15ef8832c89c0b843032a0982