### PR TITLE
Add loan application submission workflow

### DIFF
--- a/dashboard/src/api.ts
+++ b/dashboard/src/api.ts
@@ -444,6 +444,72 @@ export async function submitPropertyApplication(
   return res.json();
 }
 
+export interface LoanApplicationSubmission {
+  id: number;
+  realtor: string;
+  account_id: number;
+  property_application_id: number;
+  property_id?: number | null;
+  file?: File | null;
+  documents?: Record<string, File>;
+}
+
+export async function submitLoanApplication(
+  token: string,
+  payload: LoanApplicationSubmission,
+) {
+  const opts: RequestInit = { method: 'POST' };
+  const documents = payload.documents ?? {};
+  const hasUploads = Boolean(payload.file) || Object.keys(documents).length > 0;
+
+  if (hasUploads) {
+    const form = new FormData();
+    form.append('id', String(payload.id));
+    form.append('realtor', payload.realtor);
+    form.append('account_id', String(payload.account_id));
+    form.append('property_application_id', String(payload.property_application_id));
+    if (typeof payload.property_id === 'number') {
+      form.append('property_id', String(payload.property_id));
+    }
+    if (payload.file) {
+      form.append('file', payload.file);
+    }
+    Object.entries(documents).forEach(([slug, file]) => {
+      form.append(slug, file);
+    });
+    opts.body = form;
+    opts.headers = { Authorization: `Bearer ${token}` };
+  } else {
+    const body: Record<string, unknown> = {
+      id: payload.id,
+      realtor: payload.realtor,
+      account_id: payload.account_id,
+      property_application_id: payload.property_application_id,
+      required_documents: {},
+    };
+    if (typeof payload.property_id === 'number') {
+      body.property_id = payload.property_id;
+    }
+    opts.body = JSON.stringify(body);
+    opts.headers = headers(token);
+  }
+
+  const res = await fetch(apiUrl('/loan-applications'), opts);
+  if (!res.ok) {
+    let message = 'Failed to submit loan application';
+    try {
+      const data = await res.json();
+      if (data?.detail) {
+        message = data.detail;
+      }
+    } catch (err) {
+      // ignore parsing errors and use default message
+    }
+    throw new Error(message);
+  }
+  return res.json();
+}
+
 type QueueFilters = {
   status?: string;
   q?: string;

--- a/dashboard/src/pages/Dashboard.tsx
+++ b/dashboard/src/pages/Dashboard.tsx
@@ -5,10 +5,13 @@ import {
   DocumentWorkflow,
   getDashboard,
   getStands,
+  getAccountOpenings,
+  getPropertyApplications,
   listDocumentRequirements,
   submitOffer,
   submitAccountOpening,
   submitPropertyApplication,
+  submitLoanApplication,
 } from '../api';
 import { BarChartCard, LineChartCard, PieChartCard, toChartData } from '../components/ChartCard';
 
@@ -27,6 +30,20 @@ interface Stand {
   mandate?: MandateInfo;
 }
 
+interface AccountOpeningRecord {
+  id: number;
+  realtor: string;
+  status: string;
+  account_number?: string | null;
+}
+
+interface PropertyApplicationRecord {
+  id: number;
+  realtor: string;
+  status: string;
+  property_id?: number | null;
+}
+
 const Dashboard: React.FC = () => {
   const { auth } = useAuth();
   const [stands, setStands] = React.useState<Stand[]>([]);
@@ -43,6 +60,34 @@ const Dashboard: React.FC = () => {
   });
   const [requirementsLoaded, setRequirementsLoaded] = React.useState(false);
   const [dashboardSummary, setDashboardSummary] = React.useState<any | null>(null);
+  const [eligibleAccounts, setEligibleAccounts] = React.useState<
+    AccountOpeningRecord[]
+  >([]);
+  const [approvedPropertyApps, setApprovedPropertyApps] = React.useState<
+    PropertyApplicationRecord[]
+  >([]);
+  const [loanForm, setLoanForm] = React.useState({
+    loanId: '',
+    accountId: '',
+    propertyApplicationId: '',
+    propertyId: '',
+    primaryFile: null as File | null,
+    documents: {} as Record<string, File | null>,
+  });
+  const [loanError, setLoanError] = React.useState<string | null>(null);
+  const [loanSuccess, setLoanSuccess] = React.useState<string | null>(null);
+  const [loanProgress, setLoanProgress] = React.useState(0);
+  const [loanSubmitting, setLoanSubmitting] = React.useState(false);
+  const loanPrimaryInputRef = React.useRef<HTMLInputElement | null>(null);
+  const loanDocumentRefs = React.useRef<Record<string, HTMLInputElement | null>>({});
+
+  const buildLoanDocumentState = React.useCallback(() => {
+    const map: Record<string, File | null> = {};
+    requirements.loan_application.forEach(req => {
+      map[req.slug] = null;
+    });
+    return map;
+  }, [requirements.loan_application]);
 
   React.useEffect(() => {
     if (auth) {
@@ -66,10 +111,11 @@ const Dashboard: React.FC = () => {
     let cancelled = false;
     (async () => {
       try {
-        const [offerReqs, propertyReqs, accountReqs] = await Promise.all([
+        const [offerReqs, propertyReqs, accountReqs, loanReqs] = await Promise.all([
           listDocumentRequirements(auth.token, 'offer'),
           listDocumentRequirements(auth.token, 'property_application'),
           listDocumentRequirements(auth.token, 'account_opening'),
+          listDocumentRequirements(auth.token, 'loan_application'),
         ]);
         if (!cancelled) {
           setRequirements(prev => ({
@@ -77,6 +123,7 @@ const Dashboard: React.FC = () => {
             offer: offerReqs,
             property_application: propertyReqs,
             account_opening: accountReqs,
+            loan_application: loanReqs,
           }));
         }
       } catch (err) {
@@ -87,6 +134,7 @@ const Dashboard: React.FC = () => {
             offer: [],
             property_application: [],
             account_opening: [],
+            loan_application: [],
           }));
         }
       } finally {
@@ -95,6 +143,84 @@ const Dashboard: React.FC = () => {
         }
       }
     })();
+    return () => {
+      cancelled = true;
+    };
+  }, [auth]);
+
+  React.useEffect(() => {
+    setLoanForm(prev => {
+      const nextDocuments: Record<string, File | null> = {};
+      requirements.loan_application.forEach(req => {
+        nextDocuments[req.slug] = prev.documents?.[req.slug] ?? null;
+      });
+      return { ...prev, documents: nextDocuments };
+    });
+    loanDocumentRefs.current = {};
+  }, [requirements.loan_application]);
+
+  const selectedPropertyApplicationId = loanForm.propertyApplicationId;
+  React.useEffect(() => {
+    setLoanForm(prev => {
+      const selected = approvedPropertyApps.find(
+        app => String(app.id) === prev.propertyApplicationId,
+      );
+      const derived = selected?.property_id ? String(selected.property_id) : '';
+      if ((derived || '') === (prev.propertyId || '')) {
+        if (!selected && !prev.propertyId) {
+          return prev;
+        }
+        if (selected) {
+          return prev;
+        }
+      }
+      if (!selected && !prev.propertyId) {
+        return prev;
+      }
+      return { ...prev, propertyId: derived };
+    });
+  }, [approvedPropertyApps, selectedPropertyApplicationId]);
+
+  React.useEffect(() => {
+    if (!auth) {
+      setEligibleAccounts([]);
+      setApprovedPropertyApps([]);
+      return;
+    }
+    let cancelled = false;
+    (async () => {
+      const [accountsResult, propertiesResult] = await Promise.allSettled([
+        getAccountOpenings(auth.token, { status: 'completed' }),
+        getPropertyApplications(auth.token, { status: 'manager_approved' }),
+      ]);
+      if (cancelled) return;
+      if (accountsResult.status === 'fulfilled') {
+        const records = (accountsResult.value as AccountOpeningRecord[]).filter(
+          record =>
+            record.status === 'completed' &&
+            (!auth?.username || record.realtor === auth.username),
+        );
+        setEligibleAccounts(records);
+      } else {
+        setEligibleAccounts([]);
+      }
+      if (propertiesResult.status === 'fulfilled') {
+        const records = (propertiesResult.value as PropertyApplicationRecord[]).filter(
+          record =>
+            record.status === 'manager_approved' &&
+            (!auth?.username || record.realtor === auth.username),
+        );
+        setApprovedPropertyApps(records);
+      } else {
+        setApprovedPropertyApps([]);
+      }
+    })().catch(err => {
+      console.error(err);
+      if (!cancelled) {
+        setEligibleAccounts([]);
+        setApprovedPropertyApps([]);
+      }
+    });
     return () => {
       cancelled = true;
     };
@@ -298,6 +424,147 @@ const Dashboard: React.FC = () => {
     );
   };
 
+  const loanRequirements = requirements.loan_application;
+  const selectedProperty = approvedPropertyApps.find(
+    app => String(app.id) === loanForm.propertyApplicationId,
+  );
+  const loanDocumentsComplete = loanRequirements.every(req =>
+    Boolean(loanForm.documents[req.slug]),
+  );
+  const loanComplete =
+    Boolean(loanForm.loanId.trim()) &&
+    Boolean(loanForm.accountId.trim()) &&
+    Boolean(loanForm.propertyApplicationId.trim()) &&
+    Boolean(loanForm.primaryFile) &&
+    loanDocumentsComplete;
+
+  const validateLoanFile = (file: File | null) => {
+    if (!file) return 'File is required';
+    const ext = file.name.split('.').pop()?.toLowerCase();
+    return ext && (ext === 'pdf' || ext === 'csv')
+      ? null
+      : 'File must be PDF or CSV';
+  };
+
+  const resetLoanForm = React.useCallback(() => {
+    setLoanForm({
+      loanId: '',
+      accountId: '',
+      propertyApplicationId: '',
+      propertyId: '',
+      primaryFile: null,
+      documents: buildLoanDocumentState(),
+    });
+    if (loanPrimaryInputRef.current) {
+      loanPrimaryInputRef.current.value = '';
+    }
+    Object.values(loanDocumentRefs.current).forEach(input => {
+      if (input) {
+        input.value = '';
+      }
+    });
+    loanDocumentRefs.current = {};
+  }, [buildLoanDocumentState]);
+
+  const updateLoanDocument = (slug: string, file: File | null) => {
+    setLoanForm(prev => ({
+      ...prev,
+      documents: { ...prev.documents, [slug]: file },
+    }));
+  };
+
+  const submitLoanForm = async (e: React.FormEvent) => {
+    e.preventDefault();
+    if (loanSubmitting) return;
+    setLoanError(null);
+    setLoanSuccess(null);
+    if (!requirementsLoaded) {
+      setLoanError('Document requirements are still loading');
+      return;
+    }
+    if (!loanForm.loanId.trim()) {
+      setLoanError('Loan application ID is required');
+      return;
+    }
+    const parsedLoanId = Number(loanForm.loanId);
+    if (!Number.isFinite(parsedLoanId)) {
+      setLoanError('Loan application ID must be a number');
+      return;
+    }
+    if (!loanForm.accountId.trim()) {
+      setLoanError('Completed account ID is required');
+      return;
+    }
+    const parsedAccountId = Number(loanForm.accountId);
+    if (!Number.isFinite(parsedAccountId)) {
+      setLoanError('Completed account ID must be a number');
+      return;
+    }
+    if (!loanForm.propertyApplicationId.trim()) {
+      setLoanError('Approved property application is required');
+      return;
+    }
+    const parsedPropertyApplicationId = Number(loanForm.propertyApplicationId);
+    if (!Number.isFinite(parsedPropertyApplicationId)) {
+      setLoanError('Property application ID must be a number');
+      return;
+    }
+    let parsedPropertyId: number | undefined;
+    if (loanForm.propertyId.trim()) {
+      parsedPropertyId = Number(loanForm.propertyId);
+      if (!Number.isFinite(parsedPropertyId)) {
+        setLoanError('Property ID must be a number');
+        return;
+      }
+    }
+    const primaryError = validateLoanFile(loanForm.primaryFile);
+    if (primaryError) {
+      setLoanError(primaryError);
+      return;
+    }
+    for (const requirement of loanRequirements) {
+      const file = loanForm.documents[requirement.slug] ?? null;
+      const error = validateLoanFile(file);
+      if (error) {
+        setLoanError(`${requirement.name}: ${error}`);
+        return;
+      }
+    }
+    const documentFiles: Record<string, File> = {};
+    loanRequirements.forEach(requirement => {
+      const file = loanForm.documents[requirement.slug];
+      if (file) {
+        documentFiles[requirement.slug] = file;
+      }
+    });
+    setLoanSubmitting(true);
+    setLoanProgress(0);
+    const interval = setInterval(
+      () => setLoanProgress(progress => Math.min(progress + 10, 90)),
+      200,
+    );
+    try {
+      await submitLoanApplication(auth.token, {
+        id: parsedLoanId,
+        realtor: auth.username,
+        account_id: parsedAccountId,
+        property_application_id: parsedPropertyApplicationId,
+        property_id: parsedPropertyId,
+        file: loanForm.primaryFile!,
+        documents: documentFiles,
+      });
+      setLoanSuccess('Loan application submitted');
+      resetLoanForm();
+    } catch (err: any) {
+      setLoanError(err?.message ?? 'Submission failed');
+    } finally {
+      clearInterval(interval);
+      setLoanSubmitting(false);
+      setLoanProgress(100);
+      setTimeout(() => setLoanProgress(0), 500);
+    }
+  };
+
   if (!auth) return null;
 
   return (
@@ -457,6 +724,156 @@ const Dashboard: React.FC = () => {
             </table>
           </div>
         </div>
+      </section>
+      <section className="form-section">
+        <form className="form-card" onSubmit={submitLoanForm}>
+          <h3 className="form-title">Loan Application</h3>
+          {loanError && <p className="form-message form-message--error">{loanError}</p>}
+          {loanSuccess && <p className="form-message form-message--success">{loanSuccess}</p>}
+          <div className="form-fields">
+            <label htmlFor="loan-application-id">
+              Loan Application ID
+              <input
+                id="loan-application-id"
+                placeholder="Enter loan application ID"
+                value={loanForm.loanId}
+                onChange={e =>
+                  setLoanForm(prev => ({ ...prev, loanId: e.target.value }))
+                }
+              />
+            </label>
+            <label htmlFor="loan-account-id">
+              Completed Account
+              {eligibleAccounts.length > 0 ? (
+                <select
+                  id="loan-account-id"
+                  value={loanForm.accountId}
+                  onChange={e =>
+                    setLoanForm(prev => ({ ...prev, accountId: e.target.value }))
+                  }
+                >
+                  <option value="">Select a completed account</option>
+                  {eligibleAccounts.map(account => (
+                    <option key={account.id} value={account.id}>
+                      #{account.id}
+                      {account.account_number
+                        ? ` • Account ${account.account_number}`
+                        : ''}
+                    </option>
+                  ))}
+                </select>
+              ) : (
+                <input
+                  id="loan-account-id"
+                  placeholder="Enter completed account ID"
+                  value={loanForm.accountId}
+                  onChange={e =>
+                    setLoanForm(prev => ({ ...prev, accountId: e.target.value }))
+                  }
+                />
+              )}
+            </label>
+            <label htmlFor="loan-property-application">
+              Approved Property Application
+              {approvedPropertyApps.length > 0 ? (
+                <select
+                  id="loan-property-application"
+                  value={loanForm.propertyApplicationId}
+                  onChange={e =>
+                    setLoanForm(prev => ({
+                      ...prev,
+                      propertyApplicationId: e.target.value,
+                    }))
+                  }
+                >
+                  <option value="">Select an approved property application</option>
+                  {approvedPropertyApps.map(app => (
+                    <option key={app.id} value={app.id}>
+                      #{app.id}
+                      {typeof app.property_id === 'number'
+                        ? ` • Property ${app.property_id}`
+                        : ''}
+                    </option>
+                  ))}
+                </select>
+              ) : (
+                <input
+                  id="loan-property-application"
+                  placeholder="Enter approved property application ID"
+                  value={loanForm.propertyApplicationId}
+                  onChange={e =>
+                    setLoanForm(prev => ({
+                      ...prev,
+                      propertyApplicationId: e.target.value,
+                    }))
+                  }
+                />
+              )}
+            </label>
+            <label htmlFor="loan-property-id">
+              Property ID
+              <input
+                id="loan-property-id"
+                placeholder="Derived from property application"
+                value={loanForm.propertyId}
+                onChange={e =>
+                  setLoanForm(prev => ({ ...prev, propertyId: e.target.value }))
+                }
+                readOnly={Boolean(selectedProperty)}
+              />
+            </label>
+            <label htmlFor="loan-primary">
+              Primary Document
+              <input
+                id="loan-primary"
+                type="file"
+                accept=".pdf,.csv"
+                onChange={e =>
+                  setLoanForm(prev => ({
+                    ...prev,
+                    primaryFile: e.target.files?.[0] ?? null,
+                  }))
+                }
+                ref={loanPrimaryInputRef}
+                required
+              />
+            </label>
+            {loanRequirements.map(requirement => {
+              const inputId = `loan-${requirement.slug}`;
+              return (
+                <label key={requirement.id} htmlFor={inputId}>
+                  {requirement.name}
+                  <input
+                    id={inputId}
+                    type="file"
+                    accept=".pdf,.csv"
+                    onChange={e =>
+                      updateLoanDocument(
+                        requirement.slug,
+                        e.target.files?.[0] ?? null,
+                      )
+                    }
+                    ref={el => {
+                      loanDocumentRefs.current[requirement.slug] = el;
+                    }}
+                    required
+                  />
+                </label>
+              );
+            })}
+          </div>
+          <div className="form-actions">
+            <button
+              type="submit"
+              disabled={
+                !requirementsLoaded || !loanComplete || loanSubmitting
+              }
+            >
+              Submit Loan Application
+            </button>
+          </div>
+          {loanProgress > 0 && <progress value={loanProgress} max={100} />}
+        </form>
       </section>
     </div>
   );

--- a/dashboard/src/pages/MultiStepForm.tsx
+++ b/dashboard/src/pages/MultiStepForm.tsx
@@ -7,6 +7,9 @@ import {
   submitOffer,
   submitPropertyApplication,
   submitAccountOpening,
+  submitLoanApplication,
+  getAccountOpenings,
+  getPropertyApplications,
 } from '../api';
 
 interface FileData {
@@ -15,6 +18,29 @@ interface FileData {
   propertyId?: string;
   id?: string;
   documents: Record<string, File | null>;
+}
+
+interface LoanFormData {
+  primaryFile: File | null;
+  loanId: string;
+  accountId: string;
+  propertyApplicationId: string;
+  propertyId: string;
+  documents: Record<string, File | null>;
+}
+
+interface AccountOpeningRecord {
+  id: number;
+  realtor: string;
+  status: string;
+  account_number?: string | null;
+}
+
+interface PropertyApplicationRecord {
+  id: number;
+  realtor: string;
+  status: string;
+  property_id?: number | null;
 }
 
 const MultiStepForm: React.FC = () => {
@@ -38,6 +64,14 @@ const MultiStepForm: React.FC = () => {
     primaryFile: null,
     documents: {},
   });
+  const [loan, setLoan] = React.useState<LoanFormData>({
+    loanId: '',
+    accountId: '',
+    propertyApplicationId: '',
+    propertyId: '',
+    primaryFile: null,
+    documents: {},
+  });
   const [error, setError] = React.useState<string | null>(null);
   const [success, setSuccess] = React.useState<string | null>(null);
   const [requirements, setRequirements] = React.useState<
@@ -49,6 +83,12 @@ const MultiStepForm: React.FC = () => {
     loan_application: [],
   });
   const [requirementsLoaded, setRequirementsLoaded] = React.useState(false);
+  const [eligibleAccounts, setEligibleAccounts] = React.useState<
+    AccountOpeningRecord[]
+  >([]);
+  const [approvedPropertyApps, setApprovedPropertyApps] = React.useState<
+    PropertyApplicationRecord[]
+  >([]);
 
   const mergeDocuments = (
     reqs: DocumentRequirement[],
@@ -76,10 +116,11 @@ const MultiStepForm: React.FC = () => {
     let cancelled = false;
     (async () => {
       try {
-        const [offerReqs, propertyReqs, accountReqs] = await Promise.all([
+        const [offerReqs, propertyReqs, accountReqs, loanReqs] = await Promise.all([
           listDocumentRequirements(auth.token, 'offer'),
           listDocumentRequirements(auth.token, 'property_application'),
           listDocumentRequirements(auth.token, 'account_opening'),
+          listDocumentRequirements(auth.token, 'loan_application'),
         ]);
         if (!cancelled) {
           setRequirements(prev => ({
@@ -87,6 +128,7 @@ const MultiStepForm: React.FC = () => {
             offer: offerReqs,
             property_application: propertyReqs,
             account_opening: accountReqs,
+            loan_application: loanReqs,
           }));
         }
       } catch (err) {
@@ -97,6 +139,7 @@ const MultiStepForm: React.FC = () => {
             offer: [],
             property_application: [],
             account_opening: [],
+            loan_application: [],
           }));
         }
       } finally {
@@ -126,7 +169,67 @@ const MultiStepForm: React.FC = () => {
       ...prev,
       documents: mergeDocuments(requirements.account_opening, prev.documents),
     }));
+    setLoan(prev => ({
+      ...prev,
+      documents: mergeDocuments(requirements.loan_application, prev.documents),
+    }));
   }, [requirements]);
+
+  React.useEffect(() => {
+    if (!auth) {
+      setEligibleAccounts([]);
+      setApprovedPropertyApps([]);
+      return;
+    }
+    let cancelled = false;
+    (async () => {
+      const [accountsResult, propertiesResult] = await Promise.allSettled([
+        getAccountOpenings(auth.token, { status: 'completed' }),
+        getPropertyApplications(auth.token, { status: 'manager_approved' }),
+      ]);
+      if (cancelled) return;
+      if (accountsResult.status === 'fulfilled') {
+        const records = (accountsResult.value as AccountOpeningRecord[]).filter(
+          record =>
+            record.status === 'completed' &&
+            (!auth?.username || record.realtor === auth.username),
+        );
+        setEligibleAccounts(records);
+      } else {
+        setEligibleAccounts([]);
+      }
+      if (propertiesResult.status === 'fulfilled') {
+        const records = (propertiesResult.value as PropertyApplicationRecord[]).filter(
+          record =>
+            record.status === 'manager_approved' &&
+            (!auth?.username || record.realtor === auth.username),
+        );
+        setApprovedPropertyApps(records);
+      } else {
+        setApprovedPropertyApps([]);
+      }
+    })().catch(err => {
+      console.error(err);
+      if (!cancelled) {
+        setEligibleAccounts([]);
+        setApprovedPropertyApps([]);
+      }
+    });
+    return () => {
+      cancelled = true;
+    };
+  }, [auth]);
+
+  React.useEffect(() => {
+    const selected = approvedPropertyApps.find(
+      app => String(app.id) === loan.propertyApplicationId,
+    );
+    const derived = selected?.property_id ? String(selected.property_id) : '';
+    if ((derived || '') === (loan.propertyId || '')) {
+      return;
+    }
+    setLoan(prev => ({ ...prev, propertyId: derived }));
+  }, [approvedPropertyApps, loan.propertyApplicationId, loan.propertyId]);
 
   if (!auth) return null;
 
@@ -147,8 +250,22 @@ const MultiStepForm: React.FC = () => {
     Boolean(account.details.trim()) &&
     Boolean(account.primaryFile) &&
     requirements.account_opening.every(req => Boolean(account.documents[req.slug]));
+  const loanComplete =
+    Boolean(loan.loanId.trim()) &&
+    Boolean(loan.accountId.trim()) &&
+    Boolean(loan.propertyApplicationId.trim()) &&
+    Boolean(loan.primaryFile) &&
+    requirements.loan_application.every(req => Boolean(loan.documents[req.slug]));
 
-  const validateFile = (f?: File) => {
+  const selectedLoanProperty = React.useMemo(
+    () =>
+      approvedPropertyApps.find(
+        app => String(app.id) === loan.propertyApplicationId,
+      ) ?? null,
+    [approvedPropertyApps, loan.propertyApplicationId],
+  );
+
+  const validateFile = (f?: File | null) => {
     if (!f) return 'File is required';
     const ext = f.name.split('.').pop()?.toLowerCase();
     return ext === 'pdf' || ext === 'csv' ? null : 'File must be PDF or CSV';
@@ -268,6 +385,89 @@ const MultiStepForm: React.FC = () => {
         details: '',
         primaryFile: null,
         documents: mergeDocuments(requirements.account_opening, {}),
+      });
+      next();
+    } catch (err: any) {
+      setError(err.message);
+    }
+  };
+
+  const submitLoanStep = async (e: React.FormEvent) => {
+    e.preventDefault();
+    if (!requirementsLoaded) {
+      setError('Document requirements are still loading');
+      return;
+    }
+    if (!loan.loanId) {
+      setError('Loan application ID is required');
+      return;
+    }
+    const parsedLoanId = Number(loan.loanId);
+    if (!Number.isFinite(parsedLoanId)) {
+      setError('Loan application ID must be a number');
+      return;
+    }
+    if (!loan.accountId) {
+      setError('Completed account ID is required');
+      return;
+    }
+    const parsedAccountId = Number(loan.accountId);
+    if (!Number.isFinite(parsedAccountId)) {
+      setError('Completed account ID must be a number');
+      return;
+    }
+    if (!loan.propertyApplicationId) {
+      setError('Approved property application ID is required');
+      return;
+    }
+    const parsedPropertyApplicationId = Number(loan.propertyApplicationId);
+    if (!Number.isFinite(parsedPropertyApplicationId)) {
+      setError('Approved property application ID must be a number');
+      return;
+    }
+    let parsedPropertyId: number | undefined;
+    if (loan.propertyId) {
+      parsedPropertyId = Number(loan.propertyId);
+      if (!Number.isFinite(parsedPropertyId)) {
+        setError('Property ID must be a number');
+        return;
+      }
+    }
+    const fileErr = validateFile(loan.primaryFile);
+    if (fileErr) {
+      setError(fileErr);
+      return;
+    }
+    const missingDoc = requirements.loan_application.find(
+      req => !loan.documents[req.slug],
+    );
+    if (missingDoc) {
+      setError(`Please upload ${missingDoc.name}`);
+      return;
+    }
+    const docFiles: Record<string, File> = {};
+    requirements.loan_application.forEach(req => {
+      const file = loan.documents[req.slug];
+      if (file) docFiles[req.slug] = file;
+    });
+    try {
+      await submitLoanApplication(auth.token, {
+        id: parsedLoanId,
+        realtor: auth.username,
+        account_id: parsedAccountId,
+        property_application_id: parsedPropertyApplicationId,
+        property_id: parsedPropertyId,
+        file: loan.primaryFile!,
+        documents: docFiles,
+      });
+      setSuccess('Loan application submitted');
+      setLoan({
+        loanId: '',
+        accountId: '',
+        propertyApplicationId: '',
+        propertyId: '',
+        primaryFile: null,
+        documents: mergeDocuments(requirements.loan_application, {}),
       });
       next();
     } catch (err: any) {
@@ -490,7 +690,150 @@ const MultiStepForm: React.FC = () => {
           </form>
         </section>
       )}
-      {step > 3 && <p className="form-message form-message--success">All steps completed.</p>}
+      {step === 4 && (
+        <section className="form-section">
+          <form className="form-card" onSubmit={submitLoanStep}>
+            <h3 className="form-title">Loan Application</h3>
+            <div className="form-fields">
+              <label htmlFor="loan-id">
+                Loan Application ID
+                <input
+                  id="loan-id"
+                  placeholder="Enter loan application ID"
+                  value={loan.loanId}
+                  onChange={e =>
+                    setLoan(prev => ({ ...prev, loanId: e.target.value }))
+                  }
+                />
+              </label>
+              <label htmlFor="loan-account">
+                Completed Account
+                {eligibleAccounts.length > 0 ? (
+                  <select
+                    id="loan-account"
+                    value={loan.accountId}
+                    onChange={e =>
+                      setLoan(prev => ({ ...prev, accountId: e.target.value }))
+                    }
+                  >
+                    <option value="">Select a completed account</option>
+                    {eligibleAccounts.map(account => (
+                      <option key={account.id} value={account.id}>
+                        #{account.id}
+                        {account.account_number
+                          ? ` • Account ${account.account_number}`
+                          : ''}
+                      </option>
+                    ))}
+                  </select>
+                ) : (
+                  <input
+                    id="loan-account"
+                    placeholder="Enter completed account ID"
+                    value={loan.accountId}
+                    onChange={e =>
+                      setLoan(prev => ({ ...prev, accountId: e.target.value }))
+                    }
+                  />
+                )}
+              </label>
+              <label htmlFor="loan-property-app">
+                Approved Property Application
+                {approvedPropertyApps.length > 0 ? (
+                  <select
+                    id="loan-property-app"
+                    value={loan.propertyApplicationId}
+                    onChange={e =>
+                      setLoan(prev => ({
+                        ...prev,
+                        propertyApplicationId: e.target.value,
+                      }))
+                    }
+                  >
+                    <option value="">Select an approved property application</option>
+                    {approvedPropertyApps.map(app => (
+                      <option key={app.id} value={app.id}>
+                        #{app.id}
+                        {typeof app.property_id === 'number'
+                          ? ` • Property ${app.property_id}`
+                          : ''}
+                      </option>
+                    ))}
+                  </select>
+                ) : (
+                  <input
+                    id="loan-property-app"
+                    placeholder="Enter approved property application ID"
+                    value={loan.propertyApplicationId}
+                    onChange={e =>
+                      setLoan(prev => ({
+                        ...prev,
+                        propertyApplicationId: e.target.value,
+                      }))
+                    }
+                  />
+                )}
+              </label>
+              <label htmlFor="loan-property">
+                Property ID
+                <input
+                  id="loan-property"
+                  placeholder="Derived from property application"
+                  value={loan.propertyId}
+                  onChange={e =>
+                    setLoan(prev => ({ ...prev, propertyId: e.target.value }))
+                  }
+                  readOnly={Boolean(selectedLoanProperty)}
+                />
+              </label>
+              <label htmlFor="loan-primary">
+                Primary Document
+                <input
+                  id="loan-primary"
+                  type="file"
+                  accept=".pdf,.csv"
+                  onChange={e =>
+                    setLoan(prev => ({
+                      ...prev,
+                      primaryFile: e.target.files?.[0] ?? null,
+                    }))
+                  }
+                  required
+                />
+              </label>
+              {requirements.loan_application.map(req => (
+                <label key={req.id} htmlFor={`loan-${req.slug}`}>
+                  {req.name}
+                  <input
+                    id={`loan-${req.slug}`}
+                    type="file"
+                    accept=".pdf,.csv"
+                    onChange={e =>
+                      setLoan(prev => ({
+                        ...prev,
+                        documents: {
+                          ...prev.documents,
+                          [req.slug]: e.target.files?.[0] ?? null,
+                        },
+                      }))
+                    }
+                    required
+                  />
+                </label>
+              ))}
+            </div>
+            <div className="form-actions">
+              <button
+                type="submit"
+                disabled={!requirementsLoaded || !loanComplete}
+              >
+                Submit
+              </button>
+            </div>
+          </form>
+        </section>
+      )}
+      {step > 4 && <p className="form-message form-message--success">All steps completed.</p>}
     </div>
   );
 };


### PR DESCRIPTION
## Summary
- add a submitLoanApplication API helper that sends multipart uploads and surfaces backend validation errors
- preload eligible accounts and approved property applications and expose a loan submission form on the dashboard
- extend the multi-step form with a loan application step that validates requirements before calling the backend

## Testing
- npm run test

------
https://chatgpt.com/codex/tasks/task_e_68d00ddbe60c832c930673a71e30ecdd