### PR TITLE
Add customer profile management and inbox processing

### DIFF
--- a/app/inbox.py
+++ b/app/inbox.py
@@ -1,0 +1,154 @@
+"""Inbound email processing for customer profiles."""
+
+from __future__ import annotations
+
+import logging
+import re
+from dataclasses import dataclass
+from datetime import datetime
+from typing import Iterable, Protocol, Sequence
+
+from .models import CustomerProfile
+from .repositories import Repositories
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass
+class InboundEmail:
+    """Representation of an inbound email message."""
+
+    message_id: str
+    subject: str
+    body: str
+    received_at: datetime
+
+
+class InboxClient(Protocol):
+    """Minimal protocol for retrieving messages from an email inbox."""
+
+    def fetch_unread(self) -> Sequence[InboundEmail]:
+        """Return unread messages that should be processed."""
+
+    def mark_processed(self, message_id: str) -> None:
+        """Mark a message as processed to prevent re-processing."""
+
+
+ACCOUNT_NUMBER_PATTERN = re.compile(r"account\s*number[:\s]*([A-Z0-9-]+)", re.IGNORECASE)
+
+
+def extract_account_number(body: str) -> str | None:
+    """Attempt to extract an account number from an email body."""
+
+    if not body:
+        return None
+    match = ACCOUNT_NUMBER_PATTERN.search(body)
+    if match:
+        return match.group(1).strip()
+    fallback = re.search(r"\b([0-9]{6,})\b", body)
+    if fallback:
+        return fallback.group(1)
+    return None
+
+
+class InboundEmailProcessor:
+    """Process inbound messages and maintain customer profiles."""
+
+    def __init__(self, repos: Repositories, client: InboxClient):
+        self.repos = repos
+        self.client = client
+
+    def process_new_messages(self) -> int:
+        """Poll the inbox, creating or updating customer profiles."""
+
+        messages = self.client.fetch_unread()
+        processed = 0
+        for message in messages:
+            account_number = extract_account_number(message.body)
+            if not account_number:
+                logger.debug("Skipping message %s without account number", message.message_id)
+                self.client.mark_processed(message.message_id)
+                continue
+            logger.info(
+                "Processing inbound message %s for account %s",
+                message.message_id,
+                account_number,
+            )
+            self._create_or_update_profile(account_number, message.received_at)
+            self.client.mark_processed(message.message_id)
+            processed += 1
+        return processed
+
+    def _create_or_update_profile(self, account_number: str, received_at: datetime) -> CustomerProfile:
+        account = self._find_account(account_number)
+        loan_ids: list[int] = []
+        agreement_ids: list[int] = []
+        realtor = None
+        if account:
+            loan_ids = self._loan_ids_for_account(account.id)
+            agreement_ids = self._agreement_ids_for_loans(loan_ids)
+            realtor = account.realtor
+
+        existing = self.repos.customer_profiles.get(account_number)
+        now = datetime.utcnow()
+        if existing:
+            updates = {
+                "last_inbound_email_at": received_at,
+                "updated_at": now,
+            }
+            if account:
+                updates.update(
+                    {
+                        "account_opening_id": account.id,
+                        "realtor": realtor,
+                        "loan_application_ids": loan_ids,
+                        "agreement_ids": agreement_ids,
+                    }
+                )
+            profile = existing.model_copy(update=updates)
+        else:
+            profile = CustomerProfile(
+                id=account_number,
+                account_number=account_number,
+                account_opening_id=account.id if account else None,
+                realtor=realtor,
+                loan_application_ids=loan_ids,
+                agreement_ids=agreement_ids,
+                last_inbound_email_at=received_at,
+                deletion_requested=False,
+                deletion_requested_at=None,
+                deletion_requested_by=None,
+                deletion_approved_at=None,
+                deletion_approved_by=None,
+                created_at=now,
+                updated_at=now,
+            )
+        self.repos.customer_profiles.add(profile)
+        return profile
+
+    def _find_account(self, account_number: str):
+        for account in self.repos.account_openings.list():
+            if account.account_number == account_number:
+                return account
+        return None
+
+    def _loan_ids_for_account(self, account_id: int) -> list[int]:
+        return sorted(
+            {
+                loan.id
+                for loan in self.repos.loan_applications.list()
+                if loan.account_id == account_id
+            }
+        )
+
+    def _agreement_ids_for_loans(self, loan_ids: Iterable[int]) -> list[int]:
+        loan_id_set = set(loan_ids)
+        if not loan_id_set:
+            return []
+        return sorted(
+            {
+                agreement.id
+                for agreement in self.repos.agreements.list()
+                if agreement.loan_application_id in loan_id_set
+            }
+        )

--- a/app/main.py
+++ b/app/main.py
@@ -72,6 +72,7 @@ from .models import (
     ImportedLoanAccount,
     ContactSettings,
     ContactSettingsResponse,
+    CustomerProfile,
 )
 
 logger = logging.getLogger(__name__)
@@ -1126,6 +1127,106 @@ def _derive_unique_slug(
         suffix += 1
 
 
+def _loan_ids_for_account(account_id: int, repos: Repositories) -> List[int]:
+    return sorted(
+        {
+            loan.id
+            for loan in repos.loan_applications.list()
+            if loan.account_id == account_id
+        }
+    )
+
+
+def _agreement_ids_for_loans(loan_ids: List[int], repos: Repositories) -> List[int]:
+    loan_id_set = set(loan_ids)
+    if not loan_id_set:
+        return []
+    return sorted(
+        {
+            agreement.id
+            for agreement in repos.agreements.list()
+            if agreement.loan_application_id in loan_id_set
+        }
+    )
+
+
+def _find_account_opening_by_number(
+    account_number: str, repos: Repositories
+) -> AccountOpening | None:
+    for opening in repos.account_openings.list():
+        if opening.account_number == account_number:
+            return opening
+    return None
+
+
+def _sync_profile_from_account(
+    account: AccountOpening, repos: Repositories
+) -> CustomerProfile | None:
+    if not account.account_number:
+        return None
+    loan_ids = _loan_ids_for_account(account.id, repos)
+    agreement_ids = _agreement_ids_for_loans(loan_ids, repos)
+    existing = repos.customer_profiles.get(account.account_number)
+    now = datetime.utcnow()
+    if existing:
+        profile = existing.model_copy(
+            update={
+                "account_opening_id": account.id,
+                "realtor": account.realtor,
+                "loan_application_ids": loan_ids,
+                "agreement_ids": agreement_ids,
+                "account_number": account.account_number,
+                "updated_at": now,
+            }
+        )
+    else:
+        profile = CustomerProfile(
+            id=account.account_number,
+            account_number=account.account_number,
+            account_opening_id=account.id,
+            realtor=account.realtor,
+            loan_application_ids=loan_ids,
+            agreement_ids=agreement_ids,
+            last_inbound_email_at=None,
+            deletion_requested=False,
+            deletion_requested_at=None,
+            deletion_requested_by=None,
+            deletion_approved_at=None,
+            deletion_approved_by=None,
+            created_at=now,
+            updated_at=now,
+        )
+    repos.customer_profiles.add(profile)
+    return profile
+
+
+def _touch_profile(
+    profile: CustomerProfile, repos: Repositories, **updates: Any
+) -> CustomerProfile:
+    payload = dict(updates)
+    payload["updated_at"] = datetime.utcnow()
+    new_profile = profile.model_copy(update=payload)
+    repos.customer_profiles.add(new_profile)
+    return new_profile
+
+
+def _get_profile_or_404(
+    repos: Repositories, account_number: str
+) -> CustomerProfile:
+    profile = repos.customer_profiles.get(account_number)
+    if not profile:
+        raise HTTPException(status_code=404, detail="Customer profile not found")
+    return profile
+
+
+def _require_profile_access(profile: CustomerProfile, agent: Agent) -> None:
+    if agent.role in (AgentRole.ADMIN, AgentRole.MANAGER):
+        return
+    if agent.role == AgentRole.AGENT and profile.realtor == agent.username:
+        return
+    raise HTTPException(status_code=403, detail="Not authorized to access profile")
+
+
 async def _encode_upload_file(
     upload: UploadFile | StarletteUploadFile,
 ) -> UploadedFile:
@@ -1581,6 +1682,7 @@ def open_account(
     request.deposit_threshold = details.deposit_threshold
     request.status = SubmissionStatus.IN_PROGRESS
     repos.account_openings.add(request)
+    _sync_profile_from_account(request, repos)
     return request
 
 
@@ -1688,6 +1790,68 @@ def record_account_deposit(
     return request
 
 
+# ---- Customer profile endpoints ----
+
+
+@app.get("/profiles/{account_number}", response_model=CustomerProfile)
+def get_customer_profile(
+    account_number: str,
+    agent: Agent = Depends(get_current_agent),
+    repos: Repositories = Depends(get_repositories),
+):
+    profile = _get_profile_or_404(repos, account_number)
+    account = _find_account_opening_by_number(account_number, repos)
+    if account:
+        refreshed = _sync_profile_from_account(account, repos)
+        if refreshed:
+            profile = refreshed
+    _require_profile_access(profile, agent)
+    return profile
+
+
+@app.post("/profiles/{account_number}/request-deletion", response_model=CustomerProfile)
+def request_customer_profile_deletion(
+    account_number: str,
+    agent: Agent = Depends(get_current_agent),
+    repos: Repositories = Depends(get_repositories),
+):
+    profile = _get_profile_or_404(repos, account_number)
+    _require_profile_access(profile, agent)
+    if agent.role != AgentRole.AGENT:
+        raise HTTPException(status_code=403, detail="Only agents can request deletion")
+    updated = _touch_profile(
+        profile,
+        repos,
+        deletion_requested=True,
+        deletion_requested_at=datetime.utcnow(),
+        deletion_requested_by=agent.username,
+        deletion_approved_at=None,
+        deletion_approved_by=None,
+    )
+    repos.notifications.append(
+        f"Deletion requested for profile {account_number} by {agent.username}"
+    )
+    return updated
+
+
+@app.delete("/profiles/{account_number}", status_code=204)
+def delete_customer_profile(
+    account_number: str,
+    agent: Agent = Depends(require_management),
+    repos: Repositories = Depends(get_repositories),
+):
+    profile = repos.customer_profiles.get(account_number)
+    if not profile:
+        raise HTTPException(status_code=404, detail="Customer profile not found")
+    if not profile.deletion_requested:
+        raise HTTPException(status_code=400, detail="No pending deletion request")
+    repos.customer_profiles.delete(account_number)
+    repos.notifications.append(
+        f"Customer profile {account_number} deleted by {agent.username}"
+    )
+    return Response(status_code=204)
+
+
 @app.post("/loan-applications", response_model=LoanApplication)
 def submit_loan_application(
     application: LoanApplication,
@@ -1723,6 +1887,7 @@ def submit_loan_application(
         }
     )
     repos.loan_applications.add(sanitized_application)
+    _sync_profile_from_account(account, repos)
     repos.notifications.append(
         f"Loan application {sanitized_application.id} submitted by {sanitized_application.realtor}"
     )
@@ -2019,6 +2184,9 @@ def create_agreement(
     loan = repos.loan_applications.get(data.loan_application_id)
     if not loan:
         raise HTTPException(status_code=404, detail="Loan application not found")
+    account = repos.account_openings.get(loan.account_id)
+    if not account:
+        raise HTTPException(status_code=404, detail="Account opening not found")
     stand = repos.stands.get(data.property_id)
     if not stand:
         raise HTTPException(status_code=404, detail="Property not found")
@@ -2035,6 +2203,7 @@ def create_agreement(
         status=AgreementStatus.DRAFT,
     )
     repos.agreements.add(agreement)
+    _sync_profile_from_account(account, repos)
     return agreement
 
 

--- a/app/models.py
+++ b/app/models.py
@@ -279,3 +279,20 @@ class ContactSettings(BaseModel):
 
 class ContactSettingsResponse(ContactSettings):
     configured: bool = True
+
+
+class CustomerProfile(BaseModel):
+    id: str
+    account_number: str
+    account_opening_id: Optional[int] = None
+    realtor: Optional[str] = None
+    loan_application_ids: List[int] = Field(default_factory=list)
+    agreement_ids: List[int] = Field(default_factory=list)
+    last_inbound_email_at: Optional[datetime] = None
+    deletion_requested: bool = False
+    deletion_requested_at: Optional[datetime] = None
+    deletion_requested_by: Optional[str] = None
+    deletion_approved_at: Optional[datetime] = None
+    deletion_approved_by: Optional[str] = None
+    created_at: datetime
+    updated_at: datetime

--- a/app/repositories.py
+++ b/app/repositories.py
@@ -103,6 +103,7 @@ from .models import (
     DocumentRequirement,
     ImportedDepositAccount,
     ImportedLoanAccount,
+    CustomerProfile,
 )
 
 
@@ -121,6 +122,7 @@ class Repositories:
         self.notifications = ListRepository(session, 'notifications')
         self.agreements = Repository(session, 'agreements', Agreement)
         self.customer_loan_accounts = SimpleRepository(session, 'customer_loan_accounts')
+        self.customer_profiles = Repository(session, 'customer_profiles', CustomerProfile)
         self.audit_log = ListRepository(session, 'audit_log')
         self.counters = SimpleRepository(session, 'counters')
         self.document_requirements = Repository(

--- a/dashboard/src/App.tsx
+++ b/dashboard/src/App.tsx
@@ -21,6 +21,8 @@ import DocumentRequirementsPage from './pages/DocumentRequirements';
 import ImportedDeposits from './pages/ImportedDeposits';
 import ImportedLoanAccounts from './pages/ImportedLoanAccounts';
 import ContactSettingsPage from './pages/ContactSettings';
+import CustomerProfileAgent from './pages/CustomerProfileAgent';
+import CustomerProfilesManage from './pages/CustomerProfilesManage';
 import { ProtectedRoute, useAuth } from './auth';
 
 const App: React.FC = () => {
@@ -36,6 +38,7 @@ const App: React.FC = () => {
           { to: '/contact-settings', label: 'Contact Settings' },
           { to: '/agents', label: 'Agents' },
           { to: '/account-openings', label: 'Account Openings' },
+          { to: '/customer-profiles/manage', label: 'Customer Profiles' },
           { to: '/loan-applications', label: 'Loan Applications' },
           { to: '/loan-approvals', label: 'Loan Approvals' },
           { to: '/deposits', label: 'Deposits' },
@@ -47,6 +50,7 @@ const App: React.FC = () => {
         ? [
             { to: '/manager-dashboard', label: 'Dashboard' },
             { to: '/account-openings', label: 'Account Openings' },
+            { to: '/customer-profiles/manage', label: 'Customer Profiles' },
             { to: '/imported-deposits', label: 'Imported Deposits' },
             { to: '/imported-loan-accounts', label: 'Imported Loan Accounts' },
           ]
@@ -56,6 +60,7 @@ const App: React.FC = () => {
             ? [
                 { to: '/dashboard', label: 'Dashboard' },
                 { to: '/submit', label: 'New Submission' },
+                { to: '/customer-profiles', label: 'Customer Profiles' },
               ]
             : []
     : [];
@@ -104,6 +109,14 @@ const App: React.FC = () => {
               element={
                 <ProtectedRoute roles={["admin"]}>
                   <AgentsPage />
+                </ProtectedRoute>
+              }
+            />
+            <Route
+              path="/customer-profiles/manage"
+              element={
+                <ProtectedRoute roles={["admin", "manager"]}>
+                  <CustomerProfilesManage />
                 </ProtectedRoute>
               }
             />
@@ -240,6 +253,14 @@ const App: React.FC = () => {
               element={
                 <ProtectedRoute roles={["agent"]}>
                   <MultiStepForm />
+                </ProtectedRoute>
+              }
+            />
+            <Route
+              path="/customer-profiles"
+              element={
+                <ProtectedRoute roles={["agent"]}>
+                  <CustomerProfileAgent />
                 </ProtectedRoute>
               }
             />

--- a/dashboard/src/api.ts
+++ b/dashboard/src/api.ts
@@ -653,3 +653,47 @@ export async function decideLoan(
   if (!res.ok) throw new Error('Failed to decide loan');
   return res.json();
 }
+
+export interface CustomerProfile {
+  account_number: string;
+  account_opening_id?: number | null;
+  realtor?: string | null;
+  loan_application_ids: number[];
+  agreement_ids: number[];
+  last_inbound_email_at?: string | null;
+  deletion_requested: boolean;
+  deletion_requested_at?: string | null;
+  deletion_requested_by?: string | null;
+  deletion_approved_at?: string | null;
+  deletion_approved_by?: string | null;
+  created_at: string;
+  updated_at: string;
+}
+
+const profileUrl = (accountNumber: string) =>
+  `/profiles/${encodeURIComponent(accountNumber)}`;
+
+export async function getCustomerProfile(token: string, accountNumber: string) {
+  const res = await fetch(apiUrl(profileUrl(accountNumber)), {
+    headers: headers(token),
+  });
+  if (!res.ok) throw new Error('Failed to load profile');
+  return res.json() as Promise<CustomerProfile>;
+}
+
+export async function requestProfileDeletion(token: string, accountNumber: string) {
+  const res = await fetch(apiUrl(`${profileUrl(accountNumber)}/request-deletion`), {
+    method: 'POST',
+    headers: headers(token),
+  });
+  if (!res.ok) throw new Error('Failed to request deletion');
+  return res.json() as Promise<CustomerProfile>;
+}
+
+export async function deleteCustomerProfile(token: string, accountNumber: string) {
+  const res = await fetch(apiUrl(profileUrl(accountNumber)), {
+    method: 'DELETE',
+    headers: headers(token),
+  });
+  if (!res.ok) throw new Error('Failed to delete profile');
+}

--- a/dashboard/src/pages/CustomerProfileAgent.tsx
+++ b/dashboard/src/pages/CustomerProfileAgent.tsx
@@ -1,0 +1,108 @@
+import React from 'react';
+import { useAuth } from '../auth';
+import {
+  CustomerProfile,
+  getCustomerProfile,
+  requestProfileDeletion,
+} from '../api';
+
+const CustomerProfileAgent: React.FC = () => {
+  const { auth } = useAuth();
+  const [accountNumber, setAccountNumber] = React.useState('');
+  const [profile, setProfile] = React.useState<CustomerProfile | null>(null);
+  const [status, setStatus] = React.useState('');
+  const [error, setError] = React.useState('');
+
+  const handleLookup: React.FormEventHandler<HTMLFormElement> = async (event) => {
+    event.preventDefault();
+    if (!auth) return;
+    const trimmed = accountNumber.trim();
+    if (!trimmed) {
+      setError('Enter an account number to continue.');
+      return;
+    }
+    try {
+      const data = await getCustomerProfile(auth.token, trimmed);
+      setProfile(data);
+      setStatus('Profile loaded successfully.');
+      setError('');
+    } catch (err) {
+      setProfile(null);
+      setStatus('');
+      setError('Unable to find a profile for that account number.');
+    }
+  };
+
+  const handleRequestDeletion = async () => {
+    if (!auth || !profile) return;
+    try {
+      const data = await requestProfileDeletion(auth.token, profile.account_number);
+      setProfile(data);
+      setStatus('Deletion request submitted for review.');
+      setError('');
+    } catch (err) {
+      setError('Unable to request deletion at this time.');
+      setStatus('');
+    }
+  };
+
+  return (
+    <div>
+      <h2>Customer Profile</h2>
+      <form onSubmit={handleLookup} className="form" aria-label="Profile lookup">
+        <label htmlFor="accountNumber">Account Number</label>
+        <input
+          id="accountNumber"
+          type="text"
+          value={accountNumber}
+          onChange={(event) => setAccountNumber(event.target.value)}
+        />
+        <button type="submit">Lookup</button>
+      </form>
+      {status && <p>{status}</p>}
+      {error && (
+        <p role="alert" className="error">
+          {error}
+        </p>
+      )}
+      {profile && (
+        <section aria-live="polite">
+          <h3>Profile Summary</h3>
+          <dl>
+            <dt>Account Number</dt>
+            <dd>{profile.account_number}</dd>
+            <dt>Account Opening ID</dt>
+            <dd>{profile.account_opening_id ?? 'Not linked'}</dd>
+            <dt>Realtor</dt>
+            <dd>{profile.realtor ?? 'Unknown'}</dd>
+            <dt>Loan Applications</dt>
+            <dd>{profile.loan_application_ids.length ? profile.loan_application_ids.join(', ') : 'None'}</dd>
+            <dt>Agreements</dt>
+            <dd>{profile.agreement_ids.length ? profile.agreement_ids.join(', ') : 'None'}</dd>
+            <dt>Last Inbound Email</dt>
+            <dd>{profile.last_inbound_email_at ?? 'No inbound messages'}</dd>
+            <dt>Deletion Requested</dt>
+            <dd>{profile.deletion_requested ? 'Yes' : 'No'}</dd>
+            {profile.deletion_requested && (
+              <>
+                <dt>Requested By</dt>
+                <dd>{profile.deletion_requested_by ?? 'Unknown'}</dd>
+                <dt>Requested At</dt>
+                <dd>{profile.deletion_requested_at ?? 'Unknown'}</dd>
+              </>
+            )}
+          </dl>
+          <button
+            type="button"
+            onClick={handleRequestDeletion}
+            disabled={profile.deletion_requested}
+          >
+            {profile.deletion_requested ? 'Deletion Requested' : 'Request Deletion'}
+          </button>
+        </section>
+      )}
+    </div>
+  );
+};
+
+export default CustomerProfileAgent;

--- a/dashboard/src/pages/CustomerProfilesManage.tsx
+++ b/dashboard/src/pages/CustomerProfilesManage.tsx
@@ -1,0 +1,108 @@
+import React from 'react';
+import { useAuth } from '../auth';
+import {
+  CustomerProfile,
+  deleteCustomerProfile,
+  getCustomerProfile,
+} from '../api';
+
+const CustomerProfilesManage: React.FC = () => {
+  const { auth } = useAuth();
+  const [accountNumber, setAccountNumber] = React.useState('');
+  const [profile, setProfile] = React.useState<CustomerProfile | null>(null);
+  const [status, setStatus] = React.useState('');
+  const [error, setError] = React.useState('');
+
+  const handleLookup: React.FormEventHandler<HTMLFormElement> = async (event) => {
+    event.preventDefault();
+    if (!auth) return;
+    const trimmed = accountNumber.trim();
+    if (!trimmed) {
+      setError('Enter an account number to continue.');
+      return;
+    }
+    try {
+      const data = await getCustomerProfile(auth.token, trimmed);
+      setProfile(data);
+      setStatus('Profile loaded successfully.');
+      setError('');
+    } catch (err) {
+      setProfile(null);
+      setStatus('');
+      setError('Unable to find a profile for that account number.');
+    }
+  };
+
+  const handleDelete = async () => {
+    if (!auth || !profile) return;
+    try {
+      await deleteCustomerProfile(auth.token, profile.account_number);
+      setStatus('Profile deleted.');
+      setProfile(null);
+      setError('');
+    } catch (err) {
+      setError('Unable to delete profile. Ensure a deletion request is on file.');
+      setStatus('');
+    }
+  };
+
+  return (
+    <div>
+      <h2>Customer Profiles</h2>
+      <form onSubmit={handleLookup} className="form" aria-label="Profile lookup">
+        <label htmlFor="manageAccountNumber">Account Number</label>
+        <input
+          id="manageAccountNumber"
+          type="text"
+          value={accountNumber}
+          onChange={(event) => setAccountNumber(event.target.value)}
+        />
+        <button type="submit">Lookup</button>
+      </form>
+      {status && <p>{status}</p>}
+      {error && (
+        <p role="alert" className="error">
+          {error}
+        </p>
+      )}
+      {profile && (
+        <section aria-live="polite">
+          <h3>Profile Summary</h3>
+          <dl>
+            <dt>Account Number</dt>
+            <dd>{profile.account_number}</dd>
+            <dt>Account Opening ID</dt>
+            <dd>{profile.account_opening_id ?? 'Not linked'}</dd>
+            <dt>Realtor</dt>
+            <dd>{profile.realtor ?? 'Unknown'}</dd>
+            <dt>Loan Applications</dt>
+            <dd>{profile.loan_application_ids.length ? profile.loan_application_ids.join(', ') : 'None'}</dd>
+            <dt>Agreements</dt>
+            <dd>{profile.agreement_ids.length ? profile.agreement_ids.join(', ') : 'None'}</dd>
+            <dt>Last Inbound Email</dt>
+            <dd>{profile.last_inbound_email_at ?? 'No inbound messages'}</dd>
+            <dt>Deletion Requested</dt>
+            <dd>{profile.deletion_requested ? 'Yes' : 'No'}</dd>
+            {profile.deletion_requested && (
+              <>
+                <dt>Requested By</dt>
+                <dd>{profile.deletion_requested_by ?? 'Unknown'}</dd>
+                <dt>Requested At</dt>
+                <dd>{profile.deletion_requested_at ?? 'Unknown'}</dd>
+              </>
+            )}
+          </dl>
+          <button
+            type="button"
+            onClick={handleDelete}
+            disabled={!profile.deletion_requested}
+          >
+            Delete Profile
+          </button>
+        </section>
+      )}
+    </div>
+  );
+};
+
+export default CustomerProfilesManage;

--- a/tests/test_customer_profiles.py
+++ b/tests/test_customer_profiles.py
@@ -1,0 +1,228 @@
+from datetime import datetime
+
+from app.database import drop_db, init_db, SessionLocal
+from app.inbox import InboundEmail, InboundEmailProcessor
+from app.models import (
+    AccountOpening,
+    Agreement,
+    AgreementStatus,
+    LoanApplication,
+    SubmissionStatus,
+)
+from app.repositories import Repositories
+
+
+def setup_function():
+    drop_db()
+    init_db()
+
+
+def _bootstrap_agents(client):
+    admin_password = "AdminPass123"
+    resp = client.post(
+        "/agents",
+        json={"username": "admin", "role": "admin", "password": admin_password},
+        headers={"X-Bootstrap-Token": "bootstrap-token"},
+    )
+    assert resp.status_code == 200
+    admin_token = client.post(
+        "/auth/login", json={"username": "admin", "password": admin_password}
+    ).json()["token"]
+    admin_headers = {"Authorization": f"Bearer {admin_token}"}
+
+    agent_password = "AgentPass123"
+    resp = client.post(
+        "/agents",
+        json={"username": "agentA", "role": "agent", "password": agent_password},
+        headers=admin_headers,
+    )
+    assert resp.status_code == 200
+    agent_token = client.post(
+        "/auth/login", json={"username": "agentA", "password": agent_password}
+    ).json()["token"]
+    agent_headers = {"Authorization": f"Bearer {agent_token}"}
+    return admin_headers, agent_headers
+
+
+def _create_project_and_stand(client, admin_headers):
+    project_resp = client.post(
+        "/projects",
+        json={"name": "Project One", "description": ""},
+        headers=admin_headers,
+    )
+    assert project_resp.status_code == 200
+    project_id = project_resp.json()["id"]
+    stand_resp = client.post(
+        "/stands",
+        json={
+            "project_id": project_id,
+            "name": "Stand 1",
+            "size": 100,
+            "price": 200000,
+        },
+        headers=admin_headers,
+    )
+    assert stand_resp.status_code == 200
+    return stand_resp.json()["id"]
+
+
+def test_profile_workflow_and_deletion(client):
+    admin_headers, agent_headers = _bootstrap_agents(client)
+    stand_id = _create_project_and_stand(client, admin_headers)
+
+    account_payload = {
+        "id": 1,
+        "realtor": "agentA",
+        "details": "Primary account",
+        "required_documents": {},
+    }
+    resp = client.post(
+        "/account-openings", json=account_payload, headers=agent_headers
+    )
+    assert resp.status_code == 200
+
+    resp = client.post(
+        "/account-openings/1/approve", headers=admin_headers
+    )
+    assert resp.status_code == 200
+
+    resp = client.post(
+        "/accounts/deposits/1/open",
+        json={"account_number": "ACCT-123", "deposit_threshold": 1000},
+        headers=admin_headers,
+    )
+    assert resp.status_code == 200
+
+    resp = client.post(
+        "/accounts/deposits/1/deposit",
+        json={"amount": 1000},
+        headers=admin_headers,
+    )
+    assert resp.status_code == 200
+
+    loan_payload = {
+        "id": 77,
+        "realtor": "agentA",
+        "account_id": 1,
+        "property_id": stand_id,
+        "required_documents": {},
+    }
+    resp = client.post(
+        "/loan-applications", json=loan_payload, headers=agent_headers
+    )
+    assert resp.status_code == 200
+
+    resp = client.post(
+        "/agreements",
+        json={"id": 55, "loan_application_id": 77, "property_id": stand_id},
+        headers=admin_headers,
+    )
+    assert resp.status_code == 200
+
+    profile_resp = client.get(
+        "/profiles/ACCT-123",
+        headers=agent_headers,
+    )
+    assert profile_resp.status_code == 200
+    profile = profile_resp.json()
+    assert profile["account_opening_id"] == 1
+    assert profile["loan_application_ids"] == [77]
+    assert profile["agreement_ids"] == [55]
+    assert profile["deletion_requested"] is False
+
+    delete_request = client.post(
+        "/profiles/ACCT-123/request-deletion",
+        headers=agent_headers,
+    )
+    assert delete_request.status_code == 200
+    payload = delete_request.json()
+    assert payload["deletion_requested"] is True
+    assert payload["deletion_requested_by"] == "agentA"
+    assert payload["deletion_requested_at"] is not None
+
+    delete_resp = client.delete(
+        "/profiles/ACCT-123", headers=admin_headers
+    )
+    assert delete_resp.status_code == 204
+
+    missing_resp = client.get(
+        "/profiles/ACCT-123",
+        headers=admin_headers,
+    )
+    assert missing_resp.status_code == 404
+
+
+class _DummyInboxClient:
+    def __init__(self, messages):
+        self._messages = messages
+        self.marked = []
+
+    def fetch_unread(self):
+        return list(self._messages)
+
+    def mark_processed(self, message_id: str) -> None:
+        self.marked.append(message_id)
+
+
+def test_inbound_email_processor_creates_profile():
+    session = SessionLocal()
+    try:
+        repos = Repositories(session)
+        account = AccountOpening(
+            id=1,
+            realtor="agentA",
+            details="",
+            status=SubmissionStatus.COMPLETED,
+            account_number="EMAIL123",
+            deposit_threshold=1000,
+            deposits=[1000],
+            document=None,
+            required_documents={},
+        )
+        repos.account_openings.add(account)
+        loan = LoanApplication(
+            id=9,
+            realtor="agentA",
+            account_id=1,
+            property_id=None,
+            required_documents={},
+            status=SubmissionStatus.SUBMITTED,
+            decision=None,
+            reason=None,
+            loan_account_number=None,
+        )
+        repos.loan_applications.add(loan)
+        agreement = Agreement(
+            id=5,
+            loan_application_id=9,
+            property_id=1,
+            realtor="agentA",
+            document="doc",
+            versions=["doc"],
+            bank_document_url=None,
+            customer_document_url=None,
+            status=AgreementStatus.DRAFT,
+            audit_log=[],
+        )
+        repos.agreements.add(agreement)
+
+        received_at = datetime.utcnow()
+        message = InboundEmail(
+            message_id="1",
+            subject="Reply",
+            body="Account Number: EMAIL123",
+            received_at=received_at,
+        )
+        client = _DummyInboxClient([message])
+        processor = InboundEmailProcessor(repos, client)
+        processed = processor.process_new_messages()
+        assert processed == 1
+        profile = repos.customer_profiles.get("EMAIL123")
+        assert profile is not None
+        assert profile.account_opening_id == 1
+        assert profile.loan_application_ids == [9]
+        assert profile.agreement_ids == [5]
+        assert profile.last_inbound_email_at == received_at
+        assert client.marked == ["1"]
+    finally:
+        session.close()


### PR DESCRIPTION
## Summary
- add a persistent CustomerProfile model and repository along with API endpoints for viewing and deletion workflows
- build an inbox processing service to upsert profiles from inbound account emails and keep profiles in sync with submissions
- surface customer profile management in the dashboard for agents and managers/admins including navigation updates

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68cefa77fa88832c82e1a3dbfa258f3d