### PR TITLE
Link loan workflow to property applications

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -169,6 +169,20 @@ def run_startup_tasks() -> None:
     logger.info("Configured frontend origins: %s", ", ".join(FRONTEND_ORIGINS))
     init_db()
     seed_initial_admin_if_configured()
+    migrate_loan_application_property_links()
+
+
+def migrate_loan_application_property_links() -> None:
+    """Ensure stored loan applications include the property link field."""
+
+    session = SessionLocal()
+    try:
+        repos = Repositories(session)
+        for application in repos.loan_applications.list():
+            if "property_application_id" not in application.model_fields_set:
+                repos.loan_applications.add(application)
+    finally:
+        session.close()
 
 
 @app.on_event("startup")
@@ -1185,6 +1199,26 @@ def _ensure_agreement_for_application(
     repos.agreements.add(agreement)
 
 
+def _get_property_application_for_loan(
+    application: LoanApplication, repos: Repositories
+) -> PropertyApplication | None:
+    if not application.property_application_id:
+        return None
+    return repos.applications.get(application.property_application_id)
+
+
+def _update_property_application_status(
+    application: LoanApplication,
+    status: SubmissionStatus,
+    repos: Repositories,
+) -> None:
+    property_application = _get_property_application_for_loan(application, repos)
+    if not property_application:
+        return
+    property_application.status = status
+    repos.applications.add(property_application)
+
+
 def _find_account_opening_by_number(
     account_number: str, repos: Repositories
 ) -> AccountOpening | None:
@@ -1949,19 +1983,57 @@ def submit_loan_application(
         raise HTTPException(
             status_code=400, detail="Deposits not sufficient for loan application"
         )
+    if application.property_application_id is None:
+        raise HTTPException(
+            status_code=400,
+            detail="Property application reference is required",
+        )
+    property_application = repos.applications.get(application.property_application_id)
+    if not property_application:
+        raise HTTPException(status_code=404, detail="Property application not found")
+    if property_application.realtor != application.realtor:
+        raise HTTPException(
+            status_code=403,
+            detail="Property application must belong to the same realtor",
+        )
+    if property_application.status != SubmissionStatus.MANAGER_APPROVED:
+        raise HTTPException(
+            status_code=400,
+            detail="Property application must be manager approved",
+        )
     _validate_required_documents(
         DocumentWorkflow.LOAN_APPLICATION,
         application.required_documents,
         repos,
     )
-    if application.property_id and not repos.stands.get(application.property_id):
+    linked_property_id = application.property_id or property_application.property_id
+    if (
+        application.property_id
+        and property_application.property_id
+        and linked_property_id != property_application.property_id
+    ):
+        raise HTTPException(
+            status_code=400,
+            detail="Property does not match the approved property application",
+        )
+    if linked_property_id and not repos.stands.get(linked_property_id):
         raise HTTPException(status_code=404, detail="Property not found")
+    property_application.status = SubmissionStatus.IN_PROGRESS
+    repos.applications.add(property_application)
+    repos.notifications.append(
+        (
+            "Property application"
+            f" {property_application.id} moved to loan review by {agent.username}"
+        )
+    )
     sanitized_application = application.model_copy(
         update={
             "status": SubmissionStatus.SUBMITTED,
             "decision": None,
             "reason": None,
             "loan_account_number": None,
+            "property_application_id": property_application.id,
+            "property_id": linked_property_id,
         }
     )
     repos.loan_applications.add(sanitized_application)
@@ -1977,6 +2049,7 @@ def submit_loan_application(
             "Realtor": sanitized_application.realtor,
             "Account ID": sanitized_application.account_id,
             "Property ID": sanitized_application.property_id,
+            "Property Application ID": sanitized_application.property_application_id,
         },
         primary_document=None,
         required_documents=sanitized_application.required_documents,
@@ -2002,9 +2075,15 @@ def process_loan_team_reply(
         application.status = SubmissionStatus.COMPLETED
         application.reason = None
         _ensure_agreement_for_application(application, repos)
+        _update_property_application_status(
+            application, SubmissionStatus.COMPLETED, repos
+        )
     else:
         application.status = SubmissionStatus.REJECTED
         application.reason = reply.body.strip() or "Declined by loan team"
+        _update_property_application_status(
+            application, SubmissionStatus.REJECTED, repos
+        )
     repos.loan_applications.add(application)
     repos.notifications.append(
         f"Loan application {application.id} updated from loan team reply"
@@ -2061,8 +2140,14 @@ def decide_loan_application(
         if application.property_id and repos.agreements.get(application.id):
             raise HTTPException(status_code=400, detail="Agreement ID exists")
         _ensure_agreement_for_application(application, repos)
+        _update_property_application_status(
+            application, SubmissionStatus.COMPLETED, repos
+        )
     else:
         application.status = SubmissionStatus.REJECTED
+        _update_property_application_status(
+            application, SubmissionStatus.REJECTED, repos
+        )
     repos.loan_applications.add(application)
     return application
 

--- a/app/models.py
+++ b/app/models.py
@@ -166,6 +166,7 @@ class LoanApplication(BaseModel):
     realtor: str
     account_id: int
     property_id: Optional[int] = None
+    property_application_id: Optional[int] = None
     required_documents: Dict[str, UploadedFile] = Field(default_factory=dict)
     status: SubmissionStatus = SubmissionStatus.SUBMITTED
     decision: Optional[LoanDecision] = None

--- a/dashboard/src/pages/LoanApplications.tsx
+++ b/dashboard/src/pages/LoanApplications.tsx
@@ -1,14 +1,33 @@
 import React from 'react';
 import { useAuth } from '../auth';
-import { getLoanApplications, decideLoanApplication, generateAgreement } from '../api';
+import {
+  getLoanApplications,
+  decideLoanApplication,
+  generateAgreement,
+  getPropertyApplications,
+} from '../api';
 
 interface LoanApp {
   id: number;
   realtor: string;
   account_id: number;
   property_id?: number;
+  property_application_id?: number | null;
   status: string;
 }
+
+interface PropertyApplicationSummary {
+  id: number;
+  status: string;
+}
+
+const formatStatus = (status?: string) =>
+  status
+    ? status
+        .split('_')
+        .map(part => part.charAt(0).toUpperCase() + part.slice(1))
+        .join(' ')
+    : '—';
 
 const LoanApplications: React.FC = () => {
   const { auth } = useAuth();
@@ -17,14 +36,47 @@ const LoanApplications: React.FC = () => {
   const [sortKey, setSortKey] = React.useState<keyof LoanApp>('id');
   const [ascending, setAscending] = React.useState(true);
   const [comments, setComments] = React.useState<Record<number, string>>({});
+  const [propertyStatuses, setPropertyStatuses] = React.useState<Record<number, string>>({});
+
+  const loadPropertyStatuses = React.useCallback(
+    (records: LoanApp[]) => {
+      if (!auth) return;
+      const ids = Array.from(
+        new Set(
+          records
+            .map(record => record.property_application_id)
+            .filter((value): value is number => typeof value === 'number'),
+        ),
+      );
+      if (ids.length === 0) {
+        setPropertyStatuses({});
+        return;
+      }
+      getPropertyApplications(auth.token)
+        .then(all => {
+          const mapping: Record<number, string> = {};
+          (all as PropertyApplicationSummary[]).forEach(item => {
+            if (ids.includes(item.id)) {
+              mapping[item.id] = item.status;
+            }
+          });
+          setPropertyStatuses(mapping);
+        })
+        .catch(() => setPropertyStatuses({}));
+    },
+    [auth],
+  );
 
   React.useEffect(() => {
     if (auth) {
       getLoanApplications(auth.token, 'submitted')
-        .then(setApps)
+        .then(data => {
+          setApps(data);
+          loadPropertyStatuses(data);
+        })
         .catch(() => setError('Failed to load applications'));
     }
-  }, [auth]);
+  }, [auth, loadPropertyStatuses]);
 
   const sortBy = (key: keyof LoanApp) => {
     const asc = key === sortKey ? !ascending : true;
@@ -53,6 +105,13 @@ const LoanApplications: React.FC = () => {
           }).catch(() => setError('Failed to generate agreement'));
         }
         setApps(prev => prev.filter(a => a.id !== id));
+        setPropertyStatuses(prev => {
+          const next = { ...prev };
+          if (app.property_application_id) {
+            delete next[app.property_application_id];
+          }
+          return next;
+        });
       })
       .catch(() => setError('Failed to submit decision'));
   };
@@ -69,6 +128,9 @@ const LoanApplications: React.FC = () => {
               <th onClick={() => sortBy('id')}>ID</th>
               <th onClick={() => sortBy('realtor')}>Realtor</th>
               <th onClick={() => sortBy('account_id')}>Account</th>
+              <th>Property Application</th>
+              <th>Property Status</th>
+              <th>Actions</th>
             </tr>
           </thead>
           <tbody>
@@ -77,6 +139,8 @@ const LoanApplications: React.FC = () => {
                 <td>{app.id}</td>
                 <td>{app.realtor}</td>
                 <td>{app.account_id}</td>
+                <td>{app.property_application_id ?? '—'}</td>
+                <td>{formatStatus(propertyStatuses[app.property_application_id ?? -1])}</td>
                 <td>
                   <input
                     type="text"

--- a/dashboard/src/pages/MultiStepForm.tsx
+++ b/dashboard/src/pages/MultiStepForm.tsx
@@ -13,6 +13,7 @@ interface FileData {
   primaryFile: File | null;
   details: string;
   propertyId?: string;
+  id?: string;
   documents: Record<string, File | null>;
 }
 
@@ -28,6 +29,7 @@ const MultiStepForm: React.FC = () => {
   const [application, setApplication] = React.useState<FileData>({
     details: '',
     propertyId: '',
+    id: '',
     primaryFile: null,
     documents: {},
   });
@@ -134,6 +136,7 @@ const MultiStepForm: React.FC = () => {
     Boolean(offer.primaryFile) &&
     requirements.offer.every(req => Boolean(offer.documents[req.slug]));
   const applicationComplete =
+    Boolean(application.id?.trim()) &&
     Boolean(application.propertyId?.trim()) &&
     Boolean(application.details.trim()) &&
     Boolean(application.primaryFile) &&
@@ -196,6 +199,11 @@ const MultiStepForm: React.FC = () => {
   const submitApplicationStep = async (e: React.FormEvent) => {
     e.preventDefault();
     if (!requirementsLoaded) return setError('Document requirements are still loading');
+    if (!application.id) return setError('Application ID is required');
+    const parsedId = Number(application.id);
+    if (!Number.isFinite(parsedId)) {
+      return setError('Application ID must be a number');
+    }
     if (!application.propertyId) return setError('Property ID is required');
     if (!application.details) return setError('Details are required');
     const fileErr = validateFile(application.primaryFile);
@@ -211,7 +219,7 @@ const MultiStepForm: React.FC = () => {
     });
     try {
       await submitPropertyApplication(auth.token, {
-        id: Date.now(),
+        id: parsedId,
         realtor: auth.username,
         property_id: Number(application.propertyId),
         details: application.details,
@@ -222,6 +230,7 @@ const MultiStepForm: React.FC = () => {
       setApplication({
         details: '',
         propertyId: '',
+        id: '',
         primaryFile: null,
         documents: mergeDocuments(requirements.property_application, {}),
       });
@@ -346,6 +355,15 @@ const MultiStepForm: React.FC = () => {
           <form className="form-card" onSubmit={submitApplicationStep}>
             <h3 className="form-title">Property Application</h3>
             <div className="form-fields">
+              <label htmlFor="application-id">
+                Application ID
+                <input
+                  id="application-id"
+                  placeholder="Enter application ID"
+                  value={application.id}
+                  onChange={e => setApplication({ ...application, id: e.target.value })}
+                />
+              </label>
               <label htmlFor="application-property-id">
                 Property ID
                 <input

--- a/dashboard/src/pages/PropertyApplicationsQueue.tsx
+++ b/dashboard/src/pages/PropertyApplicationsQueue.tsx
@@ -10,27 +10,47 @@ interface PropertyApplicationRecord {
   details?: string | null;
 }
 
+const STATUS_OPTIONS = [
+  { value: 'submitted', label: 'Submitted' },
+  { value: 'manager_approved', label: 'Manager Approved' },
+  { value: 'in_progress', label: 'In Progress' },
+  { value: 'completed', label: 'Completed' },
+  { value: 'rejected', label: 'Rejected' },
+];
+
+const formatStatus = (status: string) =>
+  status
+    .split('_')
+    .map(part => part.charAt(0).toUpperCase() + part.slice(1))
+    .join(' ');
+
 const PropertyApplicationsQueue: React.FC = () => {
   const { auth } = useAuth();
   const [applications, setApplications] = React.useState<PropertyApplicationRecord[]>([]);
   const [error, setError] = React.useState('');
   const [isLoading, setIsLoading] = React.useState(false);
+  const [statusFilter, setStatusFilter] = React.useState('submitted');
 
   const loadApplications = React.useCallback(() => {
     if (!auth) return;
     setIsLoading(true);
-    getPropertyApplications(auth.token, 'submitted')
+    const statusParam = statusFilter === 'all' ? undefined : statusFilter;
+    getPropertyApplications(auth.token, statusParam)
       .then(data => {
         setApplications(data);
         setError('');
       })
       .catch(() => setError('Unable to load property applications.'))
       .finally(() => setIsLoading(false));
-  }, [auth]);
+  }, [auth, statusFilter]);
 
   React.useEffect(() => {
     loadApplications();
   }, [loadApplications]);
+
+  const handleFilterChange = (event: React.ChangeEvent<HTMLSelectElement>) => {
+    setStatusFilter(event.target.value);
+  };
 
   const handleApprove = async (id: number) => {
     if (!auth) return;
@@ -47,6 +67,23 @@ const PropertyApplicationsQueue: React.FC = () => {
     <div>
       <h2>Property Application Review Queue</h2>
       {error && <p role="alert">{error}</p>}
+      <div className="form-fields" style={{ maxWidth: 320 }}>
+        <label htmlFor="property-status-filter">
+          Filter by status
+          <select
+            id="property-status-filter"
+            value={statusFilter}
+            onChange={handleFilterChange}
+          >
+            <option value="all">All</option>
+            {STATUS_OPTIONS.map(option => (
+              <option key={option.value} value={option.value}>
+                {option.label}
+              </option>
+            ))}
+          </select>
+        </label>
+      </div>
       {isLoading && <p>Loading applications…</p>}
       {!isLoading && applications.length === 0 && <p>No applications awaiting review.</p>}
       {applications.length > 0 && (
@@ -58,7 +95,7 @@ const PropertyApplicationsQueue: React.FC = () => {
                 <th scope="col">Property</th>
                 <th scope="col">Realtor</th>
                 <th scope="col">Notes</th>
-                <th scope="col">Status</th>
+                <th scope="col">Workflow Status</th>
                 <th scope="col">Actions</th>
               </tr>
             </thead>
@@ -69,7 +106,7 @@ const PropertyApplicationsQueue: React.FC = () => {
                   <td>{app.property_id}</td>
                   <td>{app.realtor}</td>
                   <td>{app.details ?? '—'}</td>
-                  <td>{app.status}</td>
+                  <td>{formatStatus(app.status)}</td>
                   <td>
                     <button type="button" onClick={() => handleApprove(app.id)}>
                       Approve

--- a/tests/test_agreements.py
+++ b/tests/test_agreements.py
@@ -53,9 +53,30 @@ def setup_data(client):
         json={"amount": 100},
         headers=admin_headers,
     )
+    property_application = {
+        "id": 101,
+        "realtor": "realtor",
+        "property_id": stand_id,
+    }
+    client.post(
+        "/property-applications",
+        json=property_application,
+        headers=realtor_headers,
+    )
+    client.post(
+        f"/property-applications/{property_application['id']}/approve",
+        headers=admin_headers,
+    )
     client.post(
         "/loan-applications",
-        json={"id": 1, "realtor": "realtor", "account_id": 1, "documents": ["doc"]},
+        json={
+            "id": 1,
+            "realtor": "realtor",
+            "account_id": 1,
+            "property_application_id": property_application["id"],
+            "property_id": stand_id,
+            "documents": ["doc"],
+        },
         headers=realtor_headers,
     )
     return {

--- a/tests/test_customer_profiles.py
+++ b/tests/test_customer_profiles.py
@@ -100,11 +100,27 @@ def test_profile_workflow_and_deletion(client):
     )
     assert resp.status_code == 200
 
+    property_application = {
+        "id": 88,
+        "realtor": "agentA",
+        "property_id": stand_id,
+    }
+    client.post(
+        "/property-applications",
+        json=property_application,
+        headers=agent_headers,
+    )
+    client.post(
+        f"/property-applications/{property_application['id']}/approve",
+        headers=admin_headers,
+    )
+
     loan_payload = {
         "id": 77,
         "realtor": "agentA",
         "account_id": 1,
         "property_id": stand_id,
+        "property_application_id": property_application["id"],
         "required_documents": {},
     }
     resp = client.post(

--- a/tests/test_dashboard.py
+++ b/tests/test_dashboard.py
@@ -77,12 +77,28 @@ def setup_data(client, admin_headers, agent_headers):
         json={"amount": 100},
         headers=admin_headers,
     )
+    property_application = {
+        "id": 201,
+        "realtor": "agentA",
+        "property_id": stand_id,
+    }
+    client.post(
+        "/property-applications",
+        json=property_application,
+        headers=agent_headers,
+    )
+    client.post(
+        f"/property-applications/{property_application['id']}/approve",
+        headers=admin_headers,
+    )
     client.post(
         "/loan-applications",
         json={
             "id": 100,
             "realtor": "agentA",
             "account_id": 100,
+            "property_application_id": property_application["id"],
+            "property_id": stand_id,
             "documents": ["doc"],
         },
         headers=agent_headers,

--- a/tests/test_reporting.py
+++ b/tests/test_reporting.py
@@ -75,9 +75,30 @@ def setup_data(client):
         json={"amount": 100},
         headers=admin_headers,
     )
+    property_application = {
+        "id": 301,
+        "realtor": "agent",
+        "property_id": stand_one["id"],
+    }
+    client.post(
+        "/property-applications",
+        json=property_application,
+        headers=agent_headers,
+    )
+    client.post(
+        f"/property-applications/{property_application['id']}/approve",
+        headers=admin_headers,
+    )
     client.post(
         "/loan-applications",
-        json={"id": 1, "realtor": "agent", "account_id": 1, "documents": ["d"]},
+        json={
+            "id": 1,
+            "realtor": "agent",
+            "account_id": 1,
+            "property_application_id": property_application["id"],
+            "property_id": stand_one["id"],
+            "documents": ["d"],
+        },
         headers=agent_headers,
     )
     client.put(

--- a/tests/test_submissions.py
+++ b/tests/test_submissions.py
@@ -157,6 +157,31 @@ def test_submission_payload_privileged_fields_are_sanitized(client):
     )
     assert resp.status_code == 200
 
+    project_id = client.post(
+        "/projects", json={"name": "Sanitized"}, headers=admin_headers
+    ).json()["id"]
+    stand_id = client.post(
+        "/stands",
+        json={"project_id": project_id, "name": "Sanitized Stand", "size": 120, "price": 1500},
+        headers=admin_headers,
+    ).json()["id"]
+    property_application = {
+        "id": 4040,
+        "realtor": "realtor",
+        "property_id": stand_id,
+    }
+    resp = client.post(
+        "/property-applications",
+        json=property_application,
+        headers=realtor_headers,
+    )
+    assert resp.status_code == 200
+    resp = client.post(
+        f"/property-applications/{property_application['id']}/approve",
+        headers=admin_headers,
+    )
+    assert resp.status_code == 200
+
     loan_requirement = client.post(
         "/document-requirements",
         json={"name": "Loan package", "applies_to": "loan_application"},
@@ -167,6 +192,8 @@ def test_submission_payload_privileged_fields_are_sanitized(client):
         "id": 404,
         "realtor": "realtor",
         "account_id": 303,
+        "property_application_id": property_application["id"],
+        "property_id": stand_id,
         "required_documents": {
             loan_requirement["slug"]: {
                 "filename": "loan.pdf",
@@ -189,6 +216,17 @@ def test_submission_payload_privileged_fields_are_sanitized(client):
     assert body["reason"] is None
     assert body["loan_account_number"] is None
     assert "required_documents" in body
+
+    resp = client.get(
+        "/property-applications",
+        headers=admin_headers,
+    )
+    assert resp.status_code == 200
+    prop_records = {record["id"]: record for record in resp.json()}
+    assert (
+        prop_records[property_application["id"]]["status"]
+        == SubmissionStatus.IN_PROGRESS.value
+    )
     resp = client.get("/loan-applications/404", headers=realtor_headers)
     stored = resp.json()
     assert stored["status"] == SubmissionStatus.SUBMITTED.value
@@ -266,6 +304,32 @@ def test_loan_application_flow(client):
     requirement_id = requirement_data["id"]
     requirement_slug = requirement_data["slug"]
 
+    project_id = client.post(
+        "/projects", json={"name": "Loan Project"}, headers=admin_headers
+    ).json()["id"]
+    stand_id = client.post(
+        "/stands",
+        json={"project_id": project_id, "name": "Loan Stand", "size": 100, "price": 1000},
+        headers=admin_headers,
+    ).json()["id"]
+
+    property_application = {
+        "id": 11,
+        "realtor": "realtor",
+        "property_id": stand_id,
+    }
+    resp = client.post(
+        "/property-applications",
+        json=property_application,
+        headers=realtor_headers,
+    )
+    assert resp.status_code == 200
+    resp = client.post(
+        f"/property-applications/{property_application['id']}/approve",
+        headers=admin_headers,
+    )
+    assert resp.status_code == 200
+
     account = {"id": 3, "realtor": "realtor"}
     resp = client.post("/account-openings", json=account, headers=realtor_headers)
     assert resp.status_code == 200
@@ -296,6 +360,8 @@ def test_loan_application_flow(client):
         "id": 1,
         "realtor": "realtor",
         "account_id": 3,
+        "property_application_id": property_application["id"],
+        "property_id": stand_id,
         "required_documents": {
             requirement_slug: {
                 "filename": "loan.pdf",
@@ -318,6 +384,8 @@ def test_loan_application_flow(client):
         "id": 1,
         "realtor": "realtor",
         "account_id": 3,
+        "property_application_id": property_application["id"],
+        "property_id": stand_id,
         "required_documents": {},
     }
     resp = client.post(
@@ -333,6 +401,14 @@ def test_loan_application_flow(client):
     assert resp.status_code == 200
     assert resp.json()["status"] == SubmissionStatus.SUBMITTED.value
 
+    resp = client.get(
+        "/property-applications",
+        headers=admin_headers,
+    )
+    assert resp.status_code == 200
+    prop_records = {record["id"]: record for record in resp.json()}
+    assert prop_records[property_application["id"]]["status"] == SubmissionStatus.IN_PROGRESS.value
+
     resp = client.put(
         "/loan-applications/1/decision",
         json={"decision": "approved", "reason": "All good"},
@@ -343,12 +419,42 @@ def test_loan_application_flow(client):
     assert resp.json()["decision"] == "approved"
     assert resp.json()["reason"] == "All good"
 
+    resp = client.get(
+        "/property-applications",
+        headers=admin_headers,
+    )
+    assert resp.status_code == 200
+    prop_records = {record["id"]: record for record in resp.json()}
+    assert (
+        prop_records[property_application["id"]]["status"]
+        == SubmissionStatus.COMPLETED.value
+    )
+
+    second_property_application = {
+        "id": 12,
+        "realtor": "realtor",
+        "property_id": stand_id,
+    }
+    resp = client.post(
+        "/property-applications",
+        json=second_property_application,
+        headers=realtor_headers,
+    )
+    assert resp.status_code == 200
+    resp = client.post(
+        f"/property-applications/{second_property_application['id']}/approve",
+        headers=admin_headers,
+    )
+    assert resp.status_code == 200
+
     resp = client.post(
         "/loan-applications",
         json={
             "id": 2,
             "realtor": "realtor",
             "account_id": 3,
+            "property_application_id": second_property_application["id"],
+            "property_id": stand_id,
             "required_documents": {
             requirement_slug: {
                 "filename": "loan2.pdf",
@@ -370,6 +476,17 @@ def test_loan_application_flow(client):
     assert resp.json()["status"] == SubmissionStatus.REJECTED.value
     assert resp.json()["decision"] == "rejected"
     assert resp.json()["reason"] == "Insufficient credit"
+
+    resp = client.get(
+        "/property-applications",
+        headers=admin_headers,
+    )
+    assert resp.status_code == 200
+    prop_records = {record["id"]: record for record in resp.json()}
+    assert (
+        prop_records[second_property_application["id"]]["status"]
+        == SubmissionStatus.REJECTED.value
+    )
 
 
 def test_loan_application_realtor_mismatch_rejected(client):
@@ -402,6 +519,31 @@ def test_loan_application_realtor_mismatch_rejected(client):
     )
     assert resp.status_code == 200
 
+    project_id = client.post(
+        "/projects", json={"name": "Mismatch"}, headers=admin_headers
+    ).json()["id"]
+    stand_id = client.post(
+        "/stands",
+        json={"project_id": project_id, "name": "Mismatch Stand", "size": 80, "price": 500},
+        headers=admin_headers,
+    ).json()["id"]
+    property_application = {
+        "id": 21,
+        "realtor": "realtor",
+        "property_id": stand_id,
+    }
+    resp = client.post(
+        "/property-applications",
+        json=property_application,
+        headers=realtor_headers,
+    )
+    assert resp.status_code == 200
+    resp = client.post(
+        f"/property-applications/{property_application['id']}/approve",
+        headers=admin_headers,
+    )
+    assert resp.status_code == 200
+
     # Another agent attempts to submit a loan application using this account
     resp = client.post(
         "/agents",
@@ -418,6 +560,8 @@ def test_loan_application_realtor_mismatch_rejected(client):
         "id": 99,
         "realtor": "other",
         "account_id": 7,
+        "property_application_id": property_application["id"],
+        "property_id": stand_id,
         "documents": ["doc"],
     }
     resp = client.post("/loan-applications", json=loan_app, headers=other_headers)
@@ -499,12 +643,30 @@ def test_loan_application_queue_listing_and_agreement_generation(client):
         headers=admin_headers,
     )
 
+    property_application = {
+        "id": 61,
+        "realtor": "realtor",
+        "property_id": stand_id,
+    }
+    resp = client.post(
+        "/property-applications",
+        json=property_application,
+        headers=realtor_headers,
+    )
+    assert resp.status_code == 200
+    resp = client.post(
+        f"/property-applications/{property_application['id']}/approve",
+        headers=admin_headers,
+    )
+    assert resp.status_code == 200
+
     loan_app = {
         "id": 10,
         "realtor": "realtor",
         "account_id": 1,
         "documents": ["doc"],
         "property_id": stand_id,
+        "property_application_id": property_application["id"],
     }
     client.post("/loan-applications", json=loan_app, headers=realtor_headers)
 


### PR DESCRIPTION
## Summary
- add a property_application_id to loan applications, migrate existing records, and require the link before managers advance submissions
- drive property application status changes when loan applications move through submission, approval, or rejection
- expose the linkage in dashboards and forms while updating tests to exercise the new workflow requirements

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68cf0eef2720832ca3a38d8675c6ea7f