### PR TITLE
Add configurable deposit contact settings UI and API

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -1,7 +1,7 @@
 from fastapi import FastAPI, HTTPException, Depends, Header, Request, UploadFile, File, Form, Response
 from fastapi.responses import StreamingResponse
 from fastapi.middleware.cors import CORSMiddleware
-from typing import Dict, List, Optional
+from typing import Any, Dict, List, Optional
 from datetime import datetime, timedelta
 import hashlib
 import hmac
@@ -70,6 +70,8 @@ from .models import (
     DocumentWorkflow,
     ImportedDepositAccount,
     ImportedLoanAccount,
+    ContactSettings,
+    ContactSettingsResponse,
 )
 
 logger = logging.getLogger(__name__)
@@ -97,9 +99,10 @@ def _parse_recipients(value: Optional[str]) -> List[str]:
     return [part.strip() for part in value.split(",") if part.strip()]
 
 
-DEPOSIT_ACCOUNTS_RECIPIENTS = _parse_recipients(
+DEFAULT_DEPOSIT_ACCOUNTS_RECIPIENTS = _parse_recipients(
     os.environ.get("DEPOSIT_ACCOUNTS_EMAIL")
 )
+DEPOSIT_CONTACT_SETTINGS_KEY = "deposit_notifications"
 MAIL_MAX_RETRIES = max(1, int(os.environ.get("MAIL_MAX_RETRIES", "3")))
 
 pwd_context = CryptContext(schemes=["bcrypt"], deprecated="auto")
@@ -181,6 +184,58 @@ def get_projects_service(
     return ProjectsService(repos)
 
 
+def _normalize_recipients(recipients: List[str]) -> List[str]:
+    normalized: List[str] = []
+    seen: set[str] = set()
+    for recipient in recipients:
+        trimmed = str(recipient).strip()
+        if not trimmed:
+            continue
+        key = trimmed.lower()
+        if key in seen:
+            continue
+        normalized.append(trimmed)
+        seen.add(key)
+    return normalized
+
+
+def _extract_recipients(data: Any) -> List[str]:
+    if not isinstance(data, dict):
+        return []
+    raw = data.get("recipients")
+    if not isinstance(raw, list):
+        return []
+    return _normalize_recipients([str(value) for value in raw])
+
+
+def _resolve_deposit_recipients(repos: Repositories) -> List[str]:
+    stored = repos.contact_settings.get(DEPOSIT_CONTACT_SETTINGS_KEY)
+    if stored is not None:
+        return _extract_recipients(stored)
+    return _normalize_recipients(DEFAULT_DEPOSIT_ACCOUNTS_RECIPIENTS)
+
+
+def _get_contact_settings_response(repos: Repositories) -> ContactSettingsResponse:
+    stored = repos.contact_settings.get(DEPOSIT_CONTACT_SETTINGS_KEY)
+    if stored is None:
+        return ContactSettingsResponse(
+            recipients=_normalize_recipients(DEFAULT_DEPOSIT_ACCOUNTS_RECIPIENTS),
+            configured=False,
+        )
+    return ContactSettingsResponse(recipients=_extract_recipients(stored))
+
+
+def _store_contact_settings(
+    repos: Repositories, payload: ContactSettings
+) -> ContactSettingsResponse:
+    normalized = _normalize_recipients([str(item) for item in payload.recipients])
+    repos.contact_settings.set(
+        DEPOSIT_CONTACT_SETTINGS_KEY,
+        {"recipients": normalized},
+    )
+    return ContactSettingsResponse(recipients=normalized)
+
+
 def hash_password(password: str) -> str:
     return pwd_context.hash(password)
 
@@ -199,7 +254,8 @@ def _send_submission_email(
     required_documents: Dict[str, UploadedFile] | None,
     repos: Repositories,
 ) -> None:
-    if not DEPOSIT_ACCOUNTS_RECIPIENTS:
+    recipients = _resolve_deposit_recipients(repos)
+    if not recipients:
         logger.debug(
             "Skipping email dispatch for '%s' because no recipients were configured",
             subject,
@@ -228,7 +284,7 @@ def _send_submission_email(
         lines.append(f"{key}: {normalized}")
 
     request = MailRequest(
-        to=DEPOSIT_ACCOUNTS_RECIPIENTS,
+        to=recipients,
         subject=subject,
         body="\n".join(lines),
         attachments=attachments,
@@ -378,6 +434,43 @@ def list_agents(
     repos: Repositories = Depends(get_repositories),
 ):
     return [Agent(username=agent.username, role=agent.role) for agent in repos.agents.list()]
+
+
+@app.get("/contact-settings/deposit", response_model=ContactSettingsResponse)
+def get_deposit_contact_settings(
+    _: Agent = Depends(require_admin),
+    repos: Repositories = Depends(get_repositories),
+):
+    return _get_contact_settings_response(repos)
+
+
+@app.post("/contact-settings/deposit", response_model=ContactSettingsResponse)
+def create_deposit_contact_settings(
+    payload: ContactSettings,
+    _: Agent = Depends(require_admin),
+    repos: Repositories = Depends(get_repositories),
+):
+    if repos.contact_settings.get(DEPOSIT_CONTACT_SETTINGS_KEY) is not None:
+        raise HTTPException(status_code=409, detail="Contact settings already configured")
+    return _store_contact_settings(repos, payload)
+
+
+@app.put("/contact-settings/deposit", response_model=ContactSettingsResponse)
+def update_deposit_contact_settings(
+    payload: ContactSettings,
+    _: Agent = Depends(require_admin),
+    repos: Repositories = Depends(get_repositories),
+):
+    return _store_contact_settings(repos, payload)
+
+
+@app.delete("/contact-settings/deposit", status_code=204)
+def delete_deposit_contact_settings(
+    _: Agent = Depends(require_admin),
+    repos: Repositories = Depends(get_repositories),
+):
+    repos.contact_settings.delete(DEPOSIT_CONTACT_SETTINGS_KEY)
+    return Response(status_code=204)
 
 
 class LoginRequest(BaseModel):

--- a/app/models.py
+++ b/app/models.py
@@ -2,7 +2,7 @@ from enum import Enum
 from typing import Any, Dict, List, Optional
 from datetime import datetime
 
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, EmailStr, Field
 
 
 class UploadedFile(BaseModel):
@@ -271,3 +271,11 @@ class ImportedLoanAccount(ImportedAccountBase):
     principal_amount: float
     outstanding_balance: float
     interest_rate: Optional[float] = None
+
+
+class ContactSettings(BaseModel):
+    recipients: List[EmailStr]
+
+
+class ContactSettingsResponse(ContactSettings):
+    configured: bool = True

--- a/app/repositories.py
+++ b/app/repositories.py
@@ -82,6 +82,10 @@ class SimpleRepository:
         self.session.merge(row)
         self.session.commit()
 
+    def delete(self, key: Any) -> None:
+        self.session.query(Record).filter_by(store=self.store, key=str(key)).delete()
+        self.session.commit()
+
     def clear(self) -> None:
         self.session.query(Record).filter_by(store=self.store).delete()
         self.session.commit()
@@ -128,3 +132,4 @@ class Repositories:
         self.imported_loan_accounts = Repository(
             session, 'imported_loan_accounts', ImportedLoanAccount
         )
+        self.contact_settings = SimpleRepository(session, 'contact_settings')

--- a/dashboard/src/App.tsx
+++ b/dashboard/src/App.tsx
@@ -20,6 +20,7 @@ import LoanAccounts from './pages/LoanAccounts';
 import DocumentRequirementsPage from './pages/DocumentRequirements';
 import ImportedDeposits from './pages/ImportedDeposits';
 import ImportedLoanAccounts from './pages/ImportedLoanAccounts';
+import ContactSettingsPage from './pages/ContactSettings';
 import { ProtectedRoute, useAuth } from './auth';
 
 const App: React.FC = () => {
@@ -32,6 +33,7 @@ const App: React.FC = () => {
           { to: '/stands', label: 'Stands' },
           { to: '/mandates', label: 'Mandates' },
           { to: '/document-requirements', label: 'Document Requirements' },
+          { to: '/contact-settings', label: 'Contact Settings' },
           { to: '/agents', label: 'Agents' },
           { to: '/account-openings', label: 'Account Openings' },
           { to: '/loan-applications', label: 'Loan Applications' },
@@ -81,6 +83,14 @@ const App: React.FC = () => {
         <main className="app-content">
           <Routes>
             <Route path="/login" element={<Login />} />
+            <Route
+              path="/contact-settings"
+              element={
+                <ProtectedRoute roles={["admin"]}>
+                  <ContactSettingsPage />
+                </ProtectedRoute>
+              }
+            />
             <Route
               path="/document-requirements"
               element={

--- a/dashboard/src/api.ts
+++ b/dashboard/src/api.ts
@@ -117,6 +117,56 @@ export async function createAgent(token: string, agent: AgentCreate) {
   return res.json() as Promise<Agent>;
 }
 
+export interface ContactSettingsPayload {
+  recipients: string[];
+}
+
+export interface ContactSettingsResponse extends ContactSettingsPayload {
+  configured: boolean;
+}
+
+export async function getDepositContactSettings(token: string) {
+  const res = await fetch(apiUrl('/contact-settings/deposit'), {
+    headers: headers(token),
+  });
+  if (!res.ok) throw new Error('Failed to load contact settings');
+  return res.json() as Promise<ContactSettingsResponse>;
+}
+
+export async function createDepositContactSettings(
+  token: string,
+  payload: ContactSettingsPayload,
+) {
+  const res = await fetch(apiUrl('/contact-settings/deposit'), {
+    method: 'POST',
+    headers: headers(token),
+    body: JSON.stringify(payload),
+  });
+  if (!res.ok) throw new Error('Failed to create contact settings');
+  return res.json() as Promise<ContactSettingsResponse>;
+}
+
+export async function updateDepositContactSettings(
+  token: string,
+  payload: ContactSettingsPayload,
+) {
+  const res = await fetch(apiUrl('/contact-settings/deposit'), {
+    method: 'PUT',
+    headers: headers(token),
+    body: JSON.stringify(payload),
+  });
+  if (!res.ok) throw new Error('Failed to update contact settings');
+  return res.json() as Promise<ContactSettingsResponse>;
+}
+
+export async function deleteDepositContactSettings(token: string) {
+  const res = await fetch(apiUrl('/contact-settings/deposit'), {
+    method: 'DELETE',
+    headers: headers(token),
+  });
+  if (!res.ok) throw new Error('Failed to delete contact settings');
+}
+
 export type DocumentWorkflow =
   | 'offer'
   | 'property_application'

--- a/dashboard/src/auth.tsx
+++ b/dashboard/src/auth.tsx
@@ -13,7 +13,7 @@ interface AuthContextType {
   logout: () => void;
 }
 
-const AuthContext = React.createContext<AuthContextType>({
+export const AuthContext = React.createContext<AuthContextType>({
   auth: null,
   login: () => {},
   logout: () => {},

--- a/dashboard/src/pages/ContactSettings.tsx
+++ b/dashboard/src/pages/ContactSettings.tsx
@@ -1,0 +1,176 @@
+import React from 'react';
+import {
+  ContactSettingsPayload,
+  ContactSettingsResponse,
+  createDepositContactSettings,
+  deleteDepositContactSettings,
+  getDepositContactSettings,
+  updateDepositContactSettings,
+} from '../api';
+import { useAuth } from '../auth';
+
+const parseRecipients = (value: string): string[] => {
+  const seen = new Set<string>();
+  return value
+    .split(/[,\n]+/)
+    .map((part) => part.trim())
+    .filter((part) => {
+      if (!part) return false;
+      const key = part.toLowerCase();
+      if (seen.has(key)) return false;
+      seen.add(key);
+      return true;
+    });
+};
+
+const formatRecipients = (recipients: string[]) => recipients.join('\n');
+
+const ContactSettingsPage: React.FC = () => {
+  const { auth } = useAuth();
+  const token = auth?.token;
+  const [configured, setConfigured] = React.useState(false);
+  const [recipientsText, setRecipientsText] = React.useState('');
+  const [error, setError] = React.useState<string | null>(null);
+  const [success, setSuccess] = React.useState<string | null>(null);
+  const [isBusy, setIsBusy] = React.useState(false);
+
+  const loadSettings = React.useCallback(async () => {
+    if (!token) {
+      setConfigured(false);
+      setRecipientsText('');
+      return;
+    }
+    try {
+      setIsBusy(true);
+      const response = await getDepositContactSettings(token);
+      setConfigured(response.configured);
+      setRecipientsText(formatRecipients(response.recipients));
+      setError(null);
+    } catch (err) {
+      console.error(err);
+      setError('Unable to load contact settings.');
+    } finally {
+      setIsBusy(false);
+    }
+  }, [token]);
+
+  React.useEffect(() => {
+    void loadSettings();
+  }, [loadSettings]);
+
+  const saveSettings = async (payload: ContactSettingsPayload) => {
+    if (!token) return;
+    try {
+      setIsBusy(true);
+      const request = configured
+        ? updateDepositContactSettings
+        : createDepositContactSettings;
+      const response: ContactSettingsResponse = await request(token, payload);
+      setConfigured(response.configured);
+      setRecipientsText(formatRecipients(response.recipients));
+      setSuccess('Contact settings saved.');
+      setError(null);
+    } catch (err) {
+      console.error(err);
+      setError('Unable to save contact settings.');
+      setSuccess(null);
+    } finally {
+      setIsBusy(false);
+    }
+  };
+
+  const handleSubmit = async (event: React.FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    const recipients = parseRecipients(recipientsText);
+    await saveSettings({ recipients });
+  };
+
+  const handleClear = async () => {
+    if (!token) return;
+    try {
+      setIsBusy(true);
+      await deleteDepositContactSettings(token);
+      setSuccess('Custom recipients cleared.');
+      setError(null);
+      await loadSettings();
+    } catch (err) {
+      console.error(err);
+      setError('Unable to clear contact settings.');
+      setSuccess(null);
+    } finally {
+      setIsBusy(false);
+    }
+  };
+
+  return (
+    <div>
+      <h2>Admin Settings</h2>
+
+      <section className="form-section">
+        <div className="form-card">
+          <h3 className="form-title">Deposit Notifications</h3>
+          <p>
+            Configure the email addresses that should receive deposit submission
+            notifications.
+          </p>
+          {configured ? (
+            <p className="form-message form-message--info">
+              Custom recipients are in use. Update the list below to change who will
+              receive emails.
+            </p>
+          ) : (
+            <p className="form-message form-message--info">
+              No custom recipients are configured. The system will use the default
+              addresses from the environment settings until you save changes.
+            </p>
+          )}
+          {error && (
+            <p className="form-message form-message--error" role="alert">
+              {error}
+            </p>
+          )}
+          {success && (
+            <p className="form-message form-message--success" role="status">
+              {success}
+            </p>
+          )}
+        </div>
+      </section>
+
+      <section className="form-section">
+        <form className="form-card" onSubmit={handleSubmit}>
+          <div className="form-fields">
+            <label htmlFor="deposit-recipients">
+              Recipient Emails
+              <textarea
+                id="deposit-recipients"
+                value={recipientsText}
+                onChange={(event) => setRecipientsText(event.target.value)}
+                rows={6}
+                placeholder="one@example.com\nother@example.com"
+                aria-describedby="deposit-recipients-help"
+              />
+            </label>
+            <small id="deposit-recipients-help">
+              Enter one email address per line or separate them with commas.
+            </small>
+          </div>
+          <div className="form-actions">
+            <button type="submit" disabled={isBusy}>
+              Save Changes
+            </button>
+            <button
+              type="button"
+              onClick={handleClear}
+              disabled={isBusy || (!configured && !recipientsText.trim())}
+            >
+              Clear Custom Recipients
+            </button>
+          </div>
+        </form>
+      </section>
+    </div>
+  );
+};
+
+export default ContactSettingsPage;

--- a/dashboard/src/pages/__tests__/ContactSettings.test.tsx
+++ b/dashboard/src/pages/__tests__/ContactSettings.test.tsx
@@ -1,0 +1,83 @@
+import React from 'react';
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import ContactSettingsPage from '../ContactSettings';
+import { AuthContext } from '../../auth';
+
+const authContextValue = {
+  auth: { token: 'test-token', role: 'admin', username: 'admin' },
+  login: vi.fn(),
+  logout: vi.fn(),
+};
+
+const renderWithAuth = (ui: React.ReactElement) =>
+  render(<AuthContext.Provider value={authContextValue}>{ui}</AuthContext.Provider>);
+
+describe('ContactSettingsPage', () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('allows administrators to create custom recipients', async () => {
+    const fetchMock = vi
+      .spyOn(global, 'fetch')
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({ recipients: ['deposits@example.com'], configured: false }),
+      } as Response)
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({ recipients: ['custom@example.com'], configured: true }),
+      } as Response);
+
+    const user = userEvent.setup();
+    renderWithAuth(<ContactSettingsPage />);
+
+    const textarea = await screen.findByLabelText(/Recipient Emails/i);
+    expect(textarea).toHaveValue('deposits@example.com');
+
+    await user.clear(textarea);
+    await user.type(textarea, 'custom@example.com');
+    await user.click(screen.getByRole('button', { name: /Save Changes/i }));
+
+    await waitFor(() => expect(fetchMock).toHaveBeenCalledTimes(2));
+    const lastCall = fetchMock.mock.calls[1];
+    expect(lastCall?.[0]).toContain('/contact-settings/deposit');
+    expect((lastCall?.[1] as RequestInit)?.method).toBe('POST');
+    expect((lastCall?.[1] as RequestInit)?.body).toBe(
+      JSON.stringify({ recipients: ['custom@example.com'] }),
+    );
+
+    await screen.findByText(/Contact settings saved/i);
+    expect(textarea).toHaveValue('custom@example.com');
+  });
+
+  it('clears custom recipients and falls back to defaults', async () => {
+    const fetchMock = vi
+      .spyOn(global, 'fetch')
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({ recipients: ['custom@example.com'], configured: true }),
+      } as Response)
+      .mockResolvedValueOnce({ ok: true } as Response)
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({ recipients: ['deposits@example.com'], configured: false }),
+      } as Response);
+
+    const user = userEvent.setup();
+    renderWithAuth(<ContactSettingsPage />);
+
+    const textarea = await screen.findByLabelText(/Recipient Emails/i);
+    expect(textarea).toHaveValue('custom@example.com');
+
+    await user.click(screen.getByRole('button', { name: /Clear Custom Recipients/i }));
+
+    await waitFor(() => expect(fetchMock).toHaveBeenCalledTimes(3));
+    const deleteCall = fetchMock.mock.calls[1];
+    expect((deleteCall?.[1] as RequestInit)?.method).toBe('DELETE');
+
+    await screen.findByText(/Custom recipients cleared/i);
+    expect(textarea).toHaveValue('deposits@example.com');
+  });
+});

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,7 @@
 fastapi
 uvicorn
 pydantic
+email-validator
 pytest
 httpx
 sqlalchemy

--- a/tests/test_contact_settings_api.py
+++ b/tests/test_contact_settings_api.py
@@ -1,0 +1,75 @@
+import pytest
+
+from tests.test_submission_email import setup_agents
+
+
+@pytest.mark.parametrize(
+    "initial_env",
+    ["deposits@example.com"],
+    ids=["default"],
+)
+def test_contact_settings_crud_flow(client, initial_env):
+    headers = setup_agents(client)
+
+    response = client.get("/contact-settings/deposit", headers=headers["admin"])
+    assert response.status_code == 200
+    data = response.json()
+    assert data["configured"] is False
+    assert data["recipients"] == [initial_env]
+
+    create_payload = {
+        "recipients": [
+            "primary@example.com",
+            "secondary@example.com ",
+            "PRIMARY@example.com",
+        ]
+    }
+    create_response = client.post(
+        "/contact-settings/deposit",
+        json=create_payload,
+        headers=headers["admin"],
+    )
+    assert create_response.status_code == 200
+    created = create_response.json()
+    assert created["configured"] is True
+    assert created["recipients"] == [
+        "primary@example.com",
+        "secondary@example.com",
+    ]
+
+    conflict_response = client.post(
+        "/contact-settings/deposit",
+        json=create_payload,
+        headers=headers["admin"],
+    )
+    assert conflict_response.status_code == 409
+
+    update_payload = {"recipients": ["updated@example.com"]}
+    update_response = client.put(
+        "/contact-settings/deposit",
+        json=update_payload,
+        headers=headers["admin"],
+    )
+    assert update_response.status_code == 200
+    updated = update_response.json()
+    assert updated["recipients"] == ["updated@example.com"]
+    assert updated["configured"] is True
+
+    after_update = client.get("/contact-settings/deposit", headers=headers["admin"])
+    assert after_update.status_code == 200
+    assert after_update.json()["recipients"] == ["updated@example.com"]
+
+    delete_response = client.delete(
+        "/contact-settings/deposit",
+        headers=headers["admin"],
+    )
+    assert delete_response.status_code == 204
+
+    fallback_response = client.get(
+        "/contact-settings/deposit",
+        headers=headers["admin"],
+    )
+    assert fallback_response.status_code == 200
+    fallback = fallback_response.json()
+    assert fallback["configured"] is False
+    assert fallback["recipients"] == [initial_env]

--- a/tests/test_submission_email.py
+++ b/tests/test_submission_email.py
@@ -52,6 +52,12 @@ def setup_agents(client):
 
 def test_offer_submission_dispatches_email(client, mailer_stub):
     headers = setup_agents(client)
+    resp = client.post(
+        "/contact-settings/deposit",
+        json={"recipients": ["deposits-team@example.com"]},
+        headers=headers["admin"],
+    )
+    assert resp.status_code == 200
     requirement = client.post(
         "/document-requirements",
         json={"name": "Proof of funds", "applies_to": "offer"},
@@ -88,6 +94,7 @@ def test_offer_submission_dispatches_email(client, mailer_stub):
     assert len(request.attachments) == 2
     filenames = {attachment.filename for attachment in request.attachments}
     assert filenames == {"offer.pdf", "proof.pdf"}
+    assert list(request.to) == ["deposits-team@example.com"]
 
 
 def test_account_opening_upload_dispatches_email(client, mailer_stub):


### PR DESCRIPTION
## Summary
- add persistent contact settings storage and API endpoints so admins can manage deposit notification recipients
- update submission email logic to honor stored recipients and cover the backend with new tests
- build an admin UI for deposit contact settings and add frontend tests for the new workflow

## Testing
- pytest
- npm test


------
https://chatgpt.com/codex/tasks/task_e_68cef6bb13d0832c9226d72e8f3bec37