### PR TITLE
Add property application review flow and agreement workspace

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -73,6 +73,7 @@ from .models import (
     ContactSettings,
     ContactSettingsResponse,
     CustomerProfile,
+    LoanTeamReply,
 )
 
 logger = logging.getLogger(__name__)
@@ -198,6 +199,15 @@ def _normalize_recipients(recipients: List[str]) -> List[str]:
         normalized.append(trimmed)
         seen.add(key)
     return normalized
+
+
+def _parse_loan_team_decision(body: str) -> LoanDecision | None:
+    normalized = body.lower()
+    if "approved" in normalized:
+        return LoanDecision.APPROVED
+    if "declined" in normalized or "rejected" in normalized:
+        return LoanDecision.REJECTED
+    return None
 
 
 def _extract_recipients(data: Any) -> List[str]:
@@ -1150,6 +1160,31 @@ def _agreement_ids_for_loans(loan_ids: List[int], repos: Repositories) -> List[i
     )
 
 
+def _ensure_agreement_for_application(
+    application: LoanApplication, repos: Repositories
+) -> None:
+    if not application.property_id:
+        return
+    if repos.agreements.get(application.id):
+        return
+    stand = repos.stands.get(application.property_id)
+    if not stand:
+        return
+    content = f"Agreement for property {stand.name} with loan {application.id}"
+    timestamp = datetime.utcnow().isoformat()
+    agreement = Agreement(
+        id=application.id,
+        loan_application_id=application.id,
+        property_id=application.property_id,
+        realtor=application.realtor,
+        document=content,
+        versions=[content],
+        audit_log=[f"{timestamp}: generated"],
+        status=AgreementStatus.DRAFT,
+    )
+    repos.agreements.add(agreement)
+
+
 def _find_account_opening_by_number(
     account_number: str, repos: Repositories
 ) -> AccountOpening | None:
@@ -1208,6 +1243,31 @@ def _touch_profile(
     new_profile = profile.model_copy(update=payload)
     repos.customer_profiles.add(new_profile)
     return new_profile
+
+
+def _normalize_document_key(filename: str, existing: set[str]) -> str:
+    base = re.sub(r"[^a-z0-9]+", "-", filename.lower()).strip("-") or "attachment"
+    candidate = base
+    counter = 1
+    while candidate in existing:
+        candidate = f"{base}-{counter}"
+        counter += 1
+    return candidate
+
+
+def _store_profile_documents(
+    profile: CustomerProfile, attachments: List[UploadedFile], repos: Repositories
+) -> CustomerProfile:
+    if not attachments:
+        return profile
+    documents = dict(profile.documents)
+    existing = set(documents.keys())
+    for attachment in attachments:
+        name = attachment.filename or "attachment"
+        key = _normalize_document_key(name, existing)
+        documents[key] = attachment
+        existing.add(key)
+    return _touch_profile(profile, repos, documents=documents)
 
 
 def _get_profile_or_404(
@@ -1357,19 +1417,6 @@ async def upload_property_application(
     repos.notifications.append(
         f"Property application {id} submitted by {realtor}"
     )
-    _send_submission_email(
-        subject=f"Property application #{id}",
-        metadata={
-            "Submission Type": "Property Application",
-            "Application ID": id,
-            "Realtor": realtor,
-            "Property ID": property_id,
-            "Details": details,
-        },
-        primary_document=application.document,
-        required_documents=application.required_documents,
-        repos=repos,
-    )
     return application
 
 
@@ -1504,20 +1551,51 @@ def submit_property_application(
     repos.notifications.append(
         f"Property application {sanitized_application.id} submitted by {sanitized_application.realtor}"
     )
+    return sanitized_application
+
+
+@app.get("/property-applications", response_model=List[PropertyApplication])
+def list_property_applications(
+    status: Optional[SubmissionStatus] = None,
+    _: Agent = Depends(require_management),
+    repos: Repositories = Depends(get_repositories),
+):
+    applications = repos.applications.list()
+    if status:
+        applications = [app for app in applications if app.status == status]
+    return applications
+
+
+@app.post("/property-applications/{app_id}/approve", response_model=PropertyApplication)
+def approve_property_application(
+    app_id: int,
+    agent: Agent = Depends(require_management),
+    repos: Repositories = Depends(get_repositories),
+):
+    application = repos.applications.get(app_id)
+    if not application:
+        raise HTTPException(status_code=404, detail="Application not found")
+    if application.status != SubmissionStatus.SUBMITTED:
+        raise HTTPException(status_code=400, detail="Only submitted applications can be approved")
+    application.status = SubmissionStatus.MANAGER_APPROVED
+    repos.applications.add(application)
+    repos.notifications.append(
+        f"Property application {app_id} approved by {agent.username}"
+    )
     _send_submission_email(
-        subject=f"Property application #{sanitized_application.id}",
+        subject=f"Property application #{application.id}",
         metadata={
             "Submission Type": "Property Application",
-            "Application ID": sanitized_application.id,
-            "Realtor": sanitized_application.realtor,
-            "Property ID": sanitized_application.property_id,
-            "Details": sanitized_application.details,
+            "Application ID": application.id,
+            "Realtor": application.realtor,
+            "Property ID": application.property_id,
+            "Details": application.details,
         },
-        primary_document=sanitized_application.document,
-        required_documents=sanitized_application.required_documents,
+        primary_document=application.document,
+        required_documents=application.required_documents,
         repos=repos,
     )
-    return sanitized_application
+    return application
 
 
 @app.get("/property-applications/{app_id}", response_model=PropertyApplication)
@@ -1907,6 +1985,40 @@ def submit_loan_application(
     return sanitized_application
 
 
+@app.post("/automation/loan-team-reply", response_model=LoanApplication)
+def process_loan_team_reply(
+    reply: LoanTeamReply,
+    _: Agent = Depends(require_management),
+    repos: Repositories = Depends(get_repositories),
+):
+    application = repos.loan_applications.get(reply.loan_application_id)
+    if not application:
+        raise HTTPException(status_code=404, detail="Loan application not found")
+    decision = _parse_loan_team_decision(reply.body)
+    if not decision:
+        raise HTTPException(status_code=400, detail="Unable to determine decision from message")
+    application.decision = decision
+    if decision == LoanDecision.APPROVED:
+        application.status = SubmissionStatus.COMPLETED
+        application.reason = None
+        _ensure_agreement_for_application(application, repos)
+    else:
+        application.status = SubmissionStatus.REJECTED
+        application.reason = reply.body.strip() or "Declined by loan team"
+    repos.loan_applications.add(application)
+    repos.notifications.append(
+        f"Loan application {application.id} updated from loan team reply"
+    )
+    account = repos.account_openings.get(application.account_id)
+    if account and account.account_number:
+        profile = repos.customer_profiles.get(account.account_number)
+        if not profile:
+            profile = _sync_profile_from_account(account, repos)
+        if profile:
+            _store_profile_documents(profile, reply.attachments, repos)
+    return application
+
+
 @app.get("/loan-applications/{app_id}", response_model=LoanApplication)
 def get_loan_application(
     app_id: int,
@@ -1946,24 +2058,9 @@ def decide_loan_application(
     application.reason = decision.reason
     if decision.decision == LoanDecision.APPROVED:
         application.status = SubmissionStatus.COMPLETED
-        if application.property_id:
-            if repos.agreements.get(application.id):
-                raise HTTPException(status_code=400, detail="Agreement ID exists")
-            stand = repos.stands.get(application.property_id)
-            if stand:
-                content = f"Agreement for property {stand.name} with loan {application.id}"
-                timestamp = datetime.utcnow().isoformat()
-                agreement = Agreement(
-                    id=application.id,
-                    loan_application_id=application.id,
-                    property_id=application.property_id,
-                    realtor=application.realtor,
-                    document=content,
-                    versions=[content],
-                    audit_log=[f"{timestamp}: generated"],
-                    status=AgreementStatus.DRAFT,
-                )
-                repos.agreements.add(agreement)
+        if application.property_id and repos.agreements.get(application.id):
+            raise HTTPException(status_code=400, detail="Agreement ID exists")
+        _ensure_agreement_for_application(application, repos)
     else:
         application.status = SubmissionStatus.REJECTED
     repos.loan_applications.add(application)
@@ -2173,6 +2270,20 @@ def get_audit_log(
 # ---- Agreement endpoints ----
 
 
+@app.get("/agreements", response_model=List[Agreement])
+def list_agreements(
+    status: Optional[AgreementStatus] = None,
+    agent: Agent = Depends(get_current_agent),
+    repos: Repositories = Depends(get_repositories),
+):
+    agreements = repos.agreements.list()
+    if agent.role == AgentRole.AGENT:
+        agreements = [a for a in agreements if a.realtor == agent.username]
+    if status:
+        agreements = [a for a in agreements if a.status == status]
+    return agreements
+
+
 @app.post("/agreements", response_model=Agreement)
 def create_agreement(
     data: AgreementCreate,
@@ -2220,6 +2331,36 @@ def get_agreement(
     return agreement
 
 
+@app.get("/agreements/{agreement_id}/download")
+def download_agreement(
+    agreement_id: int,
+    agent: Agent = Depends(get_current_agent),
+    repos: Repositories = Depends(get_repositories),
+):
+    agreement = repos.agreements.get(agreement_id)
+    if not agreement:
+        raise HTTPException(status_code=404, detail="Agreement not found")
+    _ensure_owner(agreement.realtor, agent)
+    if agreement.document_file:
+        data = base64.b64decode(agreement.document_file.content)
+        media_type = (
+            agreement.document_file.content_type or "application/octet-stream"
+        )
+        extension = media_type.split("/")[-1] if "/" in media_type else "bin"
+        filename = (
+            agreement.document_file.filename
+            or f"agreement-{agreement_id}.{extension}"
+        )
+    else:
+        data = agreement.document.encode("utf-8")
+        filename = f"agreement-{agreement_id}.txt"
+        media_type = "text/plain"
+    headers = {
+        "Content-Disposition": f"attachment; filename=\"{filename}\""
+    }
+    return StreamingResponse(BytesIO(data), media_type=media_type, headers=headers)
+
+
 @app.get("/agreements/{agreement_id}/document")
 def view_agreement_document(
     agreement_id: int,
@@ -2230,7 +2371,77 @@ def view_agreement_document(
     if not agreement:
         raise HTTPException(status_code=404, detail="Agreement not found")
     _ensure_owner(agreement.realtor, agent)
+    if agreement.document_file:
+        data = base64.b64decode(agreement.document_file.content)
+        return Response(content=data, media_type=agreement.document_file.content_type)
     return Response(content=agreement.document, media_type="text/plain")
+
+
+@app.post(
+    "/agreements/{agreement_id}/customer-upload-file", response_model=Agreement
+)
+async def upload_customer_agreement_file(
+    agreement_id: int,
+    file: UploadFile = File(...),
+    agent: Agent = Depends(get_current_agent),
+    repos: Repositories = Depends(get_repositories),
+):
+    agreement = repos.agreements.get(agreement_id)
+    if not agreement:
+        raise HTTPException(status_code=404, detail="Agreement not found")
+    _ensure_owner(agreement.realtor, agent)
+    encoded = await _encode_upload_file(file)
+    agreement.version_files.append(encoded)
+    agreement.document_file = encoded
+    agreement.status = AgreementStatus.PARTIALLY_SIGNED
+    timestamp = datetime.utcnow().isoformat()
+    agreement.audit_log.append(
+        f"{timestamp}: customer upload by {agent.username}"
+    )
+    repos.agreements.add(agreement)
+    loan = repos.loan_applications.get(agreement.loan_application_id)
+    if loan:
+        account = repos.account_openings.get(loan.account_id)
+        if account and account.account_number:
+            profile = repos.customer_profiles.get(account.account_number)
+            if not profile:
+                profile = _sync_profile_from_account(account, repos)
+            if profile:
+                _store_profile_documents(profile, [encoded], repos)
+    return agreement
+
+
+@app.post(
+    "/agreements/{agreement_id}/manager-upload-file", response_model=Agreement
+)
+async def upload_manager_agreement_file(
+    agreement_id: int,
+    file: UploadFile = File(...),
+    agent: Agent = Depends(require_management),
+    repos: Repositories = Depends(get_repositories),
+):
+    agreement = repos.agreements.get(agreement_id)
+    if not agreement:
+        raise HTTPException(status_code=404, detail="Agreement not found")
+    encoded = await _encode_upload_file(file)
+    agreement.version_files.append(encoded)
+    agreement.document_file = encoded
+    agreement.status = AgreementStatus.SIGNED
+    timestamp = datetime.utcnow().isoformat()
+    agreement.audit_log.append(
+        f"{timestamp}: manager upload by {agent.username}"
+    )
+    repos.agreements.add(agreement)
+    loan = repos.loan_applications.get(agreement.loan_application_id)
+    if loan:
+        account = repos.account_openings.get(loan.account_id)
+        if account and account.account_number:
+            profile = repos.customer_profiles.get(account.account_number)
+            if not profile:
+                profile = _sync_profile_from_account(account, repos)
+            if profile:
+                _store_profile_documents(profile, [encoded], repos)
+    return agreement
 
 
 @app.post("/agreements/{agreement_id}/sign", response_model=Agreement)

--- a/app/models.py
+++ b/app/models.py
@@ -233,6 +233,8 @@ class Agreement(BaseModel):
     realtor: str
     document: str
     versions: List[str] = Field(default_factory=list)
+    document_file: Optional[UploadedFile] = None
+    version_files: List[UploadedFile] = Field(default_factory=list)
     bank_document_url: Optional[str] = None
     customer_document_url: Optional[str] = None
     status: AgreementStatus = AgreementStatus.DRAFT
@@ -288,6 +290,7 @@ class CustomerProfile(BaseModel):
     realtor: Optional[str] = None
     loan_application_ids: List[int] = Field(default_factory=list)
     agreement_ids: List[int] = Field(default_factory=list)
+    documents: Dict[str, UploadedFile] = Field(default_factory=dict)
     last_inbound_email_at: Optional[datetime] = None
     deletion_requested: bool = False
     deletion_requested_at: Optional[datetime] = None
@@ -296,3 +299,10 @@ class CustomerProfile(BaseModel):
     deletion_approved_by: Optional[str] = None
     created_at: datetime
     updated_at: datetime
+
+
+class LoanTeamReply(BaseModel):
+    message_id: str
+    loan_application_id: int
+    body: str
+    attachments: List[UploadedFile] = Field(default_factory=list)

--- a/dashboard/src/App.tsx
+++ b/dashboard/src/App.tsx
@@ -23,6 +23,8 @@ import ImportedLoanAccounts from './pages/ImportedLoanAccounts';
 import ContactSettingsPage from './pages/ContactSettings';
 import CustomerProfileAgent from './pages/CustomerProfileAgent';
 import CustomerProfilesManage from './pages/CustomerProfilesManage';
+import PropertyApplicationsQueue from './pages/PropertyApplicationsQueue';
+import Agreements from './pages/Agreements';
 import { ProtectedRoute, useAuth } from './auth';
 
 const App: React.FC = () => {
@@ -37,6 +39,8 @@ const App: React.FC = () => {
           { to: '/document-requirements', label: 'Document Requirements' },
           { to: '/contact-settings', label: 'Contact Settings' },
           { to: '/agents', label: 'Agents' },
+          { to: '/property-applications', label: 'Property Applications' },
+          { to: '/agreements', label: 'Agreements' },
           { to: '/account-openings', label: 'Account Openings' },
           { to: '/customer-profiles/manage', label: 'Customer Profiles' },
           { to: '/loan-applications', label: 'Loan Applications' },
@@ -49,6 +53,8 @@ const App: React.FC = () => {
       : auth.role === 'manager'
         ? [
             { to: '/manager-dashboard', label: 'Dashboard' },
+            { to: '/property-applications', label: 'Property Applications' },
+            { to: '/agreements', label: 'Agreements' },
             { to: '/account-openings', label: 'Account Openings' },
             { to: '/customer-profiles/manage', label: 'Customer Profiles' },
             { to: '/imported-deposits', label: 'Imported Deposits' },
@@ -60,6 +66,7 @@ const App: React.FC = () => {
             ? [
                 { to: '/dashboard', label: 'Dashboard' },
                 { to: '/submit', label: 'New Submission' },
+                { to: '/agreements', label: 'Agreements' },
                 { to: '/customer-profiles', label: 'Customer Profiles' },
               ]
             : []
@@ -141,6 +148,22 @@ const App: React.FC = () => {
               element={
                 <ProtectedRoute roles={["admin"]}>
                   <Mandates />
+                </ProtectedRoute>
+              }
+            />
+            <Route
+              path="/agreements"
+              element={
+                <ProtectedRoute roles={["admin", "manager", "agent"]}>
+                  <Agreements />
+                </ProtectedRoute>
+              }
+            />
+            <Route
+              path="/property-applications"
+              element={
+                <ProtectedRoute roles={["admin", "manager"]}>
+                  <PropertyApplicationsQueue />
                 </ProtectedRoute>
               }
             />

--- a/dashboard/src/api.ts
+++ b/dashboard/src/api.ts
@@ -444,6 +444,22 @@ export async function submitPropertyApplication(
   return res.json();
 }
 
+export async function getPropertyApplications(token: string, status?: string) {
+  const url = status ? `/property-applications?status=${status}` : '/property-applications';
+  const res = await fetch(apiUrl(url), { headers: headers(token) });
+  if (!res.ok) throw new Error('Failed to load property applications');
+  return res.json();
+}
+
+export async function approvePropertyApplication(token: string, id: number) {
+  const res = await fetch(apiUrl(`/property-applications/${id}/approve`), {
+    method: 'POST',
+    headers: headers(token),
+  });
+  if (!res.ok) throw new Error('Failed to approve property application');
+  return res.json();
+}
+
 export async function getAccountOpenings(token: string, status?: string) {
   const url = status ? `/account-openings?status=${status}` : '/account-openings';
   const res = await fetch(apiUrl(url), { headers: headers(token) });
@@ -660,6 +676,7 @@ export interface CustomerProfile {
   realtor?: string | null;
   loan_application_ids: number[];
   agreement_ids: number[];
+  documents?: Record<string, StoredFile>;
   last_inbound_email_at?: string | null;
   deletion_requested: boolean;
   deletion_requested_at?: string | null;
@@ -668,6 +685,78 @@ export interface CustomerProfile {
   deletion_approved_by?: string | null;
   created_at: string;
   updated_at: string;
+}
+
+export interface StoredFile {
+  filename: string;
+  content_type: string;
+  content: string;
+}
+
+export interface AgreementRecord {
+  id: number;
+  loan_application_id: number;
+  property_id: number;
+  realtor: string;
+  document: string;
+  versions: string[];
+  document_file?: StoredFile | null;
+  version_files?: StoredFile[];
+  bank_document_url?: string | null;
+  customer_document_url?: string | null;
+  status: string;
+  audit_log: string[];
+}
+
+export async function getAgreements(token: string, status?: string) {
+  const url = status ? `/agreements?status=${status}` : '/agreements';
+  const res = await fetch(apiUrl(url), { headers: headers(token) });
+  if (!res.ok) throw new Error('Failed to load agreements');
+  return res.json() as Promise<AgreementRecord[]>;
+}
+
+export async function downloadAgreement(token: string, id: number) {
+  const res = await fetch(apiUrl(`/agreements/${id}/download`), {
+    headers: headers(token),
+  });
+  if (!res.ok) throw new Error('Failed to download agreement');
+  const blob = await res.blob();
+  const disposition = res.headers.get('content-disposition') || '';
+  const match = disposition.match(/filename="?([^";]+)"?/i);
+  const filename = match ? match[1] : `agreement-${id}`;
+  return { blob, filename };
+}
+
+export async function uploadCustomerAgreementFile(
+  token: string,
+  id: number,
+  file: File,
+) {
+  const form = new FormData();
+  form.append('file', file);
+  const res = await fetch(apiUrl(`/agreements/${id}/customer-upload-file`), {
+    method: 'POST',
+    headers: { Authorization: `Bearer ${token}` },
+    body: form,
+  });
+  if (!res.ok) throw new Error('Failed to upload agreement');
+  return res.json() as Promise<AgreementRecord>;
+}
+
+export async function uploadManagerAgreementFile(
+  token: string,
+  id: number,
+  file: File,
+) {
+  const form = new FormData();
+  form.append('file', file);
+  const res = await fetch(apiUrl(`/agreements/${id}/manager-upload-file`), {
+    method: 'POST',
+    headers: { Authorization: `Bearer ${token}` },
+    body: form,
+  });
+  if (!res.ok) throw new Error('Failed to upload final agreement');
+  return res.json() as Promise<AgreementRecord>;
 }
 
 const profileUrl = (accountNumber: string) =>

--- a/dashboard/src/pages/Agreements.tsx
+++ b/dashboard/src/pages/Agreements.tsx
@@ -1,0 +1,191 @@
+import React from 'react';
+import { useAuth } from '../auth';
+import {
+  AgreementRecord,
+  downloadAgreement,
+  getAgreements,
+  uploadCustomerAgreementFile,
+  uploadManagerAgreementFile,
+} from '../api';
+
+const Agreements: React.FC = () => {
+  const { auth } = useAuth();
+  const [agreements, setAgreements] = React.useState<AgreementRecord[]>([]);
+  const [error, setError] = React.useState('');
+  const [statusMessage, setStatusMessage] = React.useState('');
+  const [isLoading, setIsLoading] = React.useState(false);
+  const [customerFiles, setCustomerFiles] = React.useState<Record<number, File | null>>({});
+  const [managerFiles, setManagerFiles] = React.useState<Record<number, File | null>>({});
+  const isManager = auth?.role === 'manager' || auth?.role === 'admin';
+
+  const loadAgreements = React.useCallback(() => {
+    if (!auth) return;
+    setIsLoading(true);
+    getAgreements(auth.token)
+      .then(data => {
+        setAgreements(data);
+        setError('');
+      })
+      .catch(() => setError('Unable to load agreements.'))
+      .finally(() => setIsLoading(false));
+  }, [auth]);
+
+  React.useEffect(() => {
+    loadAgreements();
+  }, [loadAgreements]);
+
+  const updateAgreement = (record: AgreementRecord) => {
+    setAgreements(prev => prev.map(item => (item.id === record.id ? record : item)));
+  };
+
+  const handleDownload = async (id: number) => {
+    if (!auth) return;
+    try {
+      const { blob, filename } = await downloadAgreement(auth.token, id);
+      const objectUrl = URL.createObjectURL(blob);
+      const link = document.createElement('a');
+      link.href = objectUrl;
+      link.download = filename;
+      document.body.appendChild(link);
+      link.click();
+      document.body.removeChild(link);
+      URL.revokeObjectURL(objectUrl);
+    } catch (err) {
+      setError('Failed to download agreement.');
+    }
+  };
+
+  const handleCustomerUpload = async (id: number) => {
+    if (!auth) return;
+    const file = customerFiles[id];
+    if (!file) {
+      setError('Select a file before uploading.');
+      return;
+    }
+    try {
+      const updated = await uploadCustomerAgreementFile(auth.token, id, file);
+      updateAgreement(updated);
+      setStatusMessage('Customer-reviewed agreement uploaded.');
+      setError('');
+      setCustomerFiles(prev => ({ ...prev, [id]: null }));
+    } catch (err) {
+      setError('Failed to upload customer-reviewed agreement.');
+    }
+  };
+
+  const handleManagerUpload = async (id: number) => {
+    if (!auth || !isManager) return;
+    const file = managerFiles[id];
+    if (!file) {
+      setError('Select a final agreement before uploading.');
+      return;
+    }
+    try {
+      const updated = await uploadManagerAgreementFile(auth.token, id, file);
+      updateAgreement(updated);
+      setStatusMessage('Final signed agreement uploaded.');
+      setError('');
+      setManagerFiles(prev => ({ ...prev, [id]: null }));
+    } catch (err) {
+      setError('Failed to upload final agreement.');
+    }
+  };
+
+  const renderAuditLog = (log: string[]) => {
+    if (log.length === 0) return <span>—</span>;
+    return (
+      <details>
+        <summary>History</summary>
+        <ul>
+          {log.map((entry, index) => (
+            <li key={`${entry}-${index}`}>{entry}</li>
+          ))}
+        </ul>
+      </details>
+    );
+  };
+
+  return (
+    <div>
+      <h2>Agreements Workspace</h2>
+      {statusMessage && <p className="status-message">{statusMessage}</p>}
+      {error && (
+        <p role="alert" className="error">
+          {error}
+        </p>
+      )}
+      {isLoading && <p>Loading agreements…</p>}
+      {!isLoading && agreements.length === 0 && <p>No agreements available.</p>}
+      {agreements.length > 0 && (
+        <div className="table-wrapper">
+          <table className="data-table">
+            <thead className="data-table__header">
+              <tr>
+                <th scope="col">Agreement</th>
+                <th scope="col">Property</th>
+                <th scope="col">Status</th>
+                <th scope="col">Audit Log</th>
+                <th scope="col">Actions</th>
+              </tr>
+            </thead>
+            <tbody>
+              {agreements.map(agreement => (
+                <tr key={agreement.id}>
+                  <td>#{agreement.id}</td>
+                  <td>{agreement.property_id}</td>
+                  <td>{agreement.status}</td>
+                  <td>{renderAuditLog(agreement.audit_log)}</td>
+                  <td>
+                    <div className="action-group">
+                      <button type="button" onClick={() => handleDownload(agreement.id)}>
+                        Download Latest
+                      </button>
+                    </div>
+                    <div className="action-group">
+                      <label>
+                        <span className="visually-hidden">Upload customer reviewed copy</span>
+                        <input
+                          type="file"
+                          onChange={event =>
+                            setCustomerFiles(prev => ({
+                              ...prev,
+                              [agreement.id]: event.target.files?.[0] ?? null,
+                            }))
+                          }
+                        />
+                      </label>
+                      <button type="button" onClick={() => handleCustomerUpload(agreement.id)}>
+                        Upload Customer Copy
+                      </button>
+                    </div>
+                    {isManager && (
+                      <div className="action-group">
+                        <label>
+                          <span className="visually-hidden">Upload final signed agreement</span>
+                          <input
+                            type="file"
+                            onChange={event =>
+                              setManagerFiles(prev => ({
+                                ...prev,
+                                [agreement.id]: event.target.files?.[0] ?? null,
+                              }))
+                            }
+                          />
+                        </label>
+                        <button type="button" onClick={() => handleManagerUpload(agreement.id)}>
+                          Upload Final Signed
+                        </button>
+                      </div>
+                    )}
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      )}
+    </div>
+  );
+};
+
+export default Agreements;

--- a/dashboard/src/pages/CustomerProfileAgent.tsx
+++ b/dashboard/src/pages/CustomerProfileAgent.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 import { useAuth } from '../auth';
 import {
   CustomerProfile,
+  StoredFile,
   getCustomerProfile,
   requestProfileDeletion,
 } from '../api';
@@ -12,6 +13,24 @@ const CustomerProfileAgent: React.FC = () => {
   const [profile, setProfile] = React.useState<CustomerProfile | null>(null);
   const [status, setStatus] = React.useState('');
   const [error, setError] = React.useState('');
+
+  const handleDownloadDocument = (label: string, file: StoredFile) => {
+    const byteString = window.atob(file.content);
+    const len = byteString.length;
+    const bytes = new Uint8Array(len);
+    for (let i = 0; i < len; i += 1) {
+      bytes[i] = byteString.charCodeAt(i);
+    }
+    const blob = new Blob([bytes], { type: file.content_type || 'application/octet-stream' });
+    const objectUrl = URL.createObjectURL(blob);
+    const link = document.createElement('a');
+    link.href = objectUrl;
+    link.download = file.filename || label;
+    document.body.appendChild(link);
+    link.click();
+    document.body.removeChild(link);
+    URL.revokeObjectURL(objectUrl);
+  };
 
   const handleLookup: React.FormEventHandler<HTMLFormElement> = async (event) => {
     event.preventDefault();
@@ -91,6 +110,23 @@ const CustomerProfileAgent: React.FC = () => {
                 <dd>{profile.deletion_requested_at ?? 'Unknown'}</dd>
               </>
             )}
+            <dt>Documents</dt>
+            <dd>
+              {profile.documents && Object.keys(profile.documents).length > 0 ? (
+                <ul>
+                  {Object.entries(profile.documents).map(([key, file]) => (
+                    <li key={key}>
+                      {file.filename || key}{' '}
+                      <button type="button" onClick={() => handleDownloadDocument(key, file)}>
+                        Download
+                      </button>
+                    </li>
+                  ))}
+                </ul>
+              ) : (
+                <span>No uploaded documents</span>
+              )}
+            </dd>
           </dl>
           <button
             type="button"

--- a/dashboard/src/pages/PropertyApplicationsQueue.tsx
+++ b/dashboard/src/pages/PropertyApplicationsQueue.tsx
@@ -1,0 +1,88 @@
+import React from 'react';
+import { useAuth } from '../auth';
+import { approvePropertyApplication, getPropertyApplications } from '../api';
+
+interface PropertyApplicationRecord {
+  id: number;
+  property_id: number;
+  realtor: string;
+  status: string;
+  details?: string | null;
+}
+
+const PropertyApplicationsQueue: React.FC = () => {
+  const { auth } = useAuth();
+  const [applications, setApplications] = React.useState<PropertyApplicationRecord[]>([]);
+  const [error, setError] = React.useState('');
+  const [isLoading, setIsLoading] = React.useState(false);
+
+  const loadApplications = React.useCallback(() => {
+    if (!auth) return;
+    setIsLoading(true);
+    getPropertyApplications(auth.token, 'submitted')
+      .then(data => {
+        setApplications(data);
+        setError('');
+      })
+      .catch(() => setError('Unable to load property applications.'))
+      .finally(() => setIsLoading(false));
+  }, [auth]);
+
+  React.useEffect(() => {
+    loadApplications();
+  }, [loadApplications]);
+
+  const handleApprove = async (id: number) => {
+    if (!auth) return;
+    try {
+      await approvePropertyApplication(auth.token, id);
+      setApplications(prev => prev.filter(app => app.id !== id));
+      setError('');
+    } catch (err) {
+      setError('Failed to approve property application.');
+    }
+  };
+
+  return (
+    <div>
+      <h2>Property Application Review Queue</h2>
+      {error && <p role="alert">{error}</p>}
+      {isLoading && <p>Loading applications…</p>}
+      {!isLoading && applications.length === 0 && <p>No applications awaiting review.</p>}
+      {applications.length > 0 && (
+        <div className="table-wrapper">
+          <table className="data-table">
+            <thead className="data-table__header">
+              <tr>
+                <th scope="col">Application</th>
+                <th scope="col">Property</th>
+                <th scope="col">Realtor</th>
+                <th scope="col">Notes</th>
+                <th scope="col">Status</th>
+                <th scope="col">Actions</th>
+              </tr>
+            </thead>
+            <tbody>
+              {applications.map(app => (
+                <tr key={app.id}>
+                  <td>#{app.id}</td>
+                  <td>{app.property_id}</td>
+                  <td>{app.realtor}</td>
+                  <td>{app.details ?? '—'}</td>
+                  <td>{app.status}</td>
+                  <td>
+                    <button type="button" onClick={() => handleApprove(app.id)}>
+                      Approve
+                    </button>
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      )}
+    </div>
+  );
+};
+
+export default PropertyApplicationsQueue;


### PR DESCRIPTION
## Summary
- add manager-facing property application queue and approval endpoint
- automate loan team replies with decision parsing and profile document storage
- deliver agreement workspace for agents and managers including download and upload actions

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68ceffaa88e4832c8449d4fc2047e486