### PR TITLE
Add Dockerized FastAPI + React MVP scaffold for Stands portfolio

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,9 @@
+__pycache__/
+*.pyc
+.env
+.env.*
+node_modules
+backend/.venv
+frontend/dist
+frontend/node_modules
+.db.sqlite3

--- a/README.md
+++ b/README.md
@@ -1,1 +1,38 @@
-# Stands
+# Stands Portfolio Administration MVP
+
+Local dockerized MVP for managing land stands from project setup through payments.
+
+## Stack
+- FastAPI + SQLAlchemy + Alembic
+- PostgreSQL
+- React (Vite)
+- JWT auth
+- Docker Compose
+
+## Getting started
+1. Copy environment defaults and adjust as needed:
+   ```bash
+   cp backend/.env.example backend/.env
+   ```
+2. Start services:
+   ```bash
+   docker-compose up --build
+   ```
+3. Run migrations inside the API container:
+   ```bash
+   docker-compose exec api alembic upgrade head
+   ```
+4. Seed the default admin user (admin@stands.local / admin123):
+   ```bash
+   docker-compose exec api python -m app.seed
+   ```
+5. Open the web app at http://localhost:5173 and sign in.
+
+## Services
+- API: http://localhost:8000 (docs at /docs)
+- Web: http://localhost:5173
+- Postgres: localhost:5432
+
+## Notes
+- RBAC roles: System Admin, Property Manager, Realtor, Credit Manager.
+- Minimal pages are provided for login, stands, reservations, approvals, sales, payments, and dashboards.

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -1,0 +1,14 @@
+FROM python:3.11-slim
+
+WORKDIR /app
+
+COPY requirements.txt ./
+RUN pip install --no-cache-dir -r requirements.txt
+
+COPY app ./app
+COPY alembic.ini ./alembic.ini
+COPY alembic ./alembic
+
+ENV PYTHONPATH=/app
+
+CMD ["uvicorn", "app.main:app", "--host", "0.0.0.0", "--port", "8000"]

--- a/backend/alembic.ini
+++ b/backend/alembic.ini
@@ -1,0 +1,37 @@
+[alembic]
+script_location = alembic
+sqlalchemy.url = postgresql+psycopg2://postgres:postgres@db:5432/stands
+
+env_py_location = alembic/env.py
+
+[loggers]
+keys = root,sqlalchemy,alembic
+
+[handlers]
+keys = console
+
+[formatters]
+keys = generic
+
+[logger_root]
+level = WARN
+handlers = console
+
+[logger_sqlalchemy]
+level = WARN
+handlers = console
+qualname = sqlalchemy.engine
+
+[logger_alembic]
+level = INFO
+handlers = console
+qualname = alembic
+
+[handler_console]
+class = StreamHandler
+args = (sys.stderr,)
+level = NOTSET
+formatter = generic
+
+[formatter_generic]
+format = %(levelname)-5.5s [%(name)s] %(message)s

--- a/backend/alembic/env.py
+++ b/backend/alembic/env.py
@@ -1,0 +1,58 @@
+import os
+import sys
+from logging.config import fileConfig
+from sqlalchemy import engine_from_config, pool
+from alembic import context
+
+PROJECT_DIR = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
+if PROJECT_DIR not in sys.path:
+    sys.path.append(PROJECT_DIR)
+
+from app.database import Base  # noqa: E402
+from app.models import entities  # noqa: E402
+from app.core.config import get_settings  # noqa: E402
+
+# this is the Alembic Config object, which provides
+# access to the values within the .ini file in use.
+config = context.config
+fileConfig(config.config_file_name)
+settings = get_settings()
+
+if config.get_main_option("sqlalchemy.url") == "" or config.get_main_option("sqlalchemy.url") is None:
+    config.set_main_option("sqlalchemy.url", settings.database_url)
+else:
+    config.set_main_option("sqlalchemy.url", config.get_main_option("sqlalchemy.url"))
+
+target_metadata = Base.metadata
+
+def run_migrations_offline():
+    url = config.get_main_option("sqlalchemy.url")
+    context.configure(
+        url=url,
+        target_metadata=target_metadata,
+        literal_binds=True,
+        dialect_opts={"paramstyle": "named"},
+    )
+
+    with context.begin_transaction():
+        context.run_migrations()
+
+
+def run_migrations_online():
+    connectable = engine_from_config(
+        config.get_section(config.config_ini_section),
+        prefix="sqlalchemy.",
+        poolclass=pool.NullPool,
+    )
+
+    with connectable.connect() as connection:
+        context.configure(connection=connection, target_metadata=target_metadata)
+
+        with context.begin_transaction():
+            context.run_migrations()
+
+
+if context.is_offline_mode():
+    run_migrations_offline()
+else:
+    run_migrations_online()

--- a/backend/alembic/versions/202407150001_init.py
+++ b/backend/alembic/versions/202407150001_init.py
@@ -1,0 +1,128 @@
+"""initial schema
+
+Revision ID: 202407150001
+Revises: 
+Create Date: 2024-07-15 00:01:00.000000
+"""
+
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision = "202407150001"
+down_revision = None
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.create_table(
+        "users",
+        sa.Column("id", sa.Integer(), primary_key=True),
+        sa.Column("name", sa.String(), nullable=False),
+        sa.Column("email", sa.String(), nullable=False, unique=True),
+        sa.Column("role", sa.String(), nullable=False),
+        sa.Column("password_hash", sa.String(), nullable=False),
+        sa.Column("active", sa.Boolean(), nullable=False, server_default=sa.text("true")),
+    )
+
+    op.create_table(
+        "projects",
+        sa.Column("id", sa.Integer(), primary_key=True),
+        sa.Column("name", sa.String(), nullable=False),
+        sa.Column("location", sa.String(), nullable=False),
+        sa.Column("description", sa.Text(), nullable=True),
+    )
+
+    op.create_table(
+        "stands",
+        sa.Column("id", sa.Integer(), primary_key=True),
+        sa.Column("project_id", sa.Integer(), sa.ForeignKey("projects.id"), nullable=False),
+        sa.Column("stand_number", sa.String(), nullable=False),
+        sa.Column("size_m2", sa.Numeric(), nullable=False),
+        sa.Column("price", sa.Numeric(), nullable=False),
+        sa.Column("status", sa.Enum("AVAILABLE", "RESERVED", "SOLD", "BLOCKED", name="standstatus"), nullable=False, server_default="AVAILABLE"),
+        sa.Column("notes", sa.Text(), nullable=True),
+    )
+
+    op.create_table(
+        "clients",
+        sa.Column("id", sa.Integer(), primary_key=True),
+        sa.Column("full_name", sa.String(), nullable=False),
+        sa.Column("national_id", sa.String(), nullable=False, unique=True),
+        sa.Column("phone", sa.String(), nullable=True),
+        sa.Column("email", sa.String(), nullable=True),
+        sa.Column("address", sa.String(), nullable=True),
+    )
+
+    op.create_table(
+        "reservations",
+        sa.Column("id", sa.Integer(), primary_key=True),
+        sa.Column("stand_id", sa.Integer(), sa.ForeignKey("stands.id"), nullable=False),
+        sa.Column("realtor_id", sa.Integer(), sa.ForeignKey("users.id"), nullable=False),
+        sa.Column("client_id", sa.Integer(), sa.ForeignKey("clients.id"), nullable=False),
+        sa.Column("reservation_date", sa.Date(), nullable=False),
+        sa.Column("expiry_date", sa.Date(), nullable=False),
+        sa.Column("status", sa.Enum("PENDING", "APPROVED", "REJECTED", "EXPIRED", "CANCELLED", name="reservationstatus"), nullable=False, server_default="PENDING"),
+    )
+
+    op.create_table(
+        "sales",
+        sa.Column("id", sa.Integer(), primary_key=True),
+        sa.Column("stand_id", sa.Integer(), sa.ForeignKey("stands.id"), nullable=False),
+        sa.Column("client_id", sa.Integer(), sa.ForeignKey("clients.id"), nullable=False),
+        sa.Column("sale_date", sa.Date(), nullable=False),
+        sa.Column("sale_price", sa.Numeric(), nullable=False),
+        sa.Column("status", sa.Enum("ACTIVE", "COMPLETED", "CANCELLED", name="salestatus"), nullable=False, server_default="ACTIVE"),
+    )
+
+    op.create_table(
+        "payment_plans",
+        sa.Column("id", sa.Integer(), primary_key=True),
+        sa.Column("sale_id", sa.Integer(), sa.ForeignKey("sales.id"), nullable=False),
+        sa.Column("total_due", sa.Numeric(), nullable=False),
+        sa.Column("deposit_due", sa.Numeric(), nullable=False),
+        sa.Column("installment_amount", sa.Numeric(), nullable=False),
+        sa.Column("frequency", sa.String(), nullable=False),
+        sa.Column("start_date", sa.Date(), nullable=False),
+        sa.Column("end_date", sa.Date(), nullable=False),
+        sa.Column("status", sa.String(), nullable=False),
+    )
+
+    op.create_table(
+        "payments",
+        sa.Column("id", sa.Integer(), primary_key=True),
+        sa.Column("sale_id", sa.Integer(), sa.ForeignKey("sales.id"), nullable=False),
+        sa.Column("amount", sa.Numeric(), nullable=False),
+        sa.Column("date", sa.Date(), nullable=False),
+        sa.Column("method", sa.String(), nullable=False),
+        sa.Column("reference", sa.String(), nullable=True),
+        sa.Column("recorded_by", sa.Integer(), sa.ForeignKey("users.id"), nullable=True),
+    )
+
+    op.create_table(
+        "audit_logs",
+        sa.Column("id", sa.Integer(), primary_key=True),
+        sa.Column("actor_user_id", sa.Integer(), sa.ForeignKey("users.id"), nullable=False),
+        sa.Column("action", sa.String(), nullable=False),
+        sa.Column("entity", sa.String(), nullable=False),
+        sa.Column("entity_id", sa.Integer(), nullable=False),
+        sa.Column("timestamp", sa.DateTime(), server_default=sa.func.now(), nullable=False),
+        sa.Column("meta_json", sa.JSON(), nullable=True),
+    )
+
+
+def downgrade():
+    op.drop_table("audit_logs")
+    op.drop_table("payments")
+    op.drop_table("payment_plans")
+    op.drop_table("sales")
+    op.drop_table("reservations")
+    op.drop_table("clients")
+    op.drop_table("stands")
+    op.drop_table("projects")
+    op.drop_table("users")
+    op.execute("DROP TYPE IF EXISTS standstatus")
+    op.execute("DROP TYPE IF EXISTS reservationstatus")
+    op.execute("DROP TYPE IF EXISTS salestatus")

--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -1,0 +1,18 @@
+import os
+from pydantic import BaseSettings, Field
+
+
+class Settings(BaseSettings):
+    app_name: str = "Stands Portfolio API"
+    secret_key: str = Field(default="change-this-secret")
+    access_token_expire_minutes: int = 60 * 24
+    algorithm: str = "HS256"
+    database_url: str = Field(default="postgresql+psycopg2://postgres:postgres@db:5432/stands")
+    env: str = Field(default="local")
+
+    class Config:
+        env_file = ".env"
+
+
+def get_settings() -> Settings:
+    return Settings()

--- a/backend/app/core/security.py
+++ b/backend/app/core/security.py
@@ -1,0 +1,26 @@
+from datetime import datetime, timedelta
+from typing import Optional
+
+from jose import jwt
+from passlib.context import CryptContext
+
+from .config import get_settings
+
+pwd_context = CryptContext(schemes=["bcrypt"], deprecated="auto")
+settings = get_settings()
+
+
+def verify_password(plain_password: str, hashed_password: str) -> bool:
+    return pwd_context.verify(plain_password, hashed_password)
+
+
+def get_password_hash(password: str) -> str:
+    return pwd_context.hash(password)
+
+
+def create_access_token(subject: str, expires_delta: Optional[timedelta] = None) -> str:
+    if expires_delta is None:
+        expires_delta = timedelta(minutes=settings.access_token_expire_minutes)
+    expire = datetime.utcnow() + expires_delta
+    to_encode = {"sub": subject, "exp": expire}
+    return jwt.encode(to_encode, settings.secret_key, algorithm=settings.algorithm)

--- a/backend/app/database.py
+++ b/backend/app/database.py
@@ -1,0 +1,18 @@
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker, declarative_base
+from .core.config import get_settings
+
+settings = get_settings()
+
+engine = create_engine(settings.database_url, future=True)
+SessionLocal = sessionmaker(autocommit=False, autoflush=False, bind=engine, future=True)
+
+Base = declarative_base()
+
+
+def get_db():
+    db = SessionLocal()
+    try:
+        yield db
+    finally:
+        db.close()

--- a/backend/app/dependencies.py
+++ b/backend/app/dependencies.py
@@ -1,0 +1,50 @@
+from typing import List
+from fastapi import Depends, HTTPException, status
+from fastapi.security import OAuth2PasswordBearer
+from jose import jwt, JWTError
+from sqlalchemy.orm import Session
+
+from .core.config import get_settings
+from .core.security import verify_password
+from .database import get_db
+from .models import entities
+
+settings = get_settings()
+oauth2_scheme = OAuth2PasswordBearer(tokenUrl="/api/auth/token")
+
+
+async def get_current_user(token: str = Depends(oauth2_scheme), db: Session = Depends(get_db)) -> entities.User:
+    credentials_exception = HTTPException(
+        status_code=status.HTTP_401_UNAUTHORIZED,
+        detail="Could not validate credentials",
+        headers={"WWW-Authenticate": "Bearer"},
+    )
+    try:
+        payload = jwt.decode(token, settings.secret_key, algorithms=[settings.algorithm])
+        email: str | None = payload.get("sub")
+        if email is None:
+            raise credentials_exception
+    except JWTError:
+        raise credentials_exception
+    user = db.query(entities.User).filter(entities.User.email == email, entities.User.active == True).first()
+    if user is None:
+        raise credentials_exception
+    return user
+
+
+def require_roles(allowed_roles: List[str]):
+    def role_checker(current_user: entities.User = Depends(get_current_user)) -> entities.User:
+        if current_user.role not in allowed_roles:
+            raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail="Insufficient permissions")
+        return current_user
+
+    return role_checker
+
+
+def authenticate_user(db: Session, email: str, password: str) -> entities.User | None:
+    user = db.query(entities.User).filter(entities.User.email == email).first()
+    if not user:
+        return None
+    if not verify_password(password, user.password_hash):
+        return None
+    return user

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -1,0 +1,27 @@
+from fastapi import FastAPI
+from fastapi.middleware.cors import CORSMiddleware
+
+from .routers import auth, admin, projects, stands, reservations, sales, payments
+
+app = FastAPI(title="Stands Portfolio Administration API")
+
+app.add_middleware(
+    CORSMiddleware,
+    allow_origins=["*"],
+    allow_credentials=True,
+    allow_methods=["*"],
+    allow_headers=["*"],
+)
+
+app.include_router(auth.router, prefix="/api")
+app.include_router(admin.router, prefix="/api")
+app.include_router(projects.router, prefix="/api")
+app.include_router(stands.router, prefix="/api")
+app.include_router(reservations.router, prefix="/api")
+app.include_router(sales.router, prefix="/api")
+app.include_router(payments.router, prefix="/api")
+
+
+@app.get("/health")
+async def healthcheck():
+    return {"status": "ok"}

--- a/backend/app/models/__init__.py
+++ b/backend/app/models/__init__.py
@@ -1,0 +1,29 @@
+from .entities import (
+    User,
+    Project,
+    Stand,
+    Client,
+    Reservation,
+    Sale,
+    PaymentPlan,
+    Payment,
+    AuditLog,
+    StandStatus,
+    ReservationStatus,
+    SaleStatus,
+)
+
+__all__ = [
+    "User",
+    "Project",
+    "Stand",
+    "Client",
+    "Reservation",
+    "Sale",
+    "PaymentPlan",
+    "Payment",
+    "AuditLog",
+    "StandStatus",
+    "ReservationStatus",
+    "SaleStatus",
+]

--- a/backend/app/models/entities.py
+++ b/backend/app/models/entities.py
@@ -1,0 +1,154 @@
+import enum
+from datetime import datetime
+from sqlalchemy import Column, Integer, String, Boolean, ForeignKey, Date, DateTime, Enum, Numeric, Text, JSON
+from sqlalchemy.orm import relationship
+from ..database import Base
+
+
+class StandStatus(str, enum.Enum):
+    AVAILABLE = "AVAILABLE"
+    RESERVED = "RESERVED"
+    SOLD = "SOLD"
+    BLOCKED = "BLOCKED"
+
+
+class ReservationStatus(str, enum.Enum):
+    PENDING = "PENDING"
+    APPROVED = "APPROVED"
+    REJECTED = "REJECTED"
+    EXPIRED = "EXPIRED"
+    CANCELLED = "CANCELLED"
+
+
+class SaleStatus(str, enum.Enum):
+    ACTIVE = "ACTIVE"
+    COMPLETED = "COMPLETED"
+    CANCELLED = "CANCELLED"
+
+
+class User(Base):
+    __tablename__ = "users"
+
+    id = Column(Integer, primary_key=True, index=True)
+    name = Column(String, nullable=False)
+    email = Column(String, unique=True, index=True, nullable=False)
+    role = Column(String, nullable=False)
+    password_hash = Column(String, nullable=False)
+    active = Column(Boolean, default=True)
+
+    reservations = relationship("Reservation", back_populates="realtor")
+
+
+class Project(Base):
+    __tablename__ = "projects"
+
+    id = Column(Integer, primary_key=True, index=True)
+    name = Column(String, nullable=False)
+    location = Column(String, nullable=False)
+    description = Column(Text)
+
+    stands = relationship("Stand", back_populates="project")
+
+
+class Stand(Base):
+    __tablename__ = "stands"
+
+    id = Column(Integer, primary_key=True, index=True)
+    project_id = Column(Integer, ForeignKey("projects.id"), nullable=False)
+    stand_number = Column(String, nullable=False)
+    size_m2 = Column(Numeric, nullable=False)
+    price = Column(Numeric, nullable=False)
+    status = Column(Enum(StandStatus), default=StandStatus.AVAILABLE, nullable=False)
+    notes = Column(Text)
+
+    project = relationship("Project", back_populates="stands")
+    reservations = relationship("Reservation", back_populates="stand")
+    sale = relationship("Sale", back_populates="stand", uselist=False)
+
+
+class Client(Base):
+    __tablename__ = "clients"
+
+    id = Column(Integer, primary_key=True, index=True)
+    full_name = Column(String, nullable=False)
+    national_id = Column(String, unique=True, nullable=False)
+    phone = Column(String)
+    email = Column(String)
+    address = Column(String)
+
+    reservations = relationship("Reservation", back_populates="client")
+    sales = relationship("Sale", back_populates="client")
+
+
+class Reservation(Base):
+    __tablename__ = "reservations"
+
+    id = Column(Integer, primary_key=True, index=True)
+    stand_id = Column(Integer, ForeignKey("stands.id"), nullable=False)
+    realtor_id = Column(Integer, ForeignKey("users.id"), nullable=False)
+    client_id = Column(Integer, ForeignKey("clients.id"), nullable=False)
+    reservation_date = Column(Date, nullable=False)
+    expiry_date = Column(Date, nullable=False)
+    status = Column(Enum(ReservationStatus), default=ReservationStatus.PENDING, nullable=False)
+
+    stand = relationship("Stand", back_populates="reservations")
+    realtor = relationship("User", back_populates="reservations")
+    client = relationship("Client", back_populates="reservations")
+
+
+class Sale(Base):
+    __tablename__ = "sales"
+
+    id = Column(Integer, primary_key=True, index=True)
+    stand_id = Column(Integer, ForeignKey("stands.id"), nullable=False)
+    client_id = Column(Integer, ForeignKey("clients.id"), nullable=False)
+    sale_date = Column(Date, nullable=False)
+    sale_price = Column(Numeric, nullable=False)
+    status = Column(Enum(SaleStatus), default=SaleStatus.ACTIVE, nullable=False)
+
+    stand = relationship("Stand", back_populates="sale")
+    client = relationship("Client", back_populates="sales")
+    payment_plan = relationship("PaymentPlan", back_populates="sale", uselist=False)
+    payments = relationship("Payment", back_populates="sale")
+
+
+class PaymentPlan(Base):
+    __tablename__ = "payment_plans"
+
+    id = Column(Integer, primary_key=True, index=True)
+    sale_id = Column(Integer, ForeignKey("sales.id"), nullable=False)
+    total_due = Column(Numeric, nullable=False)
+    deposit_due = Column(Numeric, nullable=False)
+    installment_amount = Column(Numeric, nullable=False)
+    frequency = Column(String, nullable=False)
+    start_date = Column(Date, nullable=False)
+    end_date = Column(Date, nullable=False)
+    status = Column(String, nullable=False)
+
+    sale = relationship("Sale", back_populates="payment_plan")
+
+
+class Payment(Base):
+    __tablename__ = "payments"
+
+    id = Column(Integer, primary_key=True, index=True)
+    sale_id = Column(Integer, ForeignKey("sales.id"), nullable=False)
+    amount = Column(Numeric, nullable=False)
+    date = Column(Date, nullable=False)
+    method = Column(String, nullable=False)
+    reference = Column(String)
+    recorded_by = Column(Integer, ForeignKey("users.id"))
+
+    sale = relationship("Sale", back_populates="payments")
+
+
+class AuditLog(Base):
+    __tablename__ = "audit_logs"
+
+    id = Column(Integer, primary_key=True, index=True)
+    actor_user_id = Column(Integer, ForeignKey("users.id"), nullable=False)
+    action = Column(String, nullable=False)
+    entity = Column(String, nullable=False)
+    entity_id = Column(Integer, nullable=False)
+    timestamp = Column(DateTime, default=datetime.utcnow, nullable=False)
+    meta_json = Column(JSON)

--- a/backend/app/routers/__init__.py
+++ b/backend/app/routers/__init__.py
@@ -1,0 +1,9 @@
+__all__ = [
+    "auth",
+    "admin",
+    "projects",
+    "stands",
+    "reservations",
+    "sales",
+    "payments",
+]

--- a/backend/app/routers/admin.py
+++ b/backend/app/routers/admin.py
@@ -1,0 +1,31 @@
+from fastapi import APIRouter, Depends
+from sqlalchemy.orm import Session
+
+from ..dependencies import require_roles
+from ..database import get_db
+from ..models import entities
+from ..schemas.common import UserCreate, UserOut
+from ..core.security import get_password_hash
+
+router = APIRouter(prefix="/admin", tags=["admin"])
+
+
+@router.post("/users", response_model=UserOut, dependencies=[Depends(require_roles(["System Admin"]))])
+def create_user(payload: UserCreate, db: Session = Depends(get_db)):
+    hashed_pw = get_password_hash(payload.password)
+    user = entities.User(
+        name=payload.name,
+        email=payload.email,
+        role=payload.role,
+        password_hash=hashed_pw,
+        active=payload.active,
+    )
+    db.add(user)
+    db.commit()
+    db.refresh(user)
+    return user
+
+
+@router.get("/users", response_model=list[UserOut], dependencies=[Depends(require_roles(["System Admin"]))])
+def list_users(db: Session = Depends(get_db)):
+    return db.query(entities.User).all()

--- a/backend/app/routers/auth.py
+++ b/backend/app/routers/auth.py
@@ -1,0 +1,23 @@
+from datetime import timedelta
+from fastapi import APIRouter, Depends, HTTPException
+from fastapi.security import OAuth2PasswordRequestForm
+from sqlalchemy.orm import Session
+
+from ..core.security import create_access_token
+from ..dependencies import authenticate_user
+from ..schemas.common import Token
+from ..database import get_db
+from ..core.config import get_settings
+
+router = APIRouter(prefix="/auth", tags=["auth"])
+settings = get_settings()
+
+
+@router.post("/token", response_model=Token)
+async def login(form_data: OAuth2PasswordRequestForm = Depends(), db: Session = Depends(get_db)):
+    user = authenticate_user(db, form_data.username, form_data.password)
+    if not user:
+        raise HTTPException(status_code=400, detail="Incorrect username or password")
+    access_token_expires = timedelta(minutes=settings.access_token_expire_minutes)
+    access_token = create_access_token(subject=user.email, expires_delta=access_token_expires)
+    return {"access_token": access_token, "token_type": "bearer"}

--- a/backend/app/routers/payments.py
+++ b/backend/app/routers/payments.py
@@ -1,0 +1,42 @@
+from fastapi import APIRouter, Depends, HTTPException
+from sqlalchemy.orm import Session
+
+from ..dependencies import require_roles
+from ..database import get_db
+from ..models import entities
+from ..schemas.common import PaymentPlanCreate, PaymentPlanOut, PaymentCreate, PaymentOut
+
+router = APIRouter(prefix="/payments", tags=["payments"])
+
+@router.get("/plans", response_model=list[PaymentPlanOut], dependencies=[Depends(require_roles(["Credit Manager", "System Admin"]))])
+def list_payment_plans(db: Session = Depends(get_db)):
+    return db.query(entities.PaymentPlan).all()
+
+
+@router.post("/plans", response_model=PaymentPlanOut, dependencies=[Depends(require_roles(["Credit Manager", "System Admin"]))])
+def create_payment_plan(payload: PaymentPlanCreate, db: Session = Depends(get_db)):
+    sale = db.query(entities.Sale).filter(entities.Sale.id == payload.sale_id).first()
+    if not sale:
+        raise HTTPException(status_code=404, detail="Sale not found")
+    plan = entities.PaymentPlan(**payload.dict())
+    db.add(plan)
+    db.commit()
+    db.refresh(plan)
+    return plan
+
+
+@router.post("", response_model=PaymentOut, dependencies=[Depends(require_roles(["Credit Manager", "System Admin"]))])
+def record_payment(payload: PaymentCreate, db: Session = Depends(get_db)):
+    sale = db.query(entities.Sale).filter(entities.Sale.id == payload.sale_id).first()
+    if not sale:
+        raise HTTPException(status_code=404, detail="Sale not found")
+    payment = entities.Payment(**payload.dict())
+    db.add(payment)
+    db.commit()
+    db.refresh(payment)
+    return payment
+
+
+@router.get("", response_model=list[PaymentOut], dependencies=[Depends(require_roles(["Credit Manager", "System Admin"]))])
+def list_payments(db: Session = Depends(get_db)):
+    return db.query(entities.Payment).all()

--- a/backend/app/routers/projects.py
+++ b/backend/app/routers/projects.py
@@ -1,0 +1,23 @@
+from fastapi import APIRouter, Depends
+from sqlalchemy.orm import Session
+
+from ..dependencies import require_roles
+from ..database import get_db
+from ..models import entities
+from ..schemas.common import ProjectCreate, ProjectOut
+
+router = APIRouter(prefix="/projects", tags=["projects"], dependencies=[Depends(require_roles(["System Admin", "Property Manager"]))])
+
+
+@router.post("", response_model=ProjectOut)
+def create_project(payload: ProjectCreate, db: Session = Depends(get_db)):
+    project = entities.Project(**payload.dict())
+    db.add(project)
+    db.commit()
+    db.refresh(project)
+    return project
+
+
+@router.get("", response_model=list[ProjectOut])
+def list_projects(db: Session = Depends(get_db)):
+    return db.query(entities.Project).all()

--- a/backend/app/routers/reservations.py
+++ b/backend/app/routers/reservations.py
@@ -1,0 +1,70 @@
+from datetime import date
+from fastapi import APIRouter, Depends, HTTPException
+from sqlalchemy.orm import Session
+
+from ..dependencies import get_current_user, require_roles
+from ..database import get_db
+from ..models import entities
+from ..schemas.common import ReservationCreate, ReservationOut
+
+router = APIRouter(prefix="/reservations", tags=["reservations"])
+
+
+@router.post("", response_model=ReservationOut, dependencies=[Depends(require_roles(["Realtor", "Property Manager", "System Admin"]))])
+def create_reservation(payload: ReservationCreate, db: Session = Depends(get_db)):
+    stand = db.query(entities.Stand).filter(entities.Stand.id == payload.stand_id).first()
+    if not stand:
+        raise HTTPException(status_code=404, detail="Stand not found")
+    if stand.status != entities.StandStatus.AVAILABLE:
+        raise HTTPException(status_code=400, detail="Stand not available")
+    reservation = entities.Reservation(**payload.dict())
+    stand.status = entities.StandStatus.RESERVED
+    db.add(reservation)
+    db.commit()
+    db.refresh(reservation)
+    return reservation
+
+
+@router.get("", response_model=list[ReservationOut])
+def list_reservations(db: Session = Depends(get_db), current_user=Depends(get_current_user)):
+    query = db.query(entities.Reservation)
+    if current_user.role == "Realtor":
+        query = query.filter(entities.Reservation.realtor_id == current_user.id)
+    return query.all()
+
+
+@router.post("/{reservation_id}/approve", response_model=ReservationOut, dependencies=[Depends(require_roles(["Property Manager", "System Admin"]))])
+def approve_reservation(reservation_id: int, db: Session = Depends(get_db)):
+    reservation = db.query(entities.Reservation).filter(entities.Reservation.id == reservation_id).first()
+    if not reservation:
+        raise HTTPException(status_code=404, detail="Reservation not found")
+    reservation.status = entities.ReservationStatus.APPROVED
+    reservation.stand.status = entities.StandStatus.RESERVED
+    db.commit()
+    db.refresh(reservation)
+    return reservation
+
+
+@router.post("/{reservation_id}/reject", response_model=ReservationOut, dependencies=[Depends(require_roles(["Property Manager", "System Admin"]))])
+def reject_reservation(reservation_id: int, db: Session = Depends(get_db)):
+    reservation = db.query(entities.Reservation).filter(entities.Reservation.id == reservation_id).first()
+    if not reservation:
+        raise HTTPException(status_code=404, detail="Reservation not found")
+    reservation.status = entities.ReservationStatus.REJECTED
+    reservation.stand.status = entities.StandStatus.AVAILABLE
+    db.commit()
+    db.refresh(reservation)
+    return reservation
+
+
+@router.post("/{reservation_id}/expire", response_model=ReservationOut, dependencies=[Depends(require_roles(["Property Manager", "System Admin"]))])
+def expire_reservation(reservation_id: int, db: Session = Depends(get_db)):
+    reservation = db.query(entities.Reservation).filter(entities.Reservation.id == reservation_id).first()
+    if not reservation:
+        raise HTTPException(status_code=404, detail="Reservation not found")
+    reservation.status = entities.ReservationStatus.EXPIRED
+    reservation.stand.status = entities.StandStatus.AVAILABLE
+    reservation.expiry_date = date.today()
+    db.commit()
+    db.refresh(reservation)
+    return reservation

--- a/backend/app/routers/sales.py
+++ b/backend/app/routers/sales.py
@@ -1,0 +1,40 @@
+from fastapi import APIRouter, Depends, HTTPException
+from sqlalchemy.orm import Session
+
+from ..dependencies import require_roles
+from ..database import get_db
+from ..models import entities
+from ..schemas.common import SaleCreate, SaleOut
+
+router = APIRouter(prefix="/sales", tags=["sales"])
+
+
+@router.get("", response_model=list[SaleOut], dependencies=[Depends(require_roles(["Property Manager", "Credit Manager", "System Admin"]))])
+def list_sales(db: Session = Depends(get_db)):
+    return db.query(entities.Sale).all()
+
+
+@router.post("", response_model=SaleOut, dependencies=[Depends(require_roles(["Property Manager", "System Admin"]))])
+def create_sale(payload: SaleCreate, db: Session = Depends(get_db)):
+    stand = db.query(entities.Stand).filter(entities.Stand.id == payload.stand_id).first()
+    if not stand:
+        raise HTTPException(status_code=404, detail="Stand not found")
+    if stand.status not in [entities.StandStatus.AVAILABLE, entities.StandStatus.RESERVED]:
+        raise HTTPException(status_code=400, detail="Stand cannot be sold")
+    sale = entities.Sale(**payload.dict())
+    stand.status = entities.StandStatus.SOLD
+    db.add(sale)
+    db.commit()
+    db.refresh(sale)
+    return sale
+
+
+@router.post("/{sale_id}/complete", response_model=SaleOut, dependencies=[Depends(require_roles(["Credit Manager", "System Admin"]))])
+def complete_sale(sale_id: int, db: Session = Depends(get_db)):
+    sale = db.query(entities.Sale).filter(entities.Sale.id == sale_id).first()
+    if not sale:
+        raise HTTPException(status_code=404, detail="Sale not found")
+    sale.status = entities.SaleStatus.COMPLETED
+    db.commit()
+    db.refresh(sale)
+    return sale

--- a/backend/app/routers/stands.py
+++ b/backend/app/routers/stands.py
@@ -1,0 +1,38 @@
+from fastapi import APIRouter, Depends, HTTPException
+from sqlalchemy.orm import Session
+
+from ..dependencies import get_current_user, require_roles
+from ..database import get_db
+from ..models import entities
+from ..schemas.common import StandCreate, StandOut
+
+router = APIRouter(prefix="/stands", tags=["stands"])
+
+
+@router.get("", response_model=list[StandOut])
+def list_stands(db: Session = Depends(get_db), current_user=Depends(get_current_user)):
+    return db.query(entities.Stand).all()
+
+
+@router.post("", response_model=StandOut, dependencies=[Depends(require_roles(["System Admin", "Property Manager"]))])
+def create_stand(payload: StandCreate, db: Session = Depends(get_db)):
+    project = db.query(entities.Project).filter(entities.Project.id == payload.project_id).first()
+    if not project:
+        raise HTTPException(status_code=404, detail="Project not found")
+    stand = entities.Stand(**payload.dict())
+    db.add(stand)
+    db.commit()
+    db.refresh(stand)
+    return stand
+
+
+@router.put("/{stand_id}", response_model=StandOut, dependencies=[Depends(require_roles(["System Admin", "Property Manager"]))])
+def update_stand(stand_id: int, payload: StandCreate, db: Session = Depends(get_db)):
+    stand = db.query(entities.Stand).filter(entities.Stand.id == stand_id).first()
+    if not stand:
+        raise HTTPException(status_code=404, detail="Stand not found")
+    for key, value in payload.dict().items():
+        setattr(stand, key, value)
+    db.commit()
+    db.refresh(stand)
+    return stand

--- a/backend/app/schemas/common.py
+++ b/backend/app/schemas/common.py
@@ -1,0 +1,176 @@
+from datetime import date, datetime
+from decimal import Decimal
+from typing import Optional
+from pydantic import BaseModel, EmailStr
+
+
+class UserBase(BaseModel):
+    name: str
+    email: EmailStr
+    role: str
+    active: bool = True
+
+
+class UserCreate(UserBase):
+    password: str
+
+
+class UserOut(UserBase):
+    id: int
+
+    class Config:
+        orm_mode = True
+
+
+class Token(BaseModel):
+    access_token: str
+    token_type: str = "bearer"
+
+
+class ProjectBase(BaseModel):
+    name: str
+    location: str
+    description: Optional[str] = None
+
+
+class ProjectCreate(ProjectBase):
+    pass
+
+
+class ProjectOut(ProjectBase):
+    id: int
+
+    class Config:
+        orm_mode = True
+
+
+class StandBase(BaseModel):
+    project_id: int
+    stand_number: str
+    size_m2: Decimal
+    price: Decimal
+    status: str
+    notes: Optional[str] = None
+
+
+class StandCreate(StandBase):
+    pass
+
+
+class StandOut(StandBase):
+    id: int
+
+    class Config:
+        orm_mode = True
+
+
+class ClientBase(BaseModel):
+    full_name: str
+    national_id: str
+    phone: Optional[str] = None
+    email: Optional[EmailStr] = None
+    address: Optional[str] = None
+
+
+class ClientCreate(ClientBase):
+    pass
+
+
+class ClientOut(ClientBase):
+    id: int
+
+    class Config:
+        orm_mode = True
+
+
+class ReservationBase(BaseModel):
+    stand_id: int
+    realtor_id: int
+    client_id: int
+    reservation_date: date
+    expiry_date: date
+    status: str
+
+
+class ReservationCreate(ReservationBase):
+    pass
+
+
+class ReservationOut(ReservationBase):
+    id: int
+
+    class Config:
+        orm_mode = True
+
+
+class SaleBase(BaseModel):
+    stand_id: int
+    client_id: int
+    sale_date: date
+    sale_price: Decimal
+    status: str
+
+
+class SaleCreate(SaleBase):
+    pass
+
+
+class SaleOut(SaleBase):
+    id: int
+
+    class Config:
+        orm_mode = True
+
+
+class PaymentPlanBase(BaseModel):
+    sale_id: int
+    total_due: Decimal
+    deposit_due: Decimal
+    installment_amount: Decimal
+    frequency: str
+    start_date: date
+    end_date: date
+    status: str
+
+
+class PaymentPlanCreate(PaymentPlanBase):
+    pass
+
+
+class PaymentPlanOut(PaymentPlanBase):
+    id: int
+
+    class Config:
+        orm_mode = True
+
+
+class PaymentBase(BaseModel):
+    sale_id: int
+    amount: Decimal
+    date: date
+    method: str
+    reference: Optional[str] = None
+    recorded_by: Optional[int] = None
+
+
+class PaymentCreate(PaymentBase):
+    pass
+
+
+class PaymentOut(PaymentBase):
+    id: int
+
+    class Config:
+        orm_mode = True
+
+
+class AuditLogOut(BaseModel):
+    id: int
+    actor_user_id: int
+    action: str
+    entity: str
+    entity_id: int
+    timestamp: datetime
+
+    class Config:
+        orm_mode = True

--- a/backend/app/seed.py
+++ b/backend/app/seed.py
@@ -1,0 +1,28 @@
+from sqlalchemy.orm import Session
+
+from .core.security import get_password_hash
+from .database import SessionLocal, engine, Base
+from .models import entities
+
+
+def seed_admin():
+    Base.metadata.create_all(bind=engine)
+    db: Session = SessionLocal()
+    existing = db.query(entities.User).filter(entities.User.email == "admin@stands.local").first()
+    if existing:
+        print("Admin already exists")
+        return
+    admin = entities.User(
+        name="Default Admin",
+        email="admin@stands.local",
+        role="System Admin",
+        password_hash=get_password_hash("admin123"),
+        active=True,
+    )
+    db.add(admin)
+    db.commit()
+    print("Created default admin user admin@stands.local / admin123")
+
+
+if __name__ == "__main__":
+    seed_admin()

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -1,0 +1,9 @@
+fastapi
+uvicorn[standard]
+sqlalchemy==2.0.32
+psycopg2-binary
+python-jose[cryptography]
+passlib[bcrypt]
+pydantic
+alembic
+python-dotenv

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,38 @@
+version: '3.9'
+services:
+  db:
+    image: postgres:15
+    environment:
+      POSTGRES_USER: postgres
+      POSTGRES_PASSWORD: postgres
+      POSTGRES_DB: stands
+    ports:
+      - "5432:5432"
+    volumes:
+      - db_data:/var/lib/postgresql/data
+
+  api:
+    build: ./backend
+    env_file:
+      - ./backend/.env.example
+    volumes:
+      - ./backend/app:/app/app
+      - ./backend/alembic:/app/alembic
+      - ./backend/alembic.ini:/app/alembic.ini
+    depends_on:
+      - db
+    ports:
+      - "8000:8000"
+    command: uvicorn app.main:app --host 0.0.0.0 --port 8000
+
+  web:
+    build: ./frontend
+    environment:
+      - VITE_API_URL=http://localhost:8000/api
+    depends_on:
+      - api
+    ports:
+      - "5173:5173"
+
+volumes:
+  db_data:

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -1,0 +1,7 @@
+FROM node:20-alpine
+WORKDIR /app
+COPY package*.json ./
+RUN npm install
+COPY . .
+RUN npm run build
+CMD ["npm", "run", "dev", "--", "--host", "0.0.0.0", "--port", "5173"]

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -1,0 +1,12 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Stands Portfolio</title>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/src/main.tsx"></script>
+  </body>
+</html>

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,0 +1,24 @@
+{
+  "name": "stands-frontend",
+  "version": "0.1.0",
+  "private": true,
+  "scripts": {
+    "dev": "vite",
+    "build": "vite build",
+    "preview": "vite preview"
+  },
+  "dependencies": {
+    "@tanstack/react-query": "^5.55.4",
+    "axios": "^1.7.2",
+    "react": "^18.3.1",
+    "react-dom": "^18.3.1",
+    "react-router-dom": "^6.23.1"
+  },
+  "devDependencies": {
+    "@types/react": "^18.2.22",
+    "@types/react-dom": "^18.2.7",
+    "@vitejs/plugin-react": "^4.3.1",
+    "typescript": "^5.4.0",
+    "vite": "^5.3.4"
+  }
+}

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,0 +1,90 @@
+import { Link, Navigate, Route, Routes } from 'react-router-dom'
+import { useAuth } from './hooks/useAuth'
+import LoginPage from './pages/LoginPage'
+import StandsPage from './pages/StandsPage'
+import ReservationsPage from './pages/ReservationsPage'
+import ApprovalsPage from './pages/ApprovalsPage'
+import SalesPage from './pages/SalesPage'
+import PaymentsPage from './pages/PaymentsPage'
+import DashboardPage from './pages/DashboardPage'
+
+const PrivateRoute = ({ children }: { children: JSX.Element }) => {
+  const { token } = useAuth()
+  if (!token) return <Navigate to="/login" replace />
+  return children
+}
+
+function App() {
+  const { token, logout } = useAuth()
+
+  return (
+    <div className="container">
+      <h1>Stands Portfolio Admin</h1>
+      {token && (
+        <nav>
+          <Link to="/stands">Stands</Link>
+          <Link to="/reservations">Reservations</Link>
+          <Link to="/approvals">Approvals</Link>
+          <Link to="/sales">Sales</Link>
+          <Link to="/payments">Payments</Link>
+          <Link to="/dashboard">Dashboard</Link>
+          <button onClick={logout}>Logout</button>
+        </nav>
+      )}
+      <Routes>
+        <Route path="/login" element={<LoginPage />} />
+        <Route
+          path="/stands"
+          element={
+            <PrivateRoute>
+              <StandsPage />
+            </PrivateRoute>
+          }
+        />
+        <Route
+          path="/reservations"
+          element={
+            <PrivateRoute>
+              <ReservationsPage />
+            </PrivateRoute>
+          }
+        />
+        <Route
+          path="/approvals"
+          element={
+            <PrivateRoute>
+              <ApprovalsPage />
+            </PrivateRoute>
+          }
+        />
+        <Route
+          path="/sales"
+          element={
+            <PrivateRoute>
+              <SalesPage />
+            </PrivateRoute>
+          }
+        />
+        <Route
+          path="/payments"
+          element={
+            <PrivateRoute>
+              <PaymentsPage />
+            </PrivateRoute>
+          }
+        />
+        <Route
+          path="/dashboard"
+          element={
+            <PrivateRoute>
+              <DashboardPage />
+            </PrivateRoute>
+          }
+        />
+        <Route path="*" element={<Navigate to={token ? '/stands' : '/login'} replace />} />
+      </Routes>
+    </div>
+  )
+}
+
+export default App

--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -1,0 +1,16 @@
+import axios from 'axios'
+
+const api = axios.create({
+  baseURL: import.meta.env.VITE_API_URL || 'http://localhost:8000/api'
+})
+
+api.interceptors.request.use((config) => {
+  const token = localStorage.getItem('token')
+  if (token) {
+    config.headers = config.headers ?? {}
+    config.headers.Authorization = `Bearer ${token}`
+  }
+  return config
+})
+
+export default api

--- a/frontend/src/hooks/useAuth.tsx
+++ b/frontend/src/hooks/useAuth.tsx
@@ -1,0 +1,40 @@
+import { createContext, useContext, useEffect, useState } from 'react'
+import api from '../api/client'
+
+interface AuthContextProps {
+  token: string | null
+  login: (email: string, password: string) => Promise<void>
+  logout: () => void
+}
+
+const AuthContext = createContext<AuthContextProps | undefined>(undefined)
+
+export const AuthProvider: React.FC<{ children: React.ReactNode }> = ({ children }) => {
+  const [token, setToken] = useState<string | null>(localStorage.getItem('token'))
+
+  useEffect(() => {
+    if (token) {
+      localStorage.setItem('token', token)
+    } else {
+      localStorage.removeItem('token')
+    }
+  }, [token])
+
+  const login = async (email: string, password: string) => {
+    const response = await api.post('/auth/token', new URLSearchParams({
+      username: email,
+      password
+    }))
+    setToken(response.data.access_token)
+  }
+
+  const logout = () => setToken(null)
+
+  return <AuthContext.Provider value={{ token, login, logout }}>{children}</AuthContext.Provider>
+}
+
+export const useAuth = () => {
+  const ctx = useContext(AuthContext)
+  if (!ctx) throw new Error('useAuth must be used inside AuthProvider')
+  return ctx
+}

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -1,0 +1,21 @@
+import React from 'react'
+import ReactDOM from 'react-dom/client'
+import { BrowserRouter } from 'react-router-dom'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import App from './App'
+import { AuthProvider } from './hooks/useAuth'
+import './styles.css'
+
+const queryClient = new QueryClient()
+
+ReactDOM.createRoot(document.getElementById('root') as HTMLElement).render(
+  <React.StrictMode>
+    <QueryClientProvider client={queryClient}>
+      <AuthProvider>
+        <BrowserRouter>
+          <App />
+        </BrowserRouter>
+      </AuthProvider>
+    </QueryClientProvider>
+  </React.StrictMode>
+)

--- a/frontend/src/pages/ApprovalsPage.tsx
+++ b/frontend/src/pages/ApprovalsPage.tsx
@@ -1,0 +1,49 @@
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query'
+import api from '../api/client'
+
+interface Reservation {
+  id: number
+  stand_id: number
+  client_id: number
+  status: string
+}
+
+const ApprovalsPage = () => {
+  const queryClient = useQueryClient()
+  const { data: reservations } = useQuery({
+    queryKey: ['reservations', 'pending'],
+    queryFn: async () => {
+      const res = await api.get<Reservation[]>('/reservations')
+      return res.data
+    }
+  })
+
+  const approve = useMutation({
+    mutationFn: (id: number) => api.post(`/reservations/${id}/approve`),
+    onSuccess: () => queryClient.invalidateQueries()
+  })
+
+  const reject = useMutation({
+    mutationFn: (id: number) => api.post(`/reservations/${id}/reject`),
+    onSuccess: () => queryClient.invalidateQueries()
+  })
+
+  return (
+    <div className="card">
+      <h2>Pending Approvals</h2>
+      <ul>
+        {reservations
+          ?.filter((r) => r.status === 'PENDING')
+          .map((r) => (
+            <li key={r.id}>
+              Stand {r.stand_id} / Client {r.client_id}
+              <button onClick={() => approve.mutate(r.id)}>Approve</button>
+              <button onClick={() => reject.mutate(r.id)}>Reject</button>
+            </li>
+          ))}
+      </ul>
+    </div>
+  )
+}
+
+export default ApprovalsPage

--- a/frontend/src/pages/DashboardPage.tsx
+++ b/frontend/src/pages/DashboardPage.tsx
@@ -1,0 +1,35 @@
+import { useQuery } from '@tanstack/react-query'
+import api from '../api/client'
+
+interface Stand { status: string }
+interface Reservation { status: string }
+interface Sale { status: string }
+
+const DashboardPage = () => {
+  const { data: stands } = useQuery({ queryKey: ['stands'], queryFn: async () => (await api.get<Stand[]>('/stands')).data })
+  const { data: reservations } = useQuery({ queryKey: ['reservations'], queryFn: async () => (await api.get<Reservation[]>('/reservations')).data })
+  const { data: sales } = useQuery({ queryKey: ['sales'], queryFn: async () => (await api.get<Sale[]>('/sales')).data })
+
+  const stats = {
+    available: stands?.filter((s) => s.status === 'AVAILABLE').length ?? 0,
+    reserved: stands?.filter((s) => s.status === 'RESERVED').length ?? 0,
+    sold: stands?.filter((s) => s.status === 'SOLD').length ?? 0,
+    pendingReservations: reservations?.filter((r) => r.status === 'PENDING').length ?? 0,
+    activeSales: sales?.filter((s) => s.status === 'ACTIVE').length ?? 0
+  }
+
+  return (
+    <div className="card">
+      <h2>Dashboard</h2>
+      <ul>
+        <li>Available stands: {stats.available}</li>
+        <li>Reserved stands: {stats.reserved}</li>
+        <li>Sold stands: {stats.sold}</li>
+        <li>Pending reservations: {stats.pendingReservations}</li>
+        <li>Active sales: {stats.activeSales}</li>
+      </ul>
+    </div>
+  )
+}
+
+export default DashboardPage

--- a/frontend/src/pages/LoginPage.tsx
+++ b/frontend/src/pages/LoginPage.tsx
@@ -1,0 +1,42 @@
+import { FormEvent, useState } from 'react'
+import { useNavigate } from 'react-router-dom'
+import { useAuth } from '../hooks/useAuth'
+
+const LoginPage = () => {
+  const { login } = useAuth()
+  const [email, setEmail] = useState('admin@stands.local')
+  const [password, setPassword] = useState('admin123')
+  const [error, setError] = useState('')
+  const navigate = useNavigate()
+
+  const handleSubmit = async (e: FormEvent) => {
+    e.preventDefault()
+    try {
+      await login(email, password)
+      navigate('/stands')
+    } catch (err) {
+      console.error(err)
+      setError('Invalid credentials')
+    }
+  }
+
+  return (
+    <div className="card">
+      <h2>Login</h2>
+      <form onSubmit={handleSubmit}>
+        <div>
+          <label>Email</label>
+          <input value={email} onChange={(e) => setEmail(e.target.value)} />
+        </div>
+        <div>
+          <label>Password</label>
+          <input type="password" value={password} onChange={(e) => setPassword(e.target.value)} />
+        </div>
+        <button type="submit">Sign In</button>
+      </form>
+      {error && <p style={{ color: 'red' }}>{error}</p>}
+    </div>
+  )
+}
+
+export default LoginPage

--- a/frontend/src/pages/PaymentsPage.tsx
+++ b/frontend/src/pages/PaymentsPage.tsx
@@ -1,0 +1,129 @@
+import { FormEvent, useState } from 'react'
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query'
+import api from '../api/client'
+
+interface PaymentPlan {
+  id: number
+  sale_id: number
+  total_due: string
+  deposit_due: string
+  status: string
+}
+
+interface Payment {
+  id: number
+  sale_id: number
+  amount: string
+  date: string
+  method: string
+}
+
+const PaymentsPage = () => {
+  const queryClient = useQueryClient()
+  const [planForm, setPlanForm] = useState({
+    sale_id: 1,
+    total_due: '0',
+    deposit_due: '0',
+    installment_amount: '0',
+    frequency: 'Monthly',
+    start_date: new Date().toISOString().slice(0, 10),
+    end_date: new Date().toISOString().slice(0, 10),
+    status: 'ACTIVE'
+  })
+
+  const [paymentForm, setPaymentForm] = useState({
+    sale_id: 1,
+    amount: '0',
+    date: new Date().toISOString().slice(0, 10),
+    method: 'BANK',
+    reference: '',
+    recorded_by: undefined as number | undefined
+  })
+
+  const { data: plans } = useQuery({
+    queryKey: ['payment-plans'],
+    queryFn: async () => (await api.get<PaymentPlan[]>('/payments/plans')).data,
+    placeholderData: []
+  })
+
+  const { data: payments } = useQuery({
+    queryKey: ['payments'],
+    queryFn: async () => (await api.get<Payment[]>('/payments')).data,
+    placeholderData: []
+  })
+
+  const createPlan = useMutation({
+    mutationFn: () => api.post('/payments/plans', planForm),
+    onSuccess: () => queryClient.invalidateQueries()
+  })
+
+  const recordPayment = useMutation({
+    mutationFn: () => api.post('/payments', paymentForm),
+    onSuccess: () => queryClient.invalidateQueries()
+  })
+
+  const handlePlanSubmit = (e: FormEvent) => {
+    e.preventDefault()
+    createPlan.mutate()
+  }
+
+  const handlePaymentSubmit = (e: FormEvent) => {
+    e.preventDefault()
+    recordPayment.mutate()
+  }
+
+  return (
+    <div>
+      <div className="card">
+        <h2>Payment Plans</h2>
+        <ul>
+          {plans?.map((p) => (
+            <li key={p.id}>
+              Sale {p.sale_id} total {p.total_due} deposit {p.deposit_due} status {p.status}
+            </li>
+          ))}
+        </ul>
+      </div>
+
+      <div className="card">
+        <h3>Create Payment Plan</h3>
+        <form onSubmit={handlePlanSubmit}>
+          <input type="number" value={planForm.sale_id} onChange={(e) => setPlanForm({ ...planForm, sale_id: Number(e.target.value) })} />
+          <input type="number" value={planForm.total_due} onChange={(e) => setPlanForm({ ...planForm, total_due: e.target.value })} />
+          <input type="number" value={planForm.deposit_due} onChange={(e) => setPlanForm({ ...planForm, deposit_due: e.target.value })} />
+          <input type="number" value={planForm.installment_amount} onChange={(e) => setPlanForm({ ...planForm, installment_amount: e.target.value })} />
+          <input value={planForm.frequency} onChange={(e) => setPlanForm({ ...planForm, frequency: e.target.value })} />
+          <input type="date" value={planForm.start_date} onChange={(e) => setPlanForm({ ...planForm, start_date: e.target.value })} />
+          <input type="date" value={planForm.end_date} onChange={(e) => setPlanForm({ ...planForm, end_date: e.target.value })} />
+          <input value={planForm.status} onChange={(e) => setPlanForm({ ...planForm, status: e.target.value })} />
+          <button type="submit">Save Plan</button>
+        </form>
+      </div>
+
+      <div className="card">
+        <h3>Record Payment</h3>
+        <form onSubmit={handlePaymentSubmit}>
+          <input type="number" value={paymentForm.sale_id} onChange={(e) => setPaymentForm({ ...paymentForm, sale_id: Number(e.target.value) })} />
+          <input type="number" value={paymentForm.amount} onChange={(e) => setPaymentForm({ ...paymentForm, amount: e.target.value })} />
+          <input type="date" value={paymentForm.date} onChange={(e) => setPaymentForm({ ...paymentForm, date: e.target.value })} />
+          <input value={paymentForm.method} onChange={(e) => setPaymentForm({ ...paymentForm, method: e.target.value })} />
+          <input value={paymentForm.reference} onChange={(e) => setPaymentForm({ ...paymentForm, reference: e.target.value })} placeholder="Reference" />
+          <button type="submit">Record</button>
+        </form>
+      </div>
+
+      <div className="card">
+        <h2>Payments</h2>
+        <ul>
+          {payments?.map((p) => (
+            <li key={p.id}>
+              Sale {p.sale_id} paid {p.amount} via {p.method} on {p.date}
+            </li>
+          ))}
+        </ul>
+      </div>
+    </div>
+  )
+}
+
+export default PaymentsPage

--- a/frontend/src/pages/ReservationsPage.tsx
+++ b/frontend/src/pages/ReservationsPage.tsx
@@ -1,0 +1,95 @@
+import { FormEvent, useState } from 'react'
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query'
+import api from '../api/client'
+
+interface Reservation {
+  id: number
+  stand_id: number
+  client_id: number
+  realtor_id: number
+  reservation_date: string
+  expiry_date: string
+  status: string
+}
+
+const ReservationsPage = () => {
+  const queryClient = useQueryClient()
+  const [form, setForm] = useState({
+    stand_id: 1,
+    client_id: 1,
+    realtor_id: 1,
+    reservation_date: new Date().toISOString().slice(0, 10),
+    expiry_date: new Date(Date.now() + 7 * 24 * 3600 * 1000).toISOString().slice(0, 10),
+    status: 'PENDING'
+  })
+
+  const { data: reservations } = useQuery({
+    queryKey: ['reservations'],
+    queryFn: async () => {
+      const res = await api.get<Reservation[]>('/reservations')
+      return res.data
+    }
+  })
+
+  const createReservation = useMutation({
+    mutationFn: async () => {
+      await api.post('/reservations', form)
+    },
+    onSuccess: () => queryClient.invalidateQueries({ queryKey: ['reservations'] })
+  })
+
+  const handleSubmit = (e: FormEvent) => {
+    e.preventDefault()
+    createReservation.mutate()
+  }
+
+  return (
+    <div>
+      <div className="card">
+        <h2>My Reservations</h2>
+        <ul>
+          {reservations?.map((r) => (
+            <li key={r.id}>
+              Stand {r.stand_id} for client {r.client_id} - {r.status}
+            </li>
+          ))}
+        </ul>
+      </div>
+
+      <div className="card">
+        <h3>Create Reservation</h3>
+        <form onSubmit={handleSubmit}>
+          <input
+            type="number"
+            placeholder="Stand ID"
+            value={form.stand_id}
+            onChange={(e) => setForm({ ...form, stand_id: Number(e.target.value) })}
+          />
+          <input
+            type="number"
+            placeholder="Client ID"
+            value={form.client_id}
+            onChange={(e) => setForm({ ...form, client_id: Number(e.target.value) })}
+          />
+          <input
+            type="number"
+            placeholder="Realtor ID"
+            value={form.realtor_id}
+            onChange={(e) => setForm({ ...form, realtor_id: Number(e.target.value) })}
+          />
+          <label>Reservation Date</label>
+          <input
+            type="date"
+            value={form.reservation_date}
+            onChange={(e) => setForm({ ...form, reservation_date: e.target.value })}
+          />
+          <label>Expiry Date</label>
+          <input type="date" value={form.expiry_date} onChange={(e) => setForm({ ...form, expiry_date: e.target.value })} />
+          <button type="submit">Reserve</button>
+        </form>
+      </div>
+    </div>
+  )
+}
+
+export default ReservationsPage

--- a/frontend/src/pages/SalesPage.tsx
+++ b/frontend/src/pages/SalesPage.tsx
@@ -1,0 +1,94 @@
+import { FormEvent, useState } from 'react'
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query'
+import api from '../api/client'
+
+interface Sale {
+  id: number
+  stand_id: number
+  client_id: number
+  sale_price: string
+  sale_date: string
+  status: string
+}
+
+const SalesPage = () => {
+  const queryClient = useQueryClient()
+  const [form, setForm] = useState({
+    stand_id: 1,
+    client_id: 1,
+    sale_price: '0',
+    sale_date: new Date().toISOString().slice(0, 10),
+    status: 'ACTIVE'
+  })
+
+  const { data: sales } = useQuery({
+    queryKey: ['sales'],
+    queryFn: async () => {
+      const res = await api.get<Sale[]>('/sales')
+      return res.data
+    }
+  })
+
+  const createSale = useMutation({
+    mutationFn: async () => api.post('/sales', form),
+    onSuccess: () => queryClient.invalidateQueries({ queryKey: ['sales'] })
+  })
+
+  const completeSale = useMutation({
+    mutationFn: (id: number) => api.post(`/sales/${id}/complete`),
+    onSuccess: () => queryClient.invalidateQueries({ queryKey: ['sales'] })
+  })
+
+  const handleSubmit = (e: FormEvent) => {
+    e.preventDefault()
+    createSale.mutate()
+  }
+
+  return (
+    <div>
+      <div className="card">
+        <h2>Sales</h2>
+        <ul>
+          {sales?.map((s) => (
+            <li key={s.id}>
+              Stand {s.stand_id} sold to client {s.client_id} at {s.sale_price} - {s.status}
+              {s.status !== 'COMPLETED' && <button onClick={() => completeSale.mutate(s.id)}>Mark Completed</button>}
+            </li>
+          ))}
+        </ul>
+      </div>
+
+      <div className="card">
+        <h3>Create Sale</h3>
+        <form onSubmit={handleSubmit}>
+          <input
+            type="number"
+            value={form.stand_id}
+            onChange={(e) => setForm({ ...form, stand_id: Number(e.target.value) })}
+            placeholder="Stand ID"
+          />
+          <input
+            type="number"
+            value={form.client_id}
+            onChange={(e) => setForm({ ...form, client_id: Number(e.target.value) })}
+            placeholder="Client ID"
+          />
+          <input
+            type="date"
+            value={form.sale_date}
+            onChange={(e) => setForm({ ...form, sale_date: e.target.value })}
+          />
+          <input
+            type="number"
+            value={form.sale_price}
+            onChange={(e) => setForm({ ...form, sale_price: e.target.value })}
+            placeholder="Price"
+          />
+          <button type="submit">Create Sale</button>
+        </form>
+      </div>
+    </div>
+  )
+}
+
+export default SalesPage

--- a/frontend/src/pages/StandsPage.tsx
+++ b/frontend/src/pages/StandsPage.tsx
@@ -1,0 +1,103 @@
+import { FormEvent, useState } from 'react'
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query'
+import api from '../api/client'
+
+interface Stand {
+  id: number
+  stand_number: string
+  price: string
+  size_m2: string
+  status: string
+  project_id: number
+  notes?: string
+}
+
+const StandsPage = () => {
+  const queryClient = useQueryClient()
+  const [form, setForm] = useState({
+    project_id: 1,
+    stand_number: '',
+    size_m2: '0',
+    price: '0',
+    status: 'AVAILABLE',
+    notes: ''
+  })
+
+  const { data: stands } = useQuery({
+    queryKey: ['stands'],
+    queryFn: async () => {
+      const res = await api.get<Stand[]>('/stands')
+      return res.data
+    }
+  })
+
+  const createStand = useMutation({
+    mutationFn: async () => {
+      await api.post('/stands', form)
+    },
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['stands'] })
+      setForm({ ...form, stand_number: '', notes: '' })
+    }
+  })
+
+  const handleSubmit = (e: FormEvent) => {
+    e.preventDefault()
+    createStand.mutate()
+  }
+
+  return (
+    <div>
+      <div className="card">
+        <h2>Stands</h2>
+        <ul>
+          {stands?.map((stand) => (
+            <li key={stand.id}>
+              #{stand.stand_number} - {stand.status} - ${stand.price}
+            </li>
+          ))}
+        </ul>
+      </div>
+      <div className="card">
+        <h3>Add Stand</h3>
+        <form onSubmit={handleSubmit}>
+          <input
+            placeholder="Stand Number"
+            value={form.stand_number}
+            onChange={(e) => setForm({ ...form, stand_number: e.target.value })}
+            required
+          />
+          <input
+            placeholder="Price"
+            type="number"
+            value={form.price}
+            onChange={(e) => setForm({ ...form, price: e.target.value })}
+          />
+          <input
+            placeholder="Size"
+            type="number"
+            value={form.size_m2}
+            onChange={(e) => setForm({ ...form, size_m2: e.target.value })}
+          />
+          <input
+            placeholder="Project Id"
+            type="number"
+            value={form.project_id}
+            onChange={(e) => setForm({ ...form, project_id: Number(e.target.value) })}
+          />
+          <select value={form.status} onChange={(e) => setForm({ ...form, status: e.target.value })}>
+            <option value="AVAILABLE">AVAILABLE</option>
+            <option value="RESERVED">RESERVED</option>
+            <option value="SOLD">SOLD</option>
+            <option value="BLOCKED">BLOCKED</option>
+          </select>
+          <button type="submit" disabled={createStand.isPending}>
+            Save
+          </button>
+        </form>
+      </div>
+    </div>
+  )
+}
+
+export default StandsPage

--- a/frontend/src/styles.css
+++ b/frontend/src/styles.css
@@ -1,0 +1,51 @@
+:root {
+  font-family: Inter, system-ui, Avenir, Helvetica, Arial, sans-serif;
+  color: #1f2937;
+  background-color: #f9fafb;
+}
+
+body {
+  margin: 0;
+}
+
+a {
+  color: #2563eb;
+}
+
+.container {
+  max-width: 1080px;
+  margin: 0 auto;
+  padding: 1.5rem;
+}
+
+.card {
+  background: #fff;
+  border: 1px solid #e5e7eb;
+  border-radius: 8px;
+  padding: 1rem;
+  box-shadow: 0 1px 2px rgba(0, 0, 0, 0.05);
+  margin-bottom: 1rem;
+}
+
+input, select, button {
+  padding: 0.5rem 0.75rem;
+  margin: 0.25rem 0;
+}
+
+button {
+  background: #2563eb;
+  color: white;
+  border: none;
+  border-radius: 4px;
+  cursor: pointer;
+}
+
+button:disabled {
+  background: #9ca3af;
+}
+
+nav {
+  display: flex;
+  gap: 1rem;
+  margin-bottom: 1rem;
+}

--- a/frontend/tsconfig.json
+++ b/frontend/tsconfig.json
@@ -1,0 +1,20 @@
+{
+  "compilerOptions": {
+    "target": "ESNext",
+    "useDefineForClassFields": true,
+    "lib": ["DOM", "DOM.Iterable", "ESNext"],
+    "module": "ESNext",
+    "skipLibCheck": true,
+    "moduleResolution": "Node",
+    "allowSyntheticDefaultImports": true,
+    "isolatedModules": true,
+    "noEmit": true,
+    "jsx": "react-jsx",
+    "esModuleInterop": true,
+    "resolveJsonModule": true,
+    "strict": true,
+    "types": ["vite/client"]
+  },
+  "include": ["src"],
+  "references": [{ "path": "./tsconfig.node.json" }]
+}

--- a/frontend/tsconfig.node.json
+++ b/frontend/tsconfig.node.json
@@ -1,0 +1,10 @@
+{
+  "compilerOptions": {
+    "composite": true,
+    "skipLibCheck": true,
+    "module": "ESNext",
+    "moduleResolution": "Node",
+    "allowSyntheticDefaultImports": true
+  },
+  "include": ["vite.config.ts"]
+}

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -1,0 +1,10 @@
+import { defineConfig } from 'vite'
+import react from '@vitejs/plugin-react'
+
+export default defineConfig({
+  plugins: [react()],
+  server: {
+    host: '0.0.0.0',
+    port: 5173
+  }
+})


### PR DESCRIPTION
### Motivation
- Provide a local, dockerized MVP to manage land stands end-to-end (project → reservation → sale → payments → clearance) with role-based access controls.
- Scaffold a minimal API + web stack so the team can iterate on workflows and UI quickly without manual environment setup.
- Include a reproducible database schema and seed data to enable fast developer onboarding and testing.

### Description
- Add `docker-compose.yml` and Dockerfiles to run `postgres`, a FastAPI `api`, and a Vite React `web` container for local development and testing.
- Implement FastAPI backend skeleton with JWT auth (`/api/auth/token`), RBAC helpers (`require_roles`), SQLAlchemy models in `backend/app/models/entities.py`, Alembic migration under `backend/alembic/versions`, and a seed script `backend/app/seed.py` to create a default admin user.
- Expose CRUD and workflow endpoints for projects, stands, reservations, sales, and payments in `backend/app/routers/*` with role restrictions and basic state transitions (reserve, approve/reject/expire reservations, create/complete sales, payment plans/payments).
- Add a minimal React frontend scaffold (`frontend/src`) with an API client, auth hook, and basic pages for login, stands, reservations, approvals, sales, payments, and dashboard plus build/dev config.

### Testing
- No automated tests were executed as part of this change.
- Basic developer-run steps are documented in `README.md` to start the stack (`cp backend/.env.example backend/.env`, `docker-compose up --build`, `docker-compose exec api alembic upgrade head`, and `docker-compose exec api python -m app.seed`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695d10149cfc832faf9d19133058122e)