### PR TITLE
Add inbound email worker and integration coverage

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -6,3 +6,12 @@ INITIAL_ADMIN_TOKEN=bootstrap-token
 # INITIAL_ADMIN_USERNAME=admin
 # INITIAL_ADMIN_PASSWORD=Secret123
 # INITIAL_ADMIN_PASSWORD_HASH=replace-with-bcrypt-hash
+
+# Inbound email processor configuration
+# IMAP_HOST=imap.example.com
+# IMAP_PORT=993
+# IMAP_USERNAME=inbox@example.com
+# IMAP_PASSWORD=change-me
+# IMAP_FOLDER=INBOX
+# IMAP_USE_SSL=true
+# INBOUND_EMAIL_POLL_INTERVAL=60

--- a/README.md
+++ b/README.md
@@ -49,6 +49,27 @@ Interactive docs will be available at `http://127.0.0.1:8000/docs`.
 Set `FRONTEND_ORIGINS` to a comma-separated list of allowed origins if your frontend runs somewhere other than
 `http://localhost:5173`.
 
+## Inbound Email Processor
+
+The `InboundEmailProcessor` can be executed as a standalone worker that polls an Outlook/IMAP inbox and
+creates or updates customer profiles when new emails arrive. Configure the connection via environment
+variables (examples are available in `.env.example`):
+
+- `IMAP_HOST` / `IMAP_PORT`
+- `IMAP_USERNAME` / `IMAP_PASSWORD`
+- `IMAP_FOLDER` (defaults to `INBOX`)
+- `IMAP_USE_SSL` (defaults to `true`)
+- `INBOUND_EMAIL_POLL_INTERVAL` (polling interval in seconds, defaults to `60`)
+
+Run the worker once to verify connectivity:
+
+```bash
+python -m app.inbox_runner --once
+```
+
+Omit `--once` to keep the loop running in the foreground. The command reuses the same database configuration
+as the API so processed messages immediately update the shared customer profiles table.
+
 ## Admin Dashboard
 
 A simple React + TypeScript dashboard is available in the `dashboard/` directory. It offers role-based routing and CRUD views for projects, stands, and mandate assignments.
@@ -108,6 +129,7 @@ Once the containers are running you can reach:
 
 - Dashboard: <http://localhost:8080>
 - API: <http://localhost:8000> (interactive docs at <http://localhost:8000/docs>)
+- Inbound email worker: runs in the background and shares the same SQLite volume
 
 To seed the initial administrator in Docker, export the optional variables before running
 Compose so the startup hook can create the account when the database is empty:
@@ -121,6 +143,8 @@ docker compose up --build
 The backend persists the SQLite database using the named volume `sqlite_data` mounted at `/app/data` and reads environment values from `.env`.
 By default it allows requests from both `http://localhost:8080` and `http://localhost:5173` so the static dashboard and the Vite dev server can call the API.
 The frontend image is built with `VITE_API_BASE=http://web:8000`, which points API calls from the bundled code to the backend service on the Docker network.
+The `inbox-worker` service (defined in `docker-compose.yml`) runs `python -m app.inbox_runner` so inbound replies are processed
+alongside the API and frontend containers.
 
 ## Authentication
 

--- a/app/inbox_runner.py
+++ b/app/inbox_runner.py
@@ -1,0 +1,278 @@
+"""Background worker entry point for inbound email processing."""
+
+from __future__ import annotations
+
+import argparse
+import logging
+import os
+import signal
+import sys
+import time
+from contextlib import contextmanager
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from email import message_from_bytes
+from email.header import decode_header
+from email.message import Message
+from email.utils import parsedate_to_datetime
+import imaplib
+from typing import Iterator, Optional
+
+from .database import SessionLocal, init_db
+from .inbox import InboundEmail, InboundEmailProcessor, InboxClient
+from .repositories import Repositories
+
+logger = logging.getLogger(__name__)
+
+
+class IMAPInboxClient(InboxClient):
+    """Simple IMAP-backed inbox client for polling unread messages."""
+
+    def __init__(
+        self,
+        host: str,
+        username: str,
+        password: str,
+        *,
+        folder: str = "INBOX",
+        port: Optional[int] = None,
+        use_ssl: bool = True,
+    ) -> None:
+        self.host = host
+        self.username = username
+        self.password = password
+        self.folder = folder
+        self.port = port
+        self.use_ssl = use_ssl
+        self._conn: Optional[imaplib.IMAP4] = None
+        self._connect()
+
+    def _connect(self) -> None:
+        if self._conn:
+            try:
+                self._conn.logout()
+            except Exception:  # pragma: no cover - defensive shutdown
+                pass
+        if self.use_ssl:
+            port = self.port or 993
+            self._conn = imaplib.IMAP4_SSL(self.host, port)
+        else:
+            port = self.port or 143
+            self._conn = imaplib.IMAP4(self.host, port)
+        self._conn.login(self.username, self.password)
+        self._conn.select(self.folder)
+
+    def _ensure_connection(self) -> imaplib.IMAP4:
+        if self._conn is None:
+            self._connect()
+        return self._conn  # type: ignore[return-value]
+
+    def fetch_unread(self) -> list[InboundEmail]:
+        conn = self._ensure_connection()
+        status, data = conn.uid("search", None, "UNSEEN")
+        if status != "OK" or not data:
+            return []
+        uid_list = data[0].split()
+        messages: list[InboundEmail] = []
+        for uid in uid_list:
+            status, payload = conn.uid("fetch", uid, "(RFC822)")
+            if status != "OK" or not payload or not payload[0]:
+                logger.warning("Failed to fetch message %s", uid.decode())
+                continue
+            raw = payload[0][1]
+            if raw is None:
+                continue
+            message = message_from_bytes(raw)
+            body = _extract_text_body(message)
+            received_at = _parse_date_header(message)
+            messages.append(
+                InboundEmail(
+                    message_id=uid.decode(),
+                    subject=_decode_header_value(message.get("Subject")),
+                    body=body,
+                    received_at=received_at,
+                )
+            )
+        return messages
+
+    def mark_processed(self, message_id: str) -> None:
+        conn = self._ensure_connection()
+        status, _ = conn.uid("store", message_id.encode(), "+FLAGS", "(\\Seen)")
+        if status != "OK":
+            logger.warning("Failed to mark message %s as processed", message_id)
+
+    def close(self) -> None:
+        if self._conn is not None:
+            try:
+                self._conn.close()
+            except Exception:
+                pass
+            try:
+                self._conn.logout()
+            except Exception:
+                pass
+            self._conn = None
+
+
+def _decode_header_value(value: Optional[str]) -> str:
+    if not value:
+        return ""
+    parts = decode_header(value)
+    decoded = []
+    for part, encoding in parts:
+        if isinstance(part, bytes):
+            decoded.append(part.decode(encoding or "utf-8", errors="ignore"))
+        else:
+            decoded.append(part)
+    return "".join(decoded).strip()
+
+
+def _extract_text_body(message: Message) -> str:
+    if message.is_multipart():
+        for part in message.walk():
+            if part.get_content_type() == "text/plain" and part.get_content_disposition() in (None, "inline"):
+                payload = part.get_payload(decode=True)
+                if payload is not None:
+                    return payload.decode(part.get_content_charset() or "utf-8", errors="ignore").strip()
+    else:
+        payload = message.get_payload(decode=True)
+        if payload is not None:
+            return payload.decode(message.get_content_charset() or "utf-8", errors="ignore").strip()
+    return ""
+
+
+def _parse_date_header(message: Message) -> datetime:
+    header = message.get("Date")
+    if header:
+        try:
+            parsed = parsedate_to_datetime(header)
+        except (TypeError, ValueError):
+            parsed = None
+        if parsed is not None:
+            if parsed.tzinfo is not None:
+                parsed = parsed.astimezone(timezone.utc).replace(tzinfo=None)
+            return parsed
+    return datetime.utcnow()
+
+
+def run_processor_once(client: InboxClient) -> int:
+    session = SessionLocal()
+    try:
+        repos = Repositories(session)
+        processor = InboundEmailProcessor(repos, client)
+        return processor.process_new_messages()
+    finally:
+        session.close()
+
+
+@dataclass
+class RunnerConfig:
+    interval_seconds: int
+    host: str
+    username: str
+    password: str
+    folder: str = "INBOX"
+    port: Optional[int] = None
+    use_ssl: bool = True
+
+
+class InboundEmailProcessorRunner:
+    def __init__(self, client: InboxClient, interval_seconds: int) -> None:
+        self.client = client
+        self.interval_seconds = interval_seconds
+        self._shutdown = False
+
+    def run(self) -> None:
+        logger.info("Starting inbound email processor loop (interval=%s seconds)", self.interval_seconds)
+        while not self._shutdown:
+            try:
+                processed = run_processor_once(self.client)
+                if processed:
+                    logger.info("Processed %s inbound messages", processed)
+            except Exception:
+                logger.exception("Error while processing inbound email")
+            self._wait()
+
+    def _wait(self) -> None:
+        slept = 0
+        while slept < self.interval_seconds and not self._shutdown:
+            time.sleep(1)
+            slept += 1
+
+    def stop(self) -> None:
+        self._shutdown = True
+
+
+def _configure_logging() -> None:
+    logging.basicConfig(level=logging.INFO, stream=sys.stdout)
+
+
+def load_config_from_env() -> RunnerConfig:
+    try:
+        host = os.environ["IMAP_HOST"]
+        username = os.environ["IMAP_USERNAME"]
+        password = os.environ["IMAP_PASSWORD"]
+    except KeyError as exc:  # pragma: no cover - configuration validation
+        raise RuntimeError(f"Missing required environment variable: {exc.args[0]}") from exc
+    interval = int(os.environ.get("INBOUND_EMAIL_POLL_INTERVAL", "60"))
+    folder = os.environ.get("IMAP_FOLDER", "INBOX")
+    port = os.environ.get("IMAP_PORT")
+    use_ssl = os.environ.get("IMAP_USE_SSL", "true").lower() != "false"
+    return RunnerConfig(
+        interval_seconds=max(1, interval),
+        host=host,
+        username=username,
+        password=password,
+        folder=folder,
+        port=int(port) if port else None,
+        use_ssl=use_ssl,
+    )
+
+
+@contextmanager
+def _imap_client_from_config(config: RunnerConfig) -> Iterator[IMAPInboxClient]:
+    client = IMAPInboxClient(
+        host=config.host,
+        username=config.username,
+        password=config.password,
+        folder=config.folder,
+        port=config.port,
+        use_ssl=config.use_ssl,
+    )
+    try:
+        yield client
+    finally:
+        client.close()
+
+
+def main(argv: Optional[list[str]] = None) -> int:
+    parser = argparse.ArgumentParser(description="Run the inbound email processor loop")
+    parser.add_argument("--once", action="store_true", help="Process messages a single time and exit")
+    args = parser.parse_args(argv)
+
+    _configure_logging()
+    init_db()
+    config = load_config_from_env()
+
+    with _imap_client_from_config(config) as client:
+        runner = InboundEmailProcessorRunner(client, config.interval_seconds)
+
+        if args.once:
+            processed = run_processor_once(client)
+            logger.info("Processed %s inbound messages", processed)
+            return 0
+
+        def handle_signal(signum, frame):  # pragma: no cover - signal handling
+            logger.info("Received signal %s; shutting down inbound email processor", signum)
+            runner.stop()
+
+        signal.signal(signal.SIGTERM, handle_signal)
+        signal.signal(signal.SIGINT, handle_signal)
+
+        runner.run()
+
+    return 0
+
+
+if __name__ == "__main__":  # pragma: no cover - CLI entry point
+    raise SystemExit(main())

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -21,5 +21,25 @@ services:
       - "8080:80"
     depends_on:
       - web
+  inbox-worker:
+    build: .
+    env_file:
+      - .env
+    command: ["python", "-m", "app.inbox_runner"]
+    environment:
+      DATABASE_URL: "sqlite:///data/app.db"
+      SECRET_KEY: "${SECRET_KEY}"
+      INITIAL_ADMIN_TOKEN: "${INITIAL_ADMIN_TOKEN}"
+      IMAP_HOST: "${IMAP_HOST}"
+      IMAP_USERNAME: "${IMAP_USERNAME}"
+      IMAP_PASSWORD: "${IMAP_PASSWORD}"
+      IMAP_FOLDER: "${IMAP_FOLDER:-INBOX}"
+      IMAP_PORT: "${IMAP_PORT:-}"
+      IMAP_USE_SSL: "${IMAP_USE_SSL:-true}"
+      INBOUND_EMAIL_POLL_INTERVAL: "${INBOUND_EMAIL_POLL_INTERVAL:-60}"
+    volumes:
+      - sqlite_data:/app/data
+    depends_on:
+      - web
 volumes:
   sqlite_data:

--- a/tests/test_inbox_runner.py
+++ b/tests/test_inbox_runner.py
@@ -1,0 +1,72 @@
+from datetime import datetime
+
+from app.database import SessionLocal, drop_db, init_db
+from app.inbox import InboundEmail
+from app.inbox_runner import InboundEmailProcessorRunner, run_processor_once
+from app.repositories import Repositories
+
+
+class DummyInboxClient:
+    def __init__(self) -> None:
+        self._messages = [
+            InboundEmail(
+                message_id="1",
+                subject="Account update",
+                body="Account Number: ACC-12345",
+                received_at=datetime.utcnow(),
+            )
+        ]
+        self.marked: list[str] = []
+
+    def fetch_unread(self):
+        messages = self._messages
+        self._messages = []
+        return messages
+
+    def mark_processed(self, message_id: str) -> None:
+        self.marked.append(message_id)
+
+
+class IdleInboxClient(DummyInboxClient):
+    def fetch_unread(self):
+        return []
+
+
+def test_run_processor_once_persists_profiles_and_marks_messages():
+    drop_db()
+    init_db()
+    client = DummyInboxClient()
+
+    processed = run_processor_once(client)
+
+    assert processed == 1
+    assert client.marked == ["1"]
+
+    session = SessionLocal()
+    try:
+        repos = Repositories(session)
+        profile = repos.customer_profiles.get("ACC-12345")
+    finally:
+        session.close()
+
+    assert profile is not None
+    assert profile.account_number == "ACC-12345"
+
+
+def test_runner_waits_when_no_messages(monkeypatch):
+    drop_db()
+    init_db()
+    client = IdleInboxClient()
+    runner = InboundEmailProcessorRunner(client, interval_seconds=1)
+
+    calls = []
+
+    def fake_sleep(seconds):
+        calls.append(seconds)
+        runner.stop()
+
+    monkeypatch.setattr("time.sleep", lambda seconds: fake_sleep(seconds))
+
+    runner.run()
+
+    assert calls  # ensures the loop waited before exiting


### PR DESCRIPTION
## Summary
- add an IMAP-backed runner module that repeatedly invokes the inbound email processor
- document configuration/env vars and wire the worker into docker-compose alongside the API and frontend
- cover the runner with integration-style tests that assert profiles are persisted and messages marked processed

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68d036864174832c81c9d6326f577365