### PR TITLE
Ignore dashboard dependencies and build artifacts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,4 +4,7 @@ __pycache__/
 data/
 node_modules/
 dist/
-
+**/node_modules/
+**/dist/
+**/build/
+**/.cache/

--- a/dashboard/.dockerignore
+++ b/dashboard/.dockerignore
@@ -1,4 +1,9 @@
 node_modules
+dist
+build
+.cache
+.vite
+*.log
 npm-debug.log*
 yarn-debug.log*
 yarn-error.log*
@@ -9,10 +14,6 @@ pnpm-debug.log*
 .vscode
 .idea
 coverage
-build
-dist
-.cache
-*.log
 .env.local
 .env.development
 .env.production

--- a/dashboard/.gitignore
+++ b/dashboard/.gitignore
@@ -1,0 +1,5 @@
+node_modules/
+dist/
+build/
+.cache/
+.vite/


### PR DESCRIPTION
## Summary
- expand the repository .gitignore to ignore node_modules, dist, build, and cache directories in any submodule
- add a dashboard/.gitignore to block local node modules and build outputs from version control
- tighten dashboard/.dockerignore to mirror the gitignore patterns and keep Docker contexts small

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d0d5cc3b5c832cbfc1d0e09ea880a2